### PR TITLE
fix: prevent duplicate tolerations on workspace pods

### DIFF
--- a/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/environment/PodMerger.java
+++ b/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/environment/PodMerger.java
@@ -23,6 +23,7 @@ import io.fabric8.kubernetes.api.model.ObjectMetaBuilder;
 import io.fabric8.kubernetes.api.model.PodSecurityContext;
 import io.fabric8.kubernetes.api.model.PodSpec;
 import io.fabric8.kubernetes.api.model.PodTemplateSpec;
+import io.fabric8.kubernetes.api.model.Toleration;
 import io.fabric8.kubernetes.api.model.Volume;
 import io.fabric8.kubernetes.api.model.apps.Deployment;
 import io.fabric8.kubernetes.api.model.apps.DeploymentBuilder;
@@ -154,8 +155,13 @@ public class PodMerger {
 
       // if there are entries with such keys then values will be overridden
       baseSpec.getAdditionalProperties().putAll(podData.getSpec().getAdditionalProperties());
+
       // add tolerations to baseSpec if any
-      baseSpec.getTolerations().addAll(podData.getSpec().getTolerations());
+      for (Toleration toleration : podData.getSpec().getTolerations()) {
+        if (!baseSpec.getTolerations().contains(toleration)) {
+          baseSpec.getTolerations().add(toleration);
+        }
+      }
     }
 
     Map<String, String> matchLabels = new HashMap<>();

--- a/infrastructures/kubernetes/src/test/java/org/eclipse/che/workspace/infrastructure/kubernetes/environment/PodMergerTest.java
+++ b/infrastructures/kubernetes/src/test/java/org/eclipse/che/workspace/infrastructure/kubernetes/environment/PodMergerTest.java
@@ -33,6 +33,7 @@ import io.fabric8.kubernetes.api.model.VolumeBuilder;
 import io.fabric8.kubernetes.api.model.apps.Deployment;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
@@ -131,7 +132,9 @@ public class PodMergerTest {
             .withVolumes(new VolumeBuilder().withName("v2").build())
             .withNodeSelector(Map.of("foo2", "bar2"))
             .withImagePullSecrets(new LocalObjectReferenceBuilder().withName("secret2").build())
-            .withTolerations(new Toleration("Effect", "key", "operator", 0L, "value2"))
+            .withTolerations(
+                new Toleration("Effect", "key", "operator", 0L, "value1"),
+                new Toleration("Effect", "key", "operator", 0L, "value2"))
             .build();
     podSpec2.setAdditionalProperty("add2", 2L);
     PodData podData2 = new PodData(podSpec2, new ObjectMetaBuilder().build());
@@ -452,5 +455,6 @@ public class PodMergerTest {
             .entrySet()
             .containsAll(toCheck.getAdditionalProperties().entrySet()));
     assertTrue(source.getTolerations().containsAll(toCheck.getTolerations()));
+    assertEquals(toCheck.getTolerations().size(), new HashSet<>(toCheck.getTolerations()).size());
   }
 }


### PR DESCRIPTION
<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests
-->

### What does this PR do?
Adds a check to ensure that the same toleration does not get added multiple times to workspace pods.

### What issues does this PR fix or reference?
<!-- Please include any related issue from eclipse che repository (or from another issue tracker).
     Include link to other pull requests like documentation PR from [the docs repo](https://github.com/eclipse/che-docs)
-->
Issue  eclipse/che#19975

### How to test this PR?
<!-- Please explain for example :
  - The test platform (openshift, kubernetes, minikube, CodeReady Container, docker-desktop, etc)
  - Installation method: chectl / che-operator
  - steps to reproduce
 -->
- Tested on AKS (but should apply to any Kubernetes platform)
- Installation method: Helm
- In values,yaml, set the che.cheWorkspacePodTolerations
- Launch a workspace and use 'kubectl get pod' to confirm that each toleration only appears once.

### PR Checklist

[As the author of this Pull Request I made sure that:](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#pull-request-template-and-its-checklist)

- [x] [The Eclipse Contributor Agreement is valid](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-eclipse-contributor-agreement-is-valid)
- [x] [Code produced is complete](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-produced-is-complete)
- [x] [Code builds without errors](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-builds-without-errors)
- [x] [Tests are covering the bugfix](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#tests-are-covering-the-bugfix)
- [x] [The repository devfile is up to date and works](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-repository-devfile-is-up-to-date-and-works)
- [x] [Sections `What issues does this PR fix or reference` and `How to test this PR` completed](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#sections-what-issues-does-this-pr-fix-or-reference-and-how-to-test-this-pr-completed)
- [x] [Relevant user documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [x] [Relevant contributing documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [CI/CD changes implemented, documented and communicated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#cicd-changes-implemented-documented-and-communicated)

### Reviewers

Reviewers, please comment how you tested the PR when approving it.
