### PR TITLE
fix: Omit default branch for GitLab repositories as it is not always 'master'

### DIFF
--- a/wsmaster/che-core-api-factory-gitlab/src/main/java/org/eclipse/che/api/factory/server/gitlab/GitlabUrl.java
+++ b/wsmaster/che-core-api-factory-gitlab/src/main/java/org/eclipse/che/api/factory/server/gitlab/GitlabUrl.java
@@ -206,8 +206,6 @@ public class GitlabUrl implements RemoteFactoryUrl {
             .toString();
     if (branch != null) {
       resultUrl = resultUrl + "?ref=" + branch;
-    } else {
-      resultUrl = resultUrl + "?ref=master";
     }
     return resultUrl;
   }

--- a/wsmaster/che-core-api-factory-gitlab/src/test/java/org/eclipse/che/api/factory/server/gitlab/GitlabAuthorizingFileContentProviderTest.java
+++ b/wsmaster/che-core-api-factory-gitlab/src/test/java/org/eclipse/che/api/factory/server/gitlab/GitlabAuthorizingFileContentProviderTest.java
@@ -45,7 +45,7 @@ public class GitlabAuthorizingFileContentProviderTest {
     verify(urlFetcher)
         .fetch(
             eq(
-                "https://gitlab.net/api/v4/projects/eclipse%2Fche/repository/files/devfile.yaml/raw?ref=master"));
+                "https://gitlab.net/api/v4/projects/eclipse%2Fche/repository/files/devfile.yaml/raw"));
   }
 
   @Test
@@ -57,7 +57,7 @@ public class GitlabAuthorizingFileContentProviderTest {
         new GitlabAuthorizingFileContentProvider(
             gitlabUrl, urlFetcher, gitCredentialsManager, personalAccessTokenManager);
     String url =
-        "https://gitlab.net/api/v4/projects/eclipse%2Fche/repository/files/devfile.yaml/raw?ref=master";
+        "https://gitlab.net/api/v4/projects/eclipse%2Fche/repository/files/devfile.yaml/raw";
     fileContentProvider.fetchContent(url);
     verify(urlFetcher).fetch(eq(url));
   }

--- a/wsmaster/che-core-api-factory-gitlab/src/test/java/org/eclipse/che/api/factory/server/gitlab/GitlabUrlTest.java
+++ b/wsmaster/che-core-api-factory-gitlab/src/test/java/org/eclipse/che/api/factory/server/gitlab/GitlabUrlTest.java
@@ -67,11 +67,11 @@ public class GitlabUrlTest {
     return new Object[][] {
       {
         "https://gitlab.net/eclipse/che.git",
-        "https://gitlab.net/api/v4/projects/eclipse%%2Fche/repository/files/%s/raw?ref=master"
+        "https://gitlab.net/api/v4/projects/eclipse%%2Fche/repository/files/%s/raw"
       },
       {
         "https://gitlab.net/eclipse/fooproj/che.git",
-        "https://gitlab.net/api/v4/projects/eclipse%%2Ffooproj/repository/files/%s/raw?ref=master"
+        "https://gitlab.net/api/v4/projects/eclipse%%2Ffooproj/repository/files/%s/raw"
       },
       {
         "https://gitlab.net/eclipse/fooproj/-/tree/master/",


### PR DESCRIPTION
### What does this PR do?
Backport of: https://github.com/eclipse-che/che-server/pull/34

Fixes the GitLab file reading behavior, by omitting master branch name by default.


### How to test this PR?
Before PR: Accepting factory with GitLab repository, having default branch other than 'master' is failing;
After PR: Accepting factory with GitLab repository, having default branch other than 'master' is OK;




### PR Checklist

[As the author of this Pull Request I made sure that:](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#pull-request-template-and-its-checklist)

- [x] [The Eclipse Contributor Agreement is valid](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-eclipse-contributor-agreement-is-valid)
- [x] [Code produced is complete](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-produced-is-complete)
- [ ] [Code builds without errors](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-builds-without-errors)
- [x] [Tests are covering the bugfix](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#tests-are-covering-the-bugfix)
- [ ] [The repository devfile is up to date and works](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-repository-devfile-is-up-to-date-and-works)
- [x] [Sections `What issues does this PR fix or reference` and `How to test this PR` completed](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#sections-what-issues-does-this-pr-fix-or-reference-and-how-to-test-this-pr-completed)
- [ ] [Relevant user documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [Relevant contributing documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [CI/CD changes implemented, documented and communicated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#cicd-changes-implemented-documented-and-communicated)

### Reviewers

Reviewers, please comment how you tested the PR when approving it.
