### PR TITLE
fix: Add nodeSelectors and tolerations to utils pods

### DIFF
--- a/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/namespace/pvc/PVCSubPathHelper.java
+++ b/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/namespace/pvc/PVCSubPathHelper.java
@@ -45,7 +45,9 @@ import org.eclipse.che.workspace.infrastructure.kubernetes.namespace.KubernetesN
 import org.eclipse.che.workspace.infrastructure.kubernetes.namespace.log.LogWatchTimeouts;
 import org.eclipse.che.workspace.infrastructure.kubernetes.namespace.log.LogWatcher;
 import org.eclipse.che.workspace.infrastructure.kubernetes.namespace.log.PodLogToEventPublisher;
+import org.eclipse.che.workspace.infrastructure.kubernetes.provision.NodeSelectorProvisioner;
 import org.eclipse.che.workspace.infrastructure.kubernetes.provision.SecurityContextProvisioner;
+import org.eclipse.che.workspace.infrastructure.kubernetes.provision.TolerationsProvisioner;
 import org.eclipse.che.workspace.infrastructure.kubernetes.util.Containers;
 import org.eclipse.che.workspace.infrastructure.kubernetes.util.RuntimeEventsPublisher;
 import org.slf4j.Logger;
@@ -88,6 +90,8 @@ public class PVCSubPathHelper {
   private final RuntimeEventsPublisher eventsPublisher;
 
   private final SecurityContextProvisioner securityContextProvisioner;
+  private final NodeSelectorProvisioner nodeSelectorProvisioner;
+  private final TolerationsProvisioner tolerationsProvisioner;
 
   @Inject
   PVCSubPathHelper(
@@ -96,6 +100,8 @@ public class PVCSubPathHelper {
       @Named("che.infra.kubernetes.pvc.jobs.image.pull_policy") String imagePullPolicy,
       KubernetesNamespaceFactory factory,
       SecurityContextProvisioner securityContextProvisioner,
+      NodeSelectorProvisioner nodeSelectorProvisioner,
+      TolerationsProvisioner tolerationsProvisioner,
       ExecutorServiceWrapper executorServiceWrapper,
       RuntimeEventsPublisher eventPublisher) {
     this.jobMemoryLimit = jobMemoryLimit;
@@ -103,6 +109,8 @@ public class PVCSubPathHelper {
     this.imagePullPolicy = imagePullPolicy;
     this.factory = factory;
     this.securityContextProvisioner = securityContextProvisioner;
+    this.nodeSelectorProvisioner = nodeSelectorProvisioner;
+    this.tolerationsProvisioner = tolerationsProvisioner;
     this.eventsPublisher = eventPublisher;
     this.executor =
         executorServiceWrapper.wrap(
@@ -204,6 +212,8 @@ public class PVCSubPathHelper {
     final String[] command = buildCommand(commandBase, arguments);
     final Pod pod = newPod(podName, pvcName, command);
     securityContextProvisioner.provision(pod.getSpec());
+    nodeSelectorProvisioner.provision(pod.getSpec());
+    tolerationsProvisioner.provision(pod.getSpec());
 
     KubernetesDeployments deployments = null;
     try {

--- a/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/provision/NodeSelectorProvisioner.java
+++ b/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/provision/NodeSelectorProvisioner.java
@@ -14,6 +14,7 @@ package org.eclipse.che.workspace.infrastructure.kubernetes.provision;
 import static java.util.Collections.emptyMap;
 
 import com.google.common.base.Splitter;
+import io.fabric8.kubernetes.api.model.PodSpec;
 import java.util.Map;
 import javax.inject.Inject;
 import javax.inject.Named;
@@ -44,6 +45,12 @@ public class NodeSelectorProvisioner implements ConfigurationProvisioner {
           .getPodsData()
           .values()
           .forEach(d -> d.getSpec().setNodeSelector(nodeSelectorAttributes));
+    }
+  }
+
+  public void provision(PodSpec podSpec) {
+    if (!nodeSelectorAttributes.isEmpty()) {
+      podSpec.setNodeSelector(nodeSelectorAttributes);
     }
   }
 }

--- a/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/provision/TolerationsProvisioner.java
+++ b/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/provision/TolerationsProvisioner.java
@@ -16,6 +16,7 @@ import static java.util.Collections.emptyList;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import io.fabric8.kubernetes.api.model.PodSpec;
 import io.fabric8.kubernetes.api.model.Toleration;
 import java.util.List;
 import javax.inject.Inject;
@@ -52,6 +53,12 @@ public class TolerationsProvisioner implements ConfigurationProvisioner {
       throws InfrastructureException {
     if (!tolerations.isEmpty()) {
       k8sEnv.getPodsData().values().forEach(d -> d.getSpec().setTolerations(tolerations));
+    }
+  }
+
+  public void provision(PodSpec podSpec) {
+    if (!tolerations.isEmpty()) {
+      podSpec.setTolerations(tolerations);
     }
   }
 }

--- a/infrastructures/kubernetes/src/test/java/org/eclipse/che/workspace/infrastructure/kubernetes/namespace/pvc/PVCSubPathHelperTest.java
+++ b/infrastructures/kubernetes/src/test/java/org/eclipse/che/workspace/infrastructure/kubernetes/namespace/pvc/PVCSubPathHelperTest.java
@@ -49,7 +49,9 @@ import org.eclipse.che.commons.observability.NoopExecutorServiceWrapper;
 import org.eclipse.che.workspace.infrastructure.kubernetes.namespace.KubernetesDeployments;
 import org.eclipse.che.workspace.infrastructure.kubernetes.namespace.KubernetesNamespace;
 import org.eclipse.che.workspace.infrastructure.kubernetes.namespace.KubernetesNamespaceFactory;
+import org.eclipse.che.workspace.infrastructure.kubernetes.provision.NodeSelectorProvisioner;
 import org.eclipse.che.workspace.infrastructure.kubernetes.provision.SecurityContextProvisioner;
+import org.eclipse.che.workspace.infrastructure.kubernetes.provision.TolerationsProvisioner;
 import org.eclipse.che.workspace.infrastructure.kubernetes.util.RuntimeEventsPublisher;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Captor;
@@ -76,6 +78,8 @@ public class PVCSubPathHelperTest {
   private static final String M2_PATH = "/.m2";
 
   @Mock private SecurityContextProvisioner securityContextProvisioner;
+  @Mock private NodeSelectorProvisioner nodeSelectorProvisioner;
+  @Mock private TolerationsProvisioner tolerationsProvisioner;
   @Mock private KubernetesNamespaceFactory k8sNamespaceFactory;
   @Mock private KubernetesNamespace k8sNamespace;
   @Mock private KubernetesDeployments osDeployments;
@@ -97,6 +101,8 @@ public class PVCSubPathHelperTest {
             "IfNotPresent",
             k8sNamespaceFactory,
             securityContextProvisioner,
+            nodeSelectorProvisioner,
+            tolerationsProvisioner,
             new NoopExecutorServiceWrapper(),
             eventsPublisher);
     lenient().when(identity.getInfrastructureNamespace()).thenReturn(NAMESPACE);
@@ -144,6 +150,8 @@ public class PVCSubPathHelperTest {
     verify(podStatus).getPhase();
     verify(osDeployments).delete(anyString());
     verify(securityContextProvisioner).provision(any());
+    verify(nodeSelectorProvisioner).provision(any());
+    verify(tolerationsProvisioner).provision(any());
   }
 
   @Test
@@ -181,6 +189,8 @@ public class PVCSubPathHelperTest {
     verify(podStatus).getPhase();
     verify(osDeployments).delete(anyString());
     verify(securityContextProvisioner).provision(any());
+    verify(nodeSelectorProvisioner).provision(any());
+    verify(tolerationsProvisioner).provision(any());
   }
 
   @Test
@@ -248,6 +258,8 @@ public class PVCSubPathHelperTest {
             "ToBeOrNotIfPresent",
             k8sNamespaceFactory,
             securityContextProvisioner,
+            nodeSelectorProvisioner,
+            tolerationsProvisioner,
             new NoopExecutorServiceWrapper(),
             eventsPublisher);
     // when


### PR DESCRIPTION
Speed up workspace creation / start operations when using nodeSelectors (and tolerations).

<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests
-->

### What does this PR do?
This changes the behaviour of the pods spawned by `org.eclipse.che.workspace.infrastructure.kubernetes.namespace.pvc.PVCSubPathHelper` to add the same nodeSelectors and tolerations as the workspace pods. This avoids those pods encountering Multi-Attach errors when attaching the PVC used by persistent workspaces, which greatly speeds up workspace startup.

### What issues does this PR fix or reference?
<!-- Please include any related issue from eclipse che repository (or from another issue tracker).
     Include link to other pull requests like documentation PR from [the docs repo](https://github.com/eclipse/che-docs)
-->
Fixes eclipse/che#19990

### How to test this PR?
<!-- Please explain for example :
  - The test platform (openshift, kubernetes, minikube, CodeReady Container, docker-desktop, etc)
  - Installation method: chectl / che-operator
  - steps to reproduce
 -->
1. In values.yaml, specify a nodeSelector (and optionally, tolerations) for the workspace pods:
```yaml
che:
  workspace:
    podNodeSelector: "node.label=che-workspaces"
```
2. Launch Che on Kubernetes (in our case, AKS)
3. Log in to Che and launch a workspace with persistence enabled
4. In the user's namespace, observe the pods using 'kubectl describe pod' - the different pods that need to attach/mount the user's PVC should no longer encounter Multi-Attach errors. Startup time should be much quicker than without this change.

### PR Checklist

[As the author of this Pull Request I made sure that:](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#pull-request-template-and-its-checklist)

- [x] [The Eclipse Contributor Agreement is valid](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-eclipse-contributor-agreement-is-valid)
- [x] [Code produced is complete](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-produced-is-complete)
- [x] [Code builds without errors](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-builds-without-errors)
- [x] [Tests are covering the bugfix](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#tests-are-covering-the-bugfix)
- [x] [The repository devfile is up to date and works](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-repository-devfile-is-up-to-date-and-works)
- [x] [Sections `What issues does this PR fix or reference` and `How to test this PR` completed](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#sections-what-issues-does-this-pr-fix-or-reference-and-how-to-test-this-pr-completed)
- [x] [Relevant user documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [x] [Relevant contributing documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [CI/CD changes implemented, documented and communicated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#cicd-changes-implemented-documented-and-communicated)

### Reviewers

Reviewers, please comment how you tested the PR when approving it.
