### PR TITLE
fix: Continue user deletion if user cannot be found in KeyCloak

### DIFF
--- a/multiuser/keycloak/che-multiuser-keycloak-user-remover/pom.xml
+++ b/multiuser/keycloak/che-multiuser-keycloak-user-remover/pom.xml
@@ -89,8 +89,28 @@
             <scope>provided</scope>
         </dependency>
         <dependency>
+            <groupId>com.github.tomakehurst</groupId>
+            <artifactId>wiremock-jre8-standalone</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>com.jayway.restassured</groupId>
             <artifactId>rest-assured</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-testng</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.testng</groupId>
+            <artifactId>testng</artifactId>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/multiuser/keycloak/che-multiuser-keycloak-user-remover/src/main/java/org/eclipse/che/multiuser/keycloak/server/KeycloakPasswordGrantTokenRequester.java
+++ b/multiuser/keycloak/che-multiuser-keycloak-user-remover/src/main/java/org/eclipse/che/multiuser/keycloak/server/KeycloakPasswordGrantTokenRequester.java
@@ -1,0 +1,136 @@
+/*
+ * Copyright (c) 2012-2021 Red Hat, Inc.
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+package org.eclipse.che.multiuser.keycloak.server;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static javax.ws.rs.HttpMethod.POST;
+
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParser;
+import com.google.gson.JsonSyntaxException;
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.io.OutputStream;
+import java.net.HttpURLConnection;
+import java.net.URL;
+import javax.inject.Singleton;
+import javax.ws.rs.core.HttpHeaders;
+import javax.ws.rs.core.MediaType;
+import org.eclipse.che.api.core.ServerException;
+import org.eclipse.che.commons.lang.IoUtil;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Requests the Keycloak access token with grant_type=password, using a Keycloak username, password,
+ * and token endpoint.
+ */
+@Singleton
+public class KeycloakPasswordGrantTokenRequester {
+
+  private static final Logger LOG =
+      LoggerFactory.getLogger(KeycloakPasswordGrantTokenRequester.class);
+
+  private static final String GRANT_TYPE = "grant_type";
+  private static final String GRANT_TYPE_VALUE = "password";
+  private static final String USERNAME = "username";
+  private static final String PASSWORD = "password";
+  private static final String CLIENT_ID = "client_id";
+  private static final String CLIENT_ID_VALUE = "admin-cli";
+  private static final String ACCESS_TOKEN = "access_token";
+
+  /**
+   * Requests the Keycloak access token with grant_type=password for the provided Keycloak user,
+   * password, and token endpoint.
+   *
+   * @param keycloakUser the Keycloak user
+   * @param keycloakPassword the Keycloak password
+   * @param keycloakTokenEndpoint the Keycloak token endpoint
+   * @return Keycloak access token
+   * @throws ServerException when any server error occurs while performing the request
+   * @throws IOException when an IO error occurs while connecting to the server
+   * @throws JsonSyntaxException when an error occurs while parsing JSON response
+   */
+  public String requestToken(
+      String keycloakUser, String keycloakPassword, String keycloakTokenEndpoint)
+      throws ServerException, IOException, JsonSyntaxException {
+
+    String accessToken = "";
+    HttpURLConnection http = null;
+    try {
+      http = createURLConnection(keycloakUser, keycloakPassword, keycloakTokenEndpoint);
+      checkResponseCode(http, keycloakTokenEndpoint);
+
+      final BufferedReader response =
+          new BufferedReader(new InputStreamReader(http.getInputStream(), UTF_8));
+      accessToken = getAccessToken(response);
+
+    } catch (IOException | JsonSyntaxException ex) {
+      throw ex;
+    } finally {
+      if (http != null) {
+        http.disconnect();
+      }
+    }
+    return accessToken;
+  }
+
+  private HttpURLConnection createURLConnection(
+      String keycloakUser, String keycloakPassword, String keycloakTokenEndpoint)
+      throws IOException {
+    HttpURLConnection http = (HttpURLConnection) new URL(keycloakTokenEndpoint).openConnection();
+    http.setConnectTimeout(60000);
+    http.setReadTimeout(60000);
+    http.setRequestMethod(POST);
+    http.setAllowUserInteraction(false);
+    http.setRequestProperty(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_FORM_URLENCODED);
+    http.setInstanceFollowRedirects(true);
+    http.setDoOutput(true);
+    StringBuilder sb = new StringBuilder();
+    sb.append(GRANT_TYPE + "=" + GRANT_TYPE_VALUE)
+        .append("&" + USERNAME + "=")
+        .append(keycloakUser)
+        .append("&" + PASSWORD + "=")
+        .append(keycloakPassword)
+        .append("&" + CLIENT_ID + "=" + CLIENT_ID_VALUE);
+
+    try (OutputStream output = http.getOutputStream()) {
+      output.write(sb.toString().getBytes(UTF_8));
+    }
+    return http;
+  }
+
+  private void checkResponseCode(HttpURLConnection http, String keycloakTokenEndpoint)
+      throws IOException, ServerException {
+    if (http.getResponseCode() != 200) {
+      throw new ServerException(
+          "Cannot get Keycloak access token. Server response: "
+              + keycloakTokenEndpoint
+              + " "
+              + http.getResponseCode()
+              + IoUtil.readStream(http.getErrorStream()));
+    }
+  }
+
+  private String getAccessToken(BufferedReader response)
+      throws ServerException, JsonSyntaxException {
+    JsonParser jsonParser = new JsonParser();
+    JsonElement jsonElement = jsonParser.parse(response);
+    JsonObject asJsonObject = jsonElement.getAsJsonObject();
+    if (!asJsonObject.has(ACCESS_TOKEN)) {
+      throw new ServerException("Keycloak access token does not exist.");
+    }
+    return asJsonObject.get(ACCESS_TOKEN).getAsString();
+  }
+}

--- a/multiuser/keycloak/che-multiuser-keycloak-user-remover/src/main/java/org/eclipse/che/multiuser/keycloak/server/KeycloakUserRemover.java
+++ b/multiuser/keycloak/che-multiuser-keycloak-user-remover/src/main/java/org/eclipse/che/multiuser/keycloak/server/KeycloakUserRemover.java
@@ -11,35 +11,23 @@
  */
 package org.eclipse.che.multiuser.keycloak.server;
 
-import static java.nio.charset.StandardCharsets.UTF_8;
-import static javax.ws.rs.HttpMethod.POST;
 import static org.eclipse.che.multiuser.keycloak.shared.KeycloakConstants.*;
 
 import com.google.common.base.Strings;
-import com.google.gson.JsonElement;
-import com.google.gson.JsonObject;
-import com.google.gson.JsonParser;
 import com.google.gson.JsonSyntaxException;
-import java.io.BufferedReader;
 import java.io.IOException;
-import java.io.InputStreamReader;
-import java.io.OutputStream;
-import java.net.HttpURLConnection;
-import java.net.URL;
 import javax.annotation.PostConstruct;
 import javax.annotation.PreDestroy;
 import javax.inject.Inject;
 import javax.inject.Named;
 import javax.inject.Singleton;
-import javax.ws.rs.core.HttpHeaders;
-import javax.ws.rs.core.MediaType;
 import org.eclipse.che.api.core.ApiException;
+import org.eclipse.che.api.core.NotFoundException;
 import org.eclipse.che.api.core.ServerException;
 import org.eclipse.che.api.core.notification.EventService;
 import org.eclipse.che.api.core.rest.HttpJsonRequestFactory;
 import org.eclipse.che.api.user.server.event.BeforeUserRemovedEvent;
 import org.eclipse.che.commons.annotation.Nullable;
-import org.eclipse.che.commons.lang.IoUtil;
 import org.eclipse.che.core.db.cascade.CascadeEventSubscriber;
 import org.eclipse.che.inject.ConfigurationException;
 import org.slf4j.Logger;
@@ -59,6 +47,7 @@ public class KeycloakUserRemover {
 
   private final String keycloakUser;
   private final String keycloakPassword;
+  private final KeycloakPasswordGrantTokenRequester keycloakTokenRequester;
   private final HttpJsonRequestFactory requestFactory;
 
   private String keycloakRemoveUserUrl;
@@ -70,10 +59,12 @@ public class KeycloakUserRemover {
       @Nullable @Named("che.keycloak.admin_username") String keycloakUser,
       @Nullable @Named("che.keycloak.admin_password") String keycloakPassword,
       KeycloakSettings keycloakSettings,
+      KeycloakPasswordGrantTokenRequester keycloakTokenRequester,
       OIDCInfo oidcInfo,
       HttpJsonRequestFactory requestFactory) {
     this.keycloakUser = keycloakUser;
     this.keycloakPassword = keycloakPassword;
+    this.keycloakTokenRequester = keycloakTokenRequester;
     this.requestFactory = requestFactory;
 
     if (userRemovalEnabled) {
@@ -100,12 +91,16 @@ public class KeycloakUserRemover {
   /**
    * Remove user from Keycloak server by given user id.
    *
-   * @param userId the user if to remove
-   * @throws ServerException when can't remove user from Keycloak
+   * @param userId the user id to remove
+   * @throws ServerException when user exists, but could not be removed from Keycloak
    */
-  public void removeUserFromKeycloak(String userId) throws ServerException {
+  public void removeUserFromKeycloak(String userId)
+      throws ServerException, IOException, JsonSyntaxException {
+
+    String token =
+        keycloakTokenRequester.requestToken(keycloakUser, keycloakPassword, keycloakTokenEndpoint);
+
     try {
-      String token = requestToken();
       int responseCode =
           requestFactory
               .fromUrl(keycloakRemoveUserUrl + userId)
@@ -116,60 +111,14 @@ public class KeycloakUserRemover {
       if (responseCode != 204) {
         throw new ServerException("Can't remove user from Keycloak. UserId:" + userId);
       }
-    } catch (IOException | ApiException e) {
+    } catch (IOException | NotFoundException e) {
+      LOG.warn(
+          "User with userId: " + userId + " does not exist in Keycloak. Continuing user deletion.",
+          e);
+    } catch (ApiException e) {
       LOG.warn("Exception during removing user from Keycloak", e);
       throw new ServerException("Exception during removing user from Keycloak", e);
     }
-  }
-
-  private String requestToken() throws ServerException {
-    String accessToken = "";
-    HttpURLConnection http = null;
-    try {
-      http = (HttpURLConnection) new URL(keycloakTokenEndpoint).openConnection();
-      http.setConnectTimeout(60000);
-      http.setReadTimeout(60000);
-      http.setRequestMethod(POST);
-      http.setAllowUserInteraction(false);
-      http.setRequestProperty(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_FORM_URLENCODED);
-      http.setInstanceFollowRedirects(true);
-      http.setDoOutput(true);
-      StringBuilder sb = new StringBuilder();
-      sb.append("grant_type=password")
-          .append("&username=")
-          .append(keycloakUser)
-          .append("&password=")
-          .append(keycloakPassword)
-          .append("&client_id=admin-cli");
-      try (OutputStream output = http.getOutputStream()) {
-        output.write(sb.toString().getBytes(UTF_8));
-      }
-      if (http.getResponseCode() != 200) {
-        throw new ServerException(
-            "Cannot get Keycloak access token. Server response: "
-                + keycloakTokenEndpoint
-                + " "
-                + http.getResponseCode()
-                + IoUtil.readStream(http.getErrorStream()));
-      }
-      final BufferedReader response =
-          new BufferedReader(new InputStreamReader(http.getInputStream(), UTF_8));
-
-      JsonParser jsonParser = new JsonParser();
-      JsonElement jsonElement = jsonParser.parse(response);
-      JsonObject asJsonObject = jsonElement.getAsJsonObject();
-      if (asJsonObject.has("access_token")) {
-        accessToken = asJsonObject.get("access_token").getAsString();
-      }
-    } catch (IOException | JsonSyntaxException ex) {
-      LOG.error(ex.getMessage(), ex);
-      throw new ServerException("Cannot get Keycloak access token.", ex);
-    } finally {
-      if (http != null) {
-        http.disconnect();
-      }
-    }
-    return accessToken;
   }
 
   @Singleton

--- a/multiuser/keycloak/che-multiuser-keycloak-user-remover/src/test/java/org/eclipse/che/multiuser/keycloak/server/KeycloakPasswordGrantTokenRequesterTest.java
+++ b/multiuser/keycloak/che-multiuser-keycloak-user-remover/src/test/java/org/eclipse/che/multiuser/keycloak/server/KeycloakPasswordGrantTokenRequesterTest.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright (c) 2012-2021 Red Hat, Inc.
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+package org.eclipse.che.multiuser.keycloak.server;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.*;
+import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.wireMockConfig;
+import static org.testng.Assert.assertEquals;
+
+import com.github.tomakehurst.wiremock.WireMockServer;
+import com.github.tomakehurst.wiremock.client.WireMock;
+import com.google.gson.JsonSyntaxException;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+public class KeycloakPasswordGrantTokenRequesterTest {
+  private WireMockServer wireMockServer;
+  private String path;
+  private String OIDCProviderUrl;
+
+  @BeforeClass
+  void start() {
+    wireMockServer = new WireMockServer(wireMockConfig().dynamicPort());
+    wireMockServer.start();
+    WireMock.configureFor("localhost", wireMockServer.port());
+    path = "/auth/realms/master/protocol/openid-connect/token";
+    OIDCProviderUrl = "http://localhost:" + wireMockServer.port() + path;
+  }
+
+  @AfterClass
+  void stop() {
+    if (wireMockServer != null) {
+      wireMockServer.stop();
+    }
+  }
+
+  @Test
+  public void shouldRetrieveAccessToken() throws Exception {
+    String expectedToken =
+        "eyJhbGciOiJSUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICJ4NkRsYjhFS3VuVDQ3Ui1YRG1JdWJkcEo0";
+    stubFor(
+        post(urlEqualTo(path))
+            .withRequestBody(
+                matching(
+                    "grant_type=password&username=admin&password=password&client_id=admin-cli"))
+            .willReturn(
+                aResponse()
+                    .withHeader("Content-Type", "application/json")
+                    .withBody("{\"access_token\": \"" + expectedToken + "\"}")));
+
+    KeycloakPasswordGrantTokenRequester r = new KeycloakPasswordGrantTokenRequester();
+    String actualToken = r.requestToken("admin", "password", OIDCProviderUrl);
+    assertEquals(actualToken, expectedToken);
+  }
+
+  @Test(expectedExceptions = JsonSyntaxException.class)
+  public void shouldThrowJsonSyntaxException() throws Exception {
+    stubFor(
+        post(urlEqualTo(path))
+            .willReturn(
+                aResponse()
+                    .withHeader("Content-Type", "application/json")
+                    .withBody("MALFORMED JSON")));
+
+    KeycloakPasswordGrantTokenRequester r = new KeycloakPasswordGrantTokenRequester();
+    r.requestToken("admin", "password", OIDCProviderUrl);
+  }
+}

--- a/multiuser/keycloak/che-multiuser-keycloak-user-remover/src/test/java/org/eclipse/che/multiuser/keycloak/server/KeycloakUserRemoverTest.java
+++ b/multiuser/keycloak/che-multiuser-keycloak-user-remover/src/test/java/org/eclipse/che/multiuser/keycloak/server/KeycloakUserRemoverTest.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright (c) 2012-2021 Red Hat, Inc.
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+package org.eclipse.che.multiuser.keycloak.server;
+
+import static org.eclipse.che.multiuser.keycloak.shared.KeycloakConstants.REALM_SETTING;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.mockito.MockitoAnnotations.initMocks;
+
+import java.io.FileNotFoundException;
+import java.util.HashMap;
+import java.util.Map;
+import org.eclipse.che.api.core.ApiException;
+import org.eclipse.che.api.core.NotFoundException;
+import org.eclipse.che.api.core.ServerException;
+import org.eclipse.che.api.core.rest.DefaultHttpJsonRequest;
+import org.eclipse.che.api.core.rest.HttpJsonRequestFactory;
+import org.mockito.Mock;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+public class KeycloakUserRemoverTest {
+
+  @Mock private KeycloakSettings keycloakSettings;
+  @Mock private OIDCInfo oidcInfo;
+  @Mock private HttpJsonRequestFactory requestFactory;
+  @Mock private KeycloakPasswordGrantTokenRequester tokenRequester;
+  @Mock private DefaultHttpJsonRequest jsonRequest;
+
+  private KeycloakUserRemover keycloakUserRemover;
+
+  @BeforeMethod
+  public void setUp() throws Exception {
+    initMocks(this);
+
+    Map<String, String> settingsMap = new HashMap<>();
+    settingsMap.put(REALM_SETTING, "realm");
+    when(keycloakSettings.get()).thenReturn(settingsMap);
+    when(oidcInfo.getAuthServerURL()).thenReturn("auth.server.url");
+    when(requestFactory.fromUrl(anyString())).thenReturn(jsonRequest);
+    when(tokenRequester.requestToken(anyString(), anyString(), anyString())).thenReturn("token");
+    when(jsonRequest.setAuthorizationHeader(anyString())).thenCallRealMethod();
+    when(jsonRequest.useDeleteMethod()).thenCallRealMethod();
+    when(jsonRequest.setMethod(anyString())).thenCallRealMethod();
+    keycloakUserRemover =
+        new KeycloakUserRemover(
+            true, "admin", "admin", keycloakSettings, tokenRequester, oidcInfo, requestFactory);
+  }
+
+  @Test
+  public void shouldCatchFileNotFoundException() throws Exception {
+    when(jsonRequest.request()).thenThrow(FileNotFoundException.class);
+    keycloakUserRemover.removeUserFromKeycloak("123");
+    verify(jsonRequest).request();
+  }
+
+  @Test
+  public void shouldCatchNotFoundException() throws Exception {
+    when(jsonRequest.request()).thenThrow(NotFoundException.class);
+    keycloakUserRemover.removeUserFromKeycloak("123");
+    verify(jsonRequest).request();
+  }
+
+  @Test(
+      expectedExceptions = ApiException.class,
+      expectedExceptionsMessageRegExp = "Exception during removing user from Keycloak")
+  public void shouldThrowAPIException() throws Exception {
+    when(jsonRequest.request()).thenThrow(ServerException.class);
+    keycloakUserRemover.removeUserFromKeycloak("123");
+    verify(jsonRequest).request();
+  }
+}


### PR DESCRIPTION
Signed-off-by: David Kwon <dakwon@redhat.com>

<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests
-->

### What does this PR do?
This PR allows users to be deleted from the Che Postgres database in the case where the user does not exist in the Keycloak level.

A warning message is logged when this happens, e.g.
```
[WARN ] [.e.c.m.k.s.KeycloakUserRemover 113]  - User with userId: 57453ea8-f076-48ea-8636-4009c8adc283 does not exist in Keycloak. Continuing user deletion.
```

Image: `quay.io/dkwon17/che-server:che-19473`

### Screenshot/screencast of this PR
<!-- Please include a screenshot or a screencast explaining what is doing this PR -->
#### With this PR:
1. Create a new user from Keycloak and login to Che so that the user exists in the Keycloak and the Che Postgres side.
2. Manually delete the user from Keycloak so that the user exists in the Che Postgres side, but not on the Keycloak side.
3. Delete the user using the user deletion endpoint. This results in a 204 response. The user is now deleted on the Che Postgres side.

In the gif, I created and deleted the `test` user:
![che-19473](https://user-images.githubusercontent.com/83611742/121370895-1b9c8d80-c90b-11eb-9b05-9c743ded8f27.gif)

#### Without this PR:
Results in 500 response code, and the user is not deleted on the Che Postgres side.
![image](https://user-images.githubusercontent.com/83611742/121372053-007e4d80-c90c-11eb-8534-5e0a0be5f901.png)



### What issues does this PR fix or reference?
<!-- Please include any related issue from eclipse che repository (or from another issue tracker).
     Include link to other pull requests like documentation PR from [the docs repo](https://github.com/eclipse/che-docs)
-->
https://github.com/eclipse/che/issues/19473


### How to test this PR?
<!-- Please explain for example :
  - The test platform (openshift, kubernetes, minikube, CodeReady Container, docker-desktop, etc)
  - Installation method: chectl / che-operator
  - steps to reproduce
 -->
Tested on minikube with chectl. To reproduce the issue, please follow the steps from "Screenshot/screencast of this PR".

### PR Checklist

[As the author of this Pull Request I made sure that:](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#pull-request-template-and-its-checklist)

- [x] [The Eclipse Contributor Agreement is valid](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-eclipse-contributor-agreement-is-valid)
- [x] [Code produced is complete](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-produced-is-complete)
- [x] [Code builds without errors](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-builds-without-errors)
- [x] [Tests are covering the bugfix](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#tests-are-covering-the-bugfix)
- [ ] [The repository devfile is up to date and works](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-repository-devfile-is-up-to-date-and-works)
- [x] [Sections `What issues does this PR fix or reference` and `How to test this PR` completed](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#sections-what-issues-does-this-pr-fix-or-reference-and-how-to-test-this-pr-completed)
- [ ] [Relevant user documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [Relevant contributing documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [CI/CD changes implemented, documented and communicated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#cicd-changes-implemented-documented-and-communicated)

### Reviewers

Reviewers, please comment how you tested the PR when approving it.
