### PR TITLE
fix: Do not generate relative files links if factory source is a raw URL

### DIFF
--- a/wsmaster/che-core-api-factory/src/main/java/org/eclipse/che/api/factory/server/FactoryLinksHelper.java
+++ b/wsmaster/che-core-api-factory/src/main/java/org/eclipse/che/api/factory/server/FactoryLinksHelper.java
@@ -111,22 +111,23 @@ public class FactoryLinksHelper {
                     .toString(),
                 factory.getSource() + " content"));
       }
-
-      // additional files links
-      for (String additionalFile : additionalFilenamesProvider.get()) {
-        links.add(
-            createLink(
-                HttpMethod.GET,
-                uriBuilder
-                    .clone()
-                    .replacePath("api")
-                    .path(ScmService.class)
-                    .path(ScmService.class, "resolveFile")
-                    .queryParam("repository", repositoryUrl)
-                    .queryParam("file", additionalFile)
-                    .build(factoryId)
-                    .toString(),
-                additionalFile + " content"));
+      if (((FactoryDevfileV2Dto) factory).getScmInfo() != null) {
+        // additional files links
+        for (String additionalFile : additionalFilenamesProvider.get()) {
+          links.add(
+              createLink(
+                  HttpMethod.GET,
+                  uriBuilder
+                      .clone()
+                      .replacePath("api")
+                      .path(ScmService.class)
+                      .path(ScmService.class, "resolveFile")
+                      .queryParam("repository", repositoryUrl)
+                      .queryParam("file", additionalFile)
+                      .build(factoryId)
+                      .toString(),
+                  additionalFile + " content"));
+        }
       }
     }
     return links;

--- a/wsmaster/che-core-api-factory/src/test/java/org/eclipse/che/api/factory/server/FactoryLinksHelperTest.java
+++ b/wsmaster/che-core-api-factory/src/test/java/org/eclipse/che/api/factory/server/FactoryLinksHelperTest.java
@@ -1,0 +1,141 @@
+/*
+ * Copyright (c) 2012-2021 Red Hat, Inc.
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+package org.eclipse.che.api.factory.server;
+
+import static org.eclipse.che.dto.server.DtoFactory.newDto;
+import static org.mockito.Mockito.when;
+import static org.testng.Assert.*;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import javax.ws.rs.core.UriBuilder;
+import org.eclipse.che.api.core.rest.ServiceContext;
+import org.eclipse.che.api.core.rest.shared.dto.Link;
+import org.eclipse.che.api.factory.shared.dto.AuthorDto;
+import org.eclipse.che.api.factory.shared.dto.FactoryDevfileV2Dto;
+import org.eclipse.che.api.factory.shared.dto.ScmInfoDto;
+import org.everrest.core.impl.uri.UriBuilderImpl;
+import org.mockito.Mock;
+import org.mockito.testng.MockitoTestNGListener;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Listeners;
+import org.testng.annotations.Test;
+
+@Listeners(MockitoTestNGListener.class)
+public class FactoryLinksHelperTest {
+
+  private static final String USER_ID = "user123";
+  private static final String URI_BASE = "http://localhost:8080";
+  public static final String TEST_REPO = "https://test.repo.com";
+
+  @Mock ServiceContext serviceContext;
+  @Mock AdditionalFilenamesProvider additionalFilenamesProvider;
+
+  @BeforeMethod
+  public void setUp() {
+    final UriBuilder uriBuilder = new UriBuilderImpl();
+    uriBuilder.uri(URI_BASE);
+    when(serviceContext.getServiceUriBuilder()).thenReturn(uriBuilder);
+  }
+
+  @Test
+  public void shouldContainDevfileLinkIfSourceIsPresent() {
+    final String testRepo = "https://test.repo.com";
+    List<Link> links =
+        FactoryLinksHelper.createLinks(
+            createV2FactoryWithSource("factory1"),
+            serviceContext,
+            additionalFilenamesProvider,
+            "user1",
+            testRepo);
+    assertTrue(
+        links
+            .stream()
+            .anyMatch(
+                l ->
+                    l.getMethod().equals("GET")
+                        && l.getRel().equals("devfile.yaml content")
+                        && l.getHref()
+                            .equals(
+                                URI_BASE
+                                    + "/api/scm/resolve?repository="
+                                    + testRepo
+                                    + "&file=devfile.yaml")));
+  }
+
+  @Test
+  public void shouldContainFilesLinksIfScmInfoIsPresent() {
+    when(additionalFilenamesProvider.get()).thenReturn(Collections.singletonList("myfile.ext"));
+    List<Link> links =
+        FactoryLinksHelper.createLinks(
+            createV2FactoryWithScmInfo("factory1", TEST_REPO),
+            serviceContext,
+            additionalFilenamesProvider,
+            "user1",
+            TEST_REPO);
+    assertTrue(
+        links
+            .stream()
+            .anyMatch(
+                l ->
+                    l.getMethod().equals("GET")
+                        && l.getRel().equals("myfile.ext content")
+                        && l.getHref()
+                            .equals(
+                                URI_BASE
+                                    + "/api/scm/resolve?repository="
+                                    + TEST_REPO
+                                    + "&file=myfile.ext")));
+  }
+
+  @Test
+  public void shouldNotContainFilesLinksIfNoScmInfoIsPresent() {
+    final String testRepo = "https://test.repo.com";
+    List<Link> links =
+        FactoryLinksHelper.createLinks(
+            createV2FactoryWithSource("factory1"),
+            serviceContext,
+            additionalFilenamesProvider,
+            "user1",
+            testRepo);
+    assertTrue(
+        links
+            .stream()
+            .noneMatch(
+                l -> l.getMethod().equals("GET") && l.getRel().equals("myfile.ext content")));
+  }
+
+  private FactoryDevfileV2Dto createV2FactoryWithScmInfo(String name, String testRepo) {
+    return (FactoryDevfileV2Dto)
+        newDto(FactoryDevfileV2Dto.class)
+            .withV("4.0")
+            .withDevfile(Map.of("a", "b"))
+            .withScmInfo(
+                newDto(ScmInfoDto.class)
+                    .withRepositoryUrl(testRepo)
+                    .withScmProviderName("prov1")
+                    .withBranch("branch"))
+            .withCreator(newDto(AuthorDto.class).withUserId(USER_ID).withCreated(12L))
+            .withName(name);
+  }
+
+  private FactoryDevfileV2Dto createV2FactoryWithSource(String name) {
+    return (FactoryDevfileV2Dto)
+        newDto(FactoryDevfileV2Dto.class)
+            .withV("4.0")
+            .withDevfile(Map.of("a", "b"))
+            .withSource("devfile.yaml")
+            .withCreator(newDto(AuthorDto.class).withUserId(USER_ID).withCreated(12L))
+            .withName(name);
+  }
+}


### PR DESCRIPTION
### What does this PR do?
Backport of: https://github.com/eclipse-che/che-server/pull/33

Prevent relative files (like che-editor.yaml, extensions.json) links creation for DEvfile v.2 factories from raw URL-s;

### Screenshot/screencast of this PR
<!-- Please include a screenshot or a screencast explaining what is doing this PR -->


### What issues does this PR fix or reference?
Fixes eclipse/che#19985


### How to test this PR?
Accept factory from devfile v.2 located at some non-repository URL (e.g. gist or equal). There must be no links to the related files (like che-editor.yaml, extensions.json)

### PR Checklist

[As the author of this Pull Request I made sure that:](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#pull-request-template-and-its-checklist)

- [x] [The Eclipse Contributor Agreement is valid](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-eclipse-contributor-agreement-is-valid)
- [x] [Code produced is complete](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-produced-is-complete)
- [x] [Code builds without errors](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-builds-without-errors)
- [x] [Tests are covering the bugfix](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#tests-are-covering-the-bugfix)
- [ ] [The repository devfile is up to date and works](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-repository-devfile-is-up-to-date-and-works)
- [x] [Sections `What issues does this PR fix or reference` and `How to test this PR` completed](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#sections-what-issues-does-this-pr-fix-or-reference-and-how-to-test-this-pr-completed)
- [ ] [Relevant user documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [Relevant contributing documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [CI/CD changes implemented, documented and communicated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#cicd-changes-implemented-documented-and-communicated)

### Reviewers

Reviewers, please comment how you tested the PR when approving it.
