### PR TITLE
fix: Explicit configuration for GitLab OAuth integration

### DIFF
--- a/assembly/assembly-wsmaster-war/src/main/webapp/WEB-INF/classes/che/che.properties
+++ b/assembly/assembly-wsmaster-war/src/main/webapp/WEB-INF/classes/che/che.properties
@@ -760,5 +760,7 @@ che.integration.bitbucket.server_endpoints=NULL
 
 # GitLab endpoints used for factory integrations.
 # Comma separated list of GitLab server URLs or NULL if no integration expected.
-# Address of the server with expected OAuth 2 integration MUST be the first in the list.
 che.integration.gitlab.server_endpoints=NULL
+
+# Address of the GitLab server with configured OAuth 2 integration
+che.integration.gitlab.oauth_endpoint=NULL

--- a/wsmaster/che-core-api-factory-gitlab/src/main/java/org/eclipse/che/api/factory/server/gitlab/GitlabOAuthTokenFetcher.java
+++ b/wsmaster/che-core-api-factory-gitlab/src/main/java/org/eclipse/che/api/factory/server/gitlab/GitlabOAuthTokenFetcher.java
@@ -97,8 +97,8 @@ public class GitlabOAuthTokenFetcher implements PersonalAccessTokenFetcher {
     if (oAuthAPI == null) {
       throw new ScmCommunicationException(
           format(
-              "OAuth is not configured for SCM provider [%s]. Make sure "
-                  + "you have read the doc about SCM providers configuration.",
+              "OAuth 2 is not configured for SCM provider [%s]. For details, refer "
+                  + "the documentation in section of SCM providers configuration.",
               OAUTH_PROVIDER_NAME));
     }
     OAuthToken oAuthToken;

--- a/wsmaster/che-core-api-factory-gitlab/src/main/java/org/eclipse/che/api/factory/server/gitlab/GitlabOAuthTokenFetcher.java
+++ b/wsmaster/che-core-api-factory-gitlab/src/main/java/org/eclipse/che/api/factory/server/gitlab/GitlabOAuthTokenFetcher.java
@@ -11,9 +11,14 @@
  */
 package org.eclipse.che.api.factory.server.gitlab;
 
+import static java.lang.String.format;
+import static java.util.stream.Collectors.toList;
+
 import com.google.common.base.Splitter;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Sets;
+import java.util.Collections;
+import java.util.List;
 import java.util.Optional;
 import java.util.Set;
 import javax.inject.Inject;
@@ -35,6 +40,7 @@ import org.eclipse.che.commons.annotation.Nullable;
 import org.eclipse.che.commons.lang.NameGenerator;
 import org.eclipse.che.commons.lang.StringUtils;
 import org.eclipse.che.commons.subject.Subject;
+import org.eclipse.che.inject.ConfigurationException;
 import org.eclipse.che.security.oauth.OAuthAPI;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -48,22 +54,34 @@ public class GitlabOAuthTokenFetcher implements PersonalAccessTokenFetcher {
       ImmutableSet.of("api", "write_repository", "openid");
   public static final String OAUTH_2_PREFIX = "oauth2-";
 
+  private final List<String> registeredGitlabEndpoints;
   private final OAuthAPI oAuthAPI;
   private final String apiEndpoint;
-  private final GitlabApiClient gitlabApiClient;
 
   @Inject
   public GitlabOAuthTokenFetcher(
       @Nullable @Named("che.integration.gitlab.server_endpoints") String gitlabEndpoints,
+      @Nullable @Named("che.integration.gitlab.oauth_endpoint") String oauthEndpoint,
       @Named("che.api") String apiEndpoint,
       OAuthAPI oAuthAPI) {
     this.apiEndpoint = apiEndpoint;
-    this.oAuthAPI = oAuthAPI;
     if (gitlabEndpoints != null) {
-      final String oAuthEndpoint = Splitter.on(",").splitToList(gitlabEndpoints).get(0);
-      this.gitlabApiClient = new GitlabApiClient(StringUtils.trimEnd(oAuthEndpoint, '/'));
+      this.registeredGitlabEndpoints =
+          Splitter.on(",")
+              .splitToStream(gitlabEndpoints)
+              .map(e -> StringUtils.trimEnd(e, '/'))
+              .collect(toList());
     } else {
-      this.gitlabApiClient = null;
+      this.registeredGitlabEndpoints = Collections.emptyList();
+    }
+    if (oauthEndpoint != null) {
+      if (!registeredGitlabEndpoints.contains(StringUtils.trimEnd(oauthEndpoint, '/'))) {
+        throw new ConfigurationException(
+            "GitLab OAuth integration endpoint must be present in registered GitLab endpoints list.");
+      }
+      this.oAuthAPI = oAuthAPI;
+    } else {
+      this.oAuthAPI = null;
     }
   }
 
@@ -71,9 +89,17 @@ public class GitlabOAuthTokenFetcher implements PersonalAccessTokenFetcher {
   public PersonalAccessToken fetchPersonalAccessToken(Subject cheSubject, String scmServerUrl)
       throws ScmUnauthorizedException, ScmCommunicationException {
     scmServerUrl = StringUtils.trimEnd(scmServerUrl, '/');
+    GitlabApiClient gitlabApiClient = getApiClient(scmServerUrl);
     if (gitlabApiClient == null || !gitlabApiClient.isConnected(scmServerUrl)) {
       LOG.debug("not a  valid url {} for current fetcher ", scmServerUrl);
       return null;
+    }
+    if (oAuthAPI == null) {
+      throw new ScmCommunicationException(
+          format(
+              "OAuth is not configured for SCM provider [%s]. Make sure "
+                  + "you have read the doc about SCM providers configuration.",
+              OAUTH_PROVIDER_NAME));
     }
     OAuthToken oAuthToken;
     try {
@@ -117,8 +143,8 @@ public class GitlabOAuthTokenFetcher implements PersonalAccessTokenFetcher {
   }
 
   @Override
-  public Optional<Boolean> isValid(PersonalAccessToken personalAccessToken)
-      throws ScmCommunicationException, ScmUnauthorizedException {
+  public Optional<Boolean> isValid(PersonalAccessToken personalAccessToken) {
+    GitlabApiClient gitlabApiClient = getApiClient(personalAccessToken.getScmProviderUrl());
     if (gitlabApiClient == null
         || !gitlabApiClient.isConnected(personalAccessToken.getScmProviderUrl())) {
       LOG.debug(
@@ -151,5 +177,11 @@ public class GitlabOAuthTokenFetcher implements PersonalAccessTokenFetcher {
         + "/oauth/authenticate?oauth_provider="
         + OAUTH_PROVIDER_NAME
         + "&request_method=POST&signature_method=rsa";
+  }
+
+  private GitlabApiClient getApiClient(String scmServerUrl) {
+    return registeredGitlabEndpoints.contains(scmServerUrl)
+        ? new GitlabApiClient(scmServerUrl)
+        : null;
   }
 }

--- a/wsmaster/che-core-api-factory-gitlab/src/test/java/org/eclipse/che/api/factory/server/gitlab/GitlabOAuthTokenFetcherTest.java
+++ b/wsmaster/che-core-api-factory-gitlab/src/test/java/org/eclipse/che/api/factory/server/gitlab/GitlabOAuthTokenFetcherTest.java
@@ -147,7 +147,8 @@ public class GitlabOAuthTokenFetcherTest {
   @Test(
       expectedExceptions = ScmCommunicationException.class,
       expectedExceptionsMessageRegExp =
-          "OAuth is not configured for SCM provider \\[gitlab\\]. Make sure you have read the doc about SCM providers configuration.")
+          "OAuth 2 is not configured for SCM provider \\[gitlab\\]. For details, refer "
+              + "the documentation in section of SCM providers configuration.")
   public void shouldThrowScmCommunicationExceptionWhenNoOauthIsConfigured() throws Exception {
     Subject subject = new SubjectImpl("Username", "id1", "token", false);
     GitlabOAuthTokenFetcher localFetcher =

--- a/wsmaster/che-core-api-factory-gitlab/src/test/java/org/eclipse/che/api/factory/server/gitlab/GitlabOAuthTokenFetcherTest.java
+++ b/wsmaster/che-core-api-factory-gitlab/src/test/java/org/eclipse/che/api/factory/server/gitlab/GitlabOAuthTokenFetcherTest.java
@@ -34,6 +34,7 @@ import org.eclipse.che.api.factory.server.scm.exception.ScmCommunicationExceptio
 import org.eclipse.che.api.factory.server.scm.exception.ScmUnauthorizedException;
 import org.eclipse.che.commons.subject.Subject;
 import org.eclipse.che.commons.subject.SubjectImpl;
+import org.eclipse.che.inject.ConfigurationException;
 import org.eclipse.che.security.oauth.OAuthAPI;
 import org.mockito.Mock;
 import org.mockito.testng.MockitoTestNGListener;
@@ -59,7 +60,8 @@ public class GitlabOAuthTokenFetcherTest {
     WireMock.configureFor("localhost", wireMockServer.port());
     wireMock = new WireMock("localhost", wireMockServer.port());
     oAuthTokenFetcher =
-        new GitlabOAuthTokenFetcher(wireMockServer.url("/"), "http://che.api", oAuthAPI);
+        new GitlabOAuthTokenFetcher(
+            wireMockServer.url("/"), wireMockServer.url("/"), "http://che.api", oAuthAPI);
   }
 
   @AfterMethod
@@ -131,6 +133,26 @@ public class GitlabOAuthTokenFetcherTest {
     PersonalAccessToken token =
         oAuthTokenFetcher.fetchPersonalAccessToken(subject, wireMockServer.url("/"));
     assertNotNull(token);
+  }
+
+  @Test(
+      expectedExceptions = ConfigurationException.class,
+      expectedExceptionsMessageRegExp =
+          "GitLab OAuth integration endpoint must be present in registered GitLab endpoints list.")
+  public void shouldThrowConfigurationExceptionIfOauthEndpointNotInTheList() throws Exception {
+    new GitlabOAuthTokenFetcher(
+        wireMockServer.url("/"), "http://foo.bar", "http://che.api", oAuthAPI);
+  }
+
+  @Test(
+      expectedExceptions = ScmCommunicationException.class,
+      expectedExceptionsMessageRegExp =
+          "OAuth is not configured for SCM provider \\[gitlab\\]. Make sure you have read the doc about SCM providers configuration.")
+  public void shouldThrowScmCommunicationExceptionWhenNoOauthIsConfigured() throws Exception {
+    Subject subject = new SubjectImpl("Username", "id1", "token", false);
+    GitlabOAuthTokenFetcher localFetcher =
+        new GitlabOAuthTokenFetcher(wireMockServer.url("/"), null, "http://che.api", oAuthAPI);
+    localFetcher.fetchPersonalAccessToken(subject, wireMockServer.url("/"));
   }
 
   @Test


### PR DESCRIPTION
### What does this PR do?
Curerntly, in case of any failure during retrieval of the file from public repository, we're starting OAuth procedure even if the reposiitory is public and no OAuth is configured on server.  (for example, no SSL key refistered or server unavailable w\out VPN or other kind of error.) In that case user will see a unexpeced error messages saying Oauth tokens is not resolvable etc.
This PR adds property which exlplicitly indicates that Gitlab OAuth is ON or OFF, so we can know should we start authentication or no.

### Screenshot/screencast of this PR
<!-- Please include a screenshot or a screencast explaining what is doing this PR -->


### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/19991 (partially)


### How to test this PR?
Run a factory for examle pointing to RH internal CEE without VPN connected:
( URL example: https://gitlab.cee.redhat.com/rhopp/che-server/-/tree/main)

Error before:
![image](https://user-images.githubusercontent.com/1651062/123066533-d1420300-d418-11eb-8a4e-d07575159bfa.png)


Error after:
![image](https://user-images.githubusercontent.com/1651062/123070688-a35ebd80-d41c-11eb-8d8e-cda3b19437eb.png)


Docs PR: https://github.com/eclipse/che-docs/pull/2045

### PR Checklist

[As the author of this Pull Request I made sure that:](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#pull-request-template-and-its-checklist)

- [x] [The Eclipse Contributor Agreement is valid](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-eclipse-contributor-agreement-is-valid)
- [x] [Code produced is complete](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-produced-is-complete)
- [x] [Code builds without errors](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-builds-without-errors)
- [ ] [Tests are covering the bugfix](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#tests-are-covering-the-bugfix)
- [x] [The repository devfile is up to date and works](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-repository-devfile-is-up-to-date-and-works)
- [x] [Sections `What issues does this PR fix or reference` and `How to test this PR` completed](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#sections-what-issues-does-this-pr-fix-or-reference-and-how-to-test-this-pr-completed)
- [ ] [Relevant user documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [Relevant contributing documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [CI/CD changes implemented, documented and communicated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#cicd-changes-implemented-documented-and-communicated)

### Reviewers

Reviewers, please comment how you tested the PR when approving it.
