### PR TITLE
ci: Use semantic commit message in release workflow

### DIFF
--- a/make-release.sh
+++ b/make-release.sh
@@ -145,7 +145,7 @@ commitChangeOrCreatePR() {
     aBRANCH="$2"
     PR_BRANCH="$3"
 
-    COMMIT_MSG="[release] Bump to ${aVERSION} in ${aBRANCH}"
+    COMMIT_MSG="chore: Bump to ${aVERSION} in ${aBRANCH}"
 
     # commit change into branch
     git commit -asm "${COMMIT_MSG}"
@@ -176,7 +176,7 @@ tagAndCommit() {
     cd $1
     # this branch isn't meant to be pushed
     git checkout -b release-${CHE_VERSION}
-    git commit -asm "Release version ${CHE_VERSION}"
+    git commit -asm "chore: Release version ${CHE_VERSION}"
     if [ $(git tag -l "$CHE_VERSION") ]; then
         echo "tag ${CHE_VERSION} already exists! recreating ..."
         git tag -d ${CHE_VERSION}
@@ -389,7 +389,7 @@ updateImageTagsInCheServer() {
     cd .ci
     ./set_tag_version_images.sh ${CHE_VERSION}
     cd ..
-    git commit -asm "Set ${CHE_VERSION} release image tags"
+    git commit -asm "chore: Set ${CHE_VERSION} release image tags"
     git push origin ${BRANCH}
 }
 


### PR DESCRIPTION
Signed-off-by: Mykhailo Kuznietsov <mkuznets@redhat.com>

<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests
-->

### What does this PR do?
Change commit message in release workflow to comply with semantic pr/commit rules

### Screenshot/screencast of this PR
<!-- Please include a screenshot or a screencast explaining what is doing this PR -->


### What issues does this PR fix or reference?
<!-- Please include any related issue from eclipse che repository (or from another issue tracker).
     Include link to other pull requests like documentation PR from [the docs repo](https://github.com/eclipse/che-docs)
-->
N / A

### How to test this PR?
<!-- Please explain for example :
  - The test platform (openshift, kubernetes, minikube, CodeReady Container, docker-desktop, etc)
  - Installation method: chectl / che-operator
  - steps to reproduce
 -->
N / A

### PR Checklist

[As the author of this Pull Request I made sure that:](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#pull-request-template-and-its-checklist)

- [x] [The Eclipse Contributor Agreement is valid](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-eclipse-contributor-agreement-is-valid)
- [x] [Code produced is complete](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-produced-is-complete)
- [x] [Code builds without errors](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-builds-without-errors)
- [ ] [Tests are covering the bugfix](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#tests-are-covering-the-bugfix)
- [ ] [The repository devfile is up to date and works](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-repository-devfile-is-up-to-date-and-works)
- [ ] [Sections `What issues does this PR fix or reference` and `How to test this PR` completed](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#sections-what-issues-does-this-pr-fix-or-reference-and-how-to-test-this-pr-completed)
- [ ] [Relevant user documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [Relevant contributing documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [x] [CI/CD changes implemented, documented and communicated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#cicd-changes-implemented-documented-and-communicated)

### Reviewers

Reviewers, please comment how you tested the PR when approving it.
