### PR TITLE
Fix: Enable infrastructure-kubernetes tests

### DIFF
--- a/infrastructures/kubernetes/pom.xml
+++ b/infrastructures/kubernetes/pom.xml
@@ -237,6 +237,12 @@
             <groupId>io.fabric8</groupId>
             <artifactId>kubernetes-server-mock</artifactId>
             <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <artifactId>junit-jupiter-api</artifactId>
+                    <groupId>org.junit.jupiter</groupId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.eclipse.che.core</groupId>

--- a/infrastructures/kubernetes/src/test/java/org/eclipse/che/workspace/infrastructure/kubernetes/DirectKubernetesAPIAccessHelperTest.java
+++ b/infrastructures/kubernetes/src/test/java/org/eclipse/che/workspace/infrastructure/kubernetes/DirectKubernetesAPIAccessHelperTest.java
@@ -114,8 +114,8 @@ public class DirectKubernetesAPIAccessHelperTest {
             new ByteArrayInputStream("null".getBytes(StandardCharsets.UTF_8)));
 
     // then
-    assertEquals(requestCaptor.getValue().header("ducks"), "many");
-    assertEquals(requestCaptor.getValue().header("geese"), "volumes");
+    assertEquals(requestCaptor.getValue().header("ducks"), null);
+    assertEquals(requestCaptor.getValue().header("geese"), null);
     assertEquals(requestCaptor.getValue().header("Content-Type"), "text/literary");
   }
 

--- a/infrastructures/kubernetes/src/test/java/org/eclipse/che/workspace/infrastructure/kubernetes/DirectKubernetesAPIAccessHelperTest.java
+++ b/infrastructures/kubernetes/src/test/java/org/eclipse/che/workspace/infrastructure/kubernetes/DirectKubernetesAPIAccessHelperTest.java
@@ -94,7 +94,7 @@ public class DirectKubernetesAPIAccessHelperTest {
   }
 
   @Test
-  public void testSendsRequestHeaders() throws Exception {
+  public void testSendsOnlyContentTypeHeaders() throws Exception {
     // given
     when(headers.getRequestHeaders())
         .thenReturn(

--- a/infrastructures/kubernetes/src/test/java/org/eclipse/che/workspace/infrastructure/kubernetes/namespace/KubernetesNamespaceFactoryTest.java
+++ b/infrastructures/kubernetes/src/test/java/org/eclipse/che/workspace/infrastructure/kubernetes/namespace/KubernetesNamespaceFactoryTest.java
@@ -97,7 +97,6 @@ import org.testng.collections.Sets;
  *
  * @author Sergii Leshchenko
  */
-@Test
 @Listeners(MockitoTestNGListener.class)
 public class KubernetesNamespaceFactoryTest {
 
@@ -654,15 +653,6 @@ public class KubernetesNamespaceFactoryTest {
     assertEquals(
         Sets.newHashSet("workspace-view", "workspace-metrics", "exec", "workspace-secrets"),
         roles.getItems().stream().map(r -> r.getMetadata().getName()).collect(Collectors.toSet()));
-
-    assertEquals(
-        Sets.newHashSet("list", "create", "delete", "get", "watch"),
-        roles
-            .getItems()
-            .stream()
-            .map(r -> r.getRules().get(0).getVerbs())
-            .collect(Collectors.toSet()));
-
     RoleBindingList bindings = k8sClient.rbac().roleBindings().inNamespace("workspace123").list();
     assertEquals(
         bindings
@@ -675,7 +665,8 @@ public class KubernetesNamespaceFactoryTest {
             "serviceAccount-cluster0",
             "serviceAccount-cluster1",
             "serviceAccount-view",
-            "serviceAccount-exec"));
+            "serviceAccount-exec",
+            "serviceAccount-secrets"));
   }
 
   @Test
@@ -728,12 +719,16 @@ public class KubernetesNamespaceFactoryTest {
 
     RoleBindingList bindings = k8sClient.rbac().roleBindings().inNamespace("workspace123").list();
     assertEquals(
-        Sets.newHashSet("serviceAccount-metrics", "serviceAccount-view", "serviceAccount-exec"),
         bindings
             .getItems()
             .stream()
             .map(r -> r.getMetadata().getName())
-            .collect(Collectors.toSet()));
+            .collect(Collectors.toSet()),
+        Sets.newHashSet(
+            "serviceAccount-metrics",
+            "serviceAccount-view",
+            "serviceAccount-exec",
+            "serviceAccount-secrets"));
   }
 
   @Test

--- a/infrastructures/kubernetes/src/test/java/org/eclipse/che/workspace/infrastructure/kubernetes/server/external/TraefikGatewayRouteConfigGeneratorTest.java
+++ b/infrastructures/kubernetes/src/test/java/org/eclipse/che/workspace/infrastructure/kubernetes/server/external/TraefikGatewayRouteConfigGeneratorTest.java
@@ -134,7 +134,7 @@ public class TraefikGatewayRouteConfigGeneratorTest {
             .endMetadata()
             .build();
 
-    gatewayConfigGenerator.addRouteConfig("external-server-1", routeConfig);
+    gatewayConfigGeneratorNonDefaultDomain.addRouteConfig("external-server-1", routeConfig);
     Map<String, String> generatedConfig =
         gatewayConfigGeneratorNonDefaultDomain.generate("che-namespace");
 


### PR DESCRIPTION

### What does this PR do?
At this point tests from infrastructure-kubernetes are not executed due to dependency conflict
```
DEBUG] Dependency collection stats {ConflictMarker.analyzeTime=20408, ConflictMarker.markTime=15531, ConflictMarker.nodeCount=1, ConflictIdSorter.graphTime=2047, ConflictIdSorter.topsortTime=5830, ConflictIdSorter.conflictIdCount=0, ConflictIdSorter.conflictIdCycleCount=0, ConflictResolver.totalTime=10009, ConflictResolver.conflictItemCount=0, DefaultDependencyCollector.collectTime=3812, DefaultDependencyCollector.transformTime=65518}
[DEBUG] Test dependencies contain org.junit.jupiter:junit-jupiter-api. Resolving org.junit.jupiter:junit-jupiter-engine:5.7.2
[DEBUG] Resolving artifact org.junit.jupiter:junit-jupiter-engine:5.7.2
[DEBUG] Resolved artifact org.junit.jupiter:junit-jupiter-engine:5.7.2 to [org.junit.jupiter:junit-jupiter-engine:jar:5.7.2, org.apiguardian:apiguardian-api:jar:1.1.0:compile, org.junit.platform:junit-platform-engine:jar:1.7.2:compile, org.opentest4j:opentest4j:jar:1.2.0:compile, org.junit.platform:junit-platform-commons:jar:1.7.2:compile, org.junit.jupiter:junit-jupiter-api:jar:5.7.2:compile]
[DEBUG] Test dependencies contain JUnit4. Resolving org.junit.vintage:junit-vintage-engine:5.7.2
[DEBUG] Resolving artifact org.junit.vintage:junit-vintage-engine:5.7.2
[DEBUG] Resolved artifact org.junit.vintage:junit-vintage-engine:5.7.2 to [org.junit.vintage:junit-vintage-engine:jar:5.7.2, org.apiguardian:apiguardian-api:jar:1.1.0:compile, org.junit.platform:junit-platform-engine:jar:1.7.2:compile, org.opentest4j:opentest4j:jar:1.2.0:compile, org.junit.platform:junit-platform-commons:jar:1.7.2:compile, junit:junit:jar:4.13:compile, org.hamcrest:hamcrest-core:jar:1.3:compile]
[DEBUG] Resolving artifact org.junit.platform:junit-platform-launcher:1.7.2
[DEBUG] Resolved artifact org.junit.platform:junit-platform-launcher:1.7.2 to [org.junit.platform:junit-platform-launcher:jar:1.7.2, org.apiguardian:apiguardian-api:jar:1.1.0:compile, org.junit.platform:junit-platform-engine:jar:1.7.2:compile, org.opentest4j:opentest4j:jar:1.2.0:compile, org.junit.platform:junit-platform-commons:jar:1.7.2:compile]
```
```
[INFO] +- io.fabric8:kubernetes-server-mock:jar:5.4.1:test
[INFO] |  +- io.fabric8:mockwebserver:jar:0.1.8:test
[INFO] |  |  +- com.squareup.okhttp3:mockwebserver:jar:3.12.6:test
[INFO] |  |  |  \- junit:junit:jar:4.13.1:test
[INFO] |  |  \- io.sundr:builder-annotations:jar:0.40.1:provided
[INFO] |  |     +- io.sundr:sundr-core:jar:0.40.1:provided
[INFO] |  |     +- io.sundr:sundr-codegen:jar:0.40.1:provided
[INFO] |  |     +- io.sundr:sundr-adapter-apt:jar:0.40.1:provided
[INFO] |  |     |  +- io.sundr:sundr-model-utils:jar:0.40.1:provided
[INFO] |  |     |  |  \- io.sundr:sundr-model-repo:jar:0.40.1:provided
[INFO] |  |     |  \- io.sundr:sundr-adapter-api:jar:0.40.1:provided
[INFO] |  |     +- io.sundr:sundr-adapter-reflect:jar:0.40.1:provided
[INFO] |  |     |  \- io.sundr:sundr-model:jar:0.40.1:provided
[INFO] |  |     |     \- io.sundr:sundr-model-base:jar:0.40.1:provided
[INFO] |  |     \- io.sundr:resourcecify-annotations:jar:0.40.1:provided
[INFO] |  \- org.junit.jupiter:junit-jupiter-api:jar:5.7.2:test
[INFO] |     +- org.apiguardian:apiguardian-api:jar:1.1.0:test
[INFO] |     +- org.opentest4j:opentest4j:jar:1.2.0:test
[INFO] |     \- org.junit.platform:junit-platform-commons:jar:1.7.2:test
```
 - Fix in DirectKubernetesAPIAccessHelperTest.java  due to https://github.com/eclipse-che/che-server/pull/6
 - In  KubernetesNamespaceFactoryTest.java  removed ```Sets.newHashSet("list", "create", "delete", "get", "watch"),``` because it compared with set of sets with verbs of different permissions was added https://github.com/eclipse-che/che-server/pull/44
 - Fix in KubernetesNamespaceFactoryTest add missed SA names 
 - Fix in TraefikGatewayRouteConfigGeneratorTest.java configuration added in the wrong class. (copy/paste error)


### Screenshot/screencast of this PR
<img width="1333" alt="Знімок екрана 2021-07-14 о 15 24 58" src="https://user-images.githubusercontent.com/1614429/125621630-0c92b68f-7666-46be-9345-f92a92ca7739.png">


### What issues does this PR fix or reference?
n/a


### How to test this PR?
- ```cd infrastructure/kubernetes```
- ```mvn clean install```

### PR Checklist

[As the author of this Pull Request I made sure that:](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#pull-request-template-and-its-checklist)

- [x] [The Eclipse Contributor Agreement is valid](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-eclipse-contributor-agreement-is-valid)
- [x] [Code produced is complete](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-produced-is-complete)
- [x] [Code builds without errors](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-builds-without-errors)
- [x] [Tests are covering the bugfix](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#tests-are-covering-the-bugfix)
- [x] [The repository devfile is up to date and works](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-repository-devfile-is-up-to-date-and-works)
- [x] [Sections `What issues does this PR fix or reference` and `How to test this PR` completed](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#sections-what-issues-does-this-pr-fix-or-reference-and-how-to-test-this-pr-completed)
- [x] [Relevant user documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [x] [Relevant contributing documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [x] [CI/CD changes implemented, documented and communicated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#cicd-changes-implemented-documented-and-communicated)

### Reviewers

Reviewers, please comment how you tested the PR when approving it.
