### PR TITLE
feat: REST Service on the Che server-side that will initiate k8s namespace provisioning

### DIFF
--- a/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/api/server/KubernetesNamespaceService.java
+++ b/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/api/server/KubernetesNamespaceService.java
@@ -72,8 +72,8 @@ public class KubernetesNamespaceService extends Service {
   @ApiOperation(
       value = "Provision k8s namespaces where user is able to create workspaces",
       notes =
-          "This operation can be performed only by authorized user."
-              + "This is under beta and may be significant changed",
+          "This operation can be performed only by an authorized user."
+              + " This is a beta feature that may be significantly changed.",
       response = KubernetesNamespaceMetaDto.class)
   @ApiResponses({
     @ApiResponse(code = 200, message = "The namespaces successfully provisioned"),

--- a/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/api/server/KubernetesNamespaceService.java
+++ b/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/api/server/KubernetesNamespaceService.java
@@ -70,16 +70,16 @@ public class KubernetesNamespaceService extends Service {
   @Path("provision")
   @Produces(APPLICATION_JSON)
   @ApiOperation(
-      value = "Provision k8s namespaces where user is able to create workspaces",
+      value = "Provision k8s namespace where user is able to create workspaces",
       notes =
           "This operation can be performed only by an authorized user."
               + " This is a beta feature that may be significantly changed.",
       response = KubernetesNamespaceMetaDto.class)
   @ApiResponses({
-    @ApiResponse(code = 200, message = "The namespaces successfully provisioned"),
+    @ApiResponse(code = 200, message = "The namespace successfully provisioned"),
     @ApiResponse(
         code = 500,
-        message = "Internal server error occurred during namespaces provisioning")
+        message = "Internal server error occurred during namespace provisioning")
   })
   public KubernetesNamespaceMetaDto provision() throws InfrastructureException {
     return asDto(

--- a/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/api/server/KubernetesNamespaceService.java
+++ b/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/api/server/KubernetesNamespaceService.java
@@ -77,7 +77,9 @@ public class KubernetesNamespaceService extends Service {
       response = KubernetesNamespaceMetaDto.class)
   @ApiResponses({
     @ApiResponse(code = 200, message = "The namespaces successfully provisioned"),
-    @ApiResponse(code = 500, message = "Internal server error occurred during namespaces provisioning")
+    @ApiResponse(
+        code = 500,
+        message = "Internal server error occurred during namespaces provisioning")
   })
   public KubernetesNamespaceMetaDto provision() throws InfrastructureException {
     return asDto(

--- a/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/api/server/KubernetesNamespaceService.java
+++ b/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/api/server/KubernetesNamespaceService.java
@@ -22,10 +22,13 @@ import java.util.List;
 import java.util.stream.Collectors;
 import javax.inject.Inject;
 import javax.ws.rs.GET;
+import javax.ws.rs.POST;
 import javax.ws.rs.Path;
 import javax.ws.rs.Produces;
 import org.eclipse.che.api.core.rest.Service;
 import org.eclipse.che.api.workspace.server.spi.InfrastructureException;
+import org.eclipse.che.api.workspace.server.spi.NamespaceResolutionContext;
+import org.eclipse.che.commons.env.EnvironmentContext;
 import org.eclipse.che.dto.server.DtoFactory;
 import org.eclipse.che.workspace.infrastructure.kubernetes.api.shared.KubernetesNamespaceMeta;
 import org.eclipse.che.workspace.infrastructure.kubernetes.api.shared.dto.KubernetesNamespaceMetaDto;
@@ -61,6 +64,25 @@ public class KubernetesNamespaceService extends Service {
   })
   public List<KubernetesNamespaceMetaDto> getNamespaces() throws InfrastructureException {
     return namespaceFactory.list().stream().map(this::asDto).collect(Collectors.toList());
+  }
+
+  @POST
+  @Path("provision")
+  @Produces(APPLICATION_JSON)
+  @ApiOperation(
+      value = "Provision k8s namespaces where user is able to create workspaces",
+      notes =
+          "This operation can be performed only by authorized user."
+              + "This is under beta and may be significant changed",
+      response = KubernetesNamespaceMetaDto.class)
+  @ApiResponses({
+    @ApiResponse(code = 200, message = "The namespaces successfully provisioned"),
+    @ApiResponse(code = 500, message = "Internal server error occurred during namespaces provisioning")
+  })
+  public KubernetesNamespaceMetaDto provision() throws InfrastructureException {
+    return asDto(
+        namespaceFactory.provision(
+            new NamespaceResolutionContext(EnvironmentContext.getCurrent().getSubject())));
   }
 
   private KubernetesNamespaceMetaDto asDto(KubernetesNamespaceMeta kubernetesNamespaceMeta) {

--- a/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/namespace/KubernetesNamespaceFactory.java
+++ b/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/namespace/KubernetesNamespaceFactory.java
@@ -344,8 +344,8 @@ public class KubernetesNamespaceFactory {
     KubernetesNamespace namespace =
         getOrCreate(
             new RuntimeIdentityImpl(
-                "wsid",
-                "env",
+                null,
+                null,
                 namespaceResolutionContext.getUserId(),
                 evaluateNamespaceName(namespaceResolutionContext)));
 

--- a/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/namespace/KubernetesNamespaceFactory.java
+++ b/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/namespace/KubernetesNamespaceFactory.java
@@ -351,7 +351,7 @@ public class KubernetesNamespaceFactory {
 
     return fetchNamespace(namespace.getName())
         .orElseThrow(
-            () -> new InfrastructureException("Not able to find namespace" + namespace.getName()));
+            () -> new InfrastructureException("Not able to find namespace " + namespace.getName()));
   }
 
   public KubernetesNamespace get(RuntimeIdentity identity) throws InfrastructureException {

--- a/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/namespace/KubernetesNamespaceFactory.java
+++ b/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/namespace/KubernetesNamespaceFactory.java
@@ -50,6 +50,7 @@ import org.eclipse.che.api.core.model.workspace.Workspace;
 import org.eclipse.che.api.core.model.workspace.runtime.RuntimeIdentity;
 import org.eclipse.che.api.user.server.PreferenceManager;
 import org.eclipse.che.api.user.server.UserManager;
+import org.eclipse.che.api.workspace.server.model.impl.RuntimeIdentityImpl;
 import org.eclipse.che.api.workspace.server.spi.InfrastructureException;
 import org.eclipse.che.api.workspace.server.spi.NamespaceResolutionContext;
 import org.eclipse.che.commons.annotation.Nullable;
@@ -336,6 +337,21 @@ public class KubernetesNamespaceFactory {
     }
 
     return namespace;
+  }
+
+  public KubernetesNamespaceMeta provision(NamespaceResolutionContext namespaceResolutionContext)
+      throws InfrastructureException {
+    KubernetesNamespace namespace =
+        getOrCreate(
+            new RuntimeIdentityImpl(
+                "wsid",
+                "env",
+                namespaceResolutionContext.getUserId(),
+                evaluateNamespaceName(namespaceResolutionContext)));
+
+    return fetchNamespace(namespace.getName())
+        .orElseThrow(
+            () -> new InfrastructureException("Not able to find namespace" + namespace.getName()));
   }
 
   public KubernetesNamespace get(RuntimeIdentity identity) throws InfrastructureException {

--- a/infrastructures/kubernetes/src/test/java/org/eclipse/che/workspace/infrastructure/kubernetes/api/server/KubernetesNamespaceServiceTest.java
+++ b/infrastructures/kubernetes/src/test/java/org/eclipse/che/workspace/infrastructure/kubernetes/api/server/KubernetesNamespaceServiceTest.java
@@ -16,6 +16,7 @@ import static java.util.Collections.singletonList;
 import static org.everrest.assured.JettyHttpServer.ADMIN_USER_NAME;
 import static org.everrest.assured.JettyHttpServer.ADMIN_USER_PASSWORD;
 import static org.everrest.assured.JettyHttpServer.SECURE_PATH;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.testng.Assert.assertEquals;
@@ -24,15 +25,25 @@ import com.google.common.collect.ImmutableMap;
 import com.jayway.restassured.response.Response;
 import java.util.Collections;
 import java.util.List;
+import org.eclipse.che.api.core.rest.ApiExceptionMapper;
 import org.eclipse.che.api.core.rest.CheJsonProvider;
+import org.eclipse.che.api.workspace.server.spi.NamespaceResolutionContext;
+import org.eclipse.che.commons.env.EnvironmentContext;
+import org.eclipse.che.commons.subject.Subject;
+import org.eclipse.che.commons.subject.SubjectImpl;
 import org.eclipse.che.dto.server.DtoFactory;
 import org.eclipse.che.workspace.infrastructure.kubernetes.api.server.impls.KubernetesNamespaceMetaImpl;
 import org.eclipse.che.workspace.infrastructure.kubernetes.api.shared.dto.KubernetesNamespaceMetaDto;
 import org.eclipse.che.workspace.infrastructure.kubernetes.namespace.KubernetesNamespaceFactory;
 import org.everrest.assured.EverrestJetty;
+import org.everrest.core.Filter;
+import org.everrest.core.GenericContainerRequest;
+import org.everrest.core.RequestFilter;
+import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.testng.MockitoTestNGListener;
+import org.testng.Assert;
 import org.testng.annotations.Listeners;
 import org.testng.annotations.Test;
 
@@ -43,6 +54,14 @@ import org.testng.annotations.Test;
  */
 @Listeners(value = {EverrestJetty.class, MockitoTestNGListener.class})
 public class KubernetesNamespaceServiceTest {
+
+  @SuppressWarnings("unused")
+  private static final ApiExceptionMapper MAPPER = new ApiExceptionMapper();
+
+  @SuppressWarnings("unused")
+  private static final EnvironmentFilter FILTER = new EnvironmentFilter();
+
+  private static final Subject SUBJECT = new SubjectImpl("john", "id-123", "token", false);
 
   @SuppressWarnings("unused") // is declared for deploying by everrest-assured
   private CheJsonProvider jsonProvider = new CheJsonProvider(Collections.emptySet());
@@ -73,7 +92,69 @@ public class KubernetesNamespaceServiceTest {
     verify(namespaceFactory).list();
   }
 
+  @Test
+  public void shouldProvisionNamespace() throws Exception {
+    // given
+    KubernetesNamespaceMetaImpl namespaceMeta =
+        new KubernetesNamespaceMetaImpl(
+            "ws-namespace", ImmutableMap.of("phase", "active", "default", "true"));
+    when(namespaceFactory.provision(any(NamespaceResolutionContext.class)))
+        .thenReturn(namespaceMeta);
+    // when
+    final Response response =
+        given()
+            .auth()
+            .basic(ADMIN_USER_NAME, ADMIN_USER_PASSWORD)
+            .when()
+            .post(SECURE_PATH + "/kubernetes/namespace/provision");
+    // then
+
+    assertEquals(response.getStatusCode(), 200);
+    KubernetesNamespaceMetaDto actual = unwrapDto(response, KubernetesNamespaceMetaDto.class);
+    assertEquals(actual.getName(), namespaceMeta.getName());
+    assertEquals(actual.getAttributes(), namespaceMeta.getAttributes());
+    verify(namespaceFactory).provision(any(NamespaceResolutionContext.class));
+  }
+
+  @Test
+  public void shouldProvisionNamespaceWithCorrectContext() throws Exception {
+    // given
+    KubernetesNamespaceMetaImpl namespaceMeta =
+        new KubernetesNamespaceMetaImpl(
+            "ws-namespace", ImmutableMap.of("phase", "active", "default", "true"));
+    when(namespaceFactory.provision(any(NamespaceResolutionContext.class)))
+        .thenReturn(namespaceMeta);
+    // when
+    final Response response =
+        given()
+            .auth()
+            .basic(ADMIN_USER_NAME, ADMIN_USER_PASSWORD)
+            .when()
+            .post(SECURE_PATH + "/kubernetes/namespace/provision");
+    // then
+
+    assertEquals(response.getStatusCode(), 200);
+    ArgumentCaptor<NamespaceResolutionContext> captor =
+        ArgumentCaptor.forClass(NamespaceResolutionContext.class);
+    verify(namespaceFactory).provision(captor.capture());
+    NamespaceResolutionContext actualContext = captor.getValue();
+    assertEquals(actualContext.getUserId(), SUBJECT.getUserId());
+    assertEquals(actualContext.getUserName(), SUBJECT.getUserName());
+    Assert.assertNull(actualContext.getWorkspaceId());
+  }
+
   private static <T> List<T> unwrapDtoList(Response response, Class<T> dtoClass) {
     return DtoFactory.getInstance().createListDtoFromJson(response.body().print(), dtoClass);
+  }
+
+  private static <T> T unwrapDto(Response response, Class<T> dtoClass) {
+    return DtoFactory.getInstance().createDtoFromJson(response.body().print(), dtoClass);
+  }
+
+  @Filter
+  public static class EnvironmentFilter implements RequestFilter {
+    public void doFilter(GenericContainerRequest request) {
+      EnvironmentContext.getCurrent().setSubject(SUBJECT);
+    }
   }
 }

--- a/infrastructures/kubernetes/src/test/java/org/eclipse/che/workspace/infrastructure/kubernetes/namespace/KubernetesNamespaceFactoryTest.java
+++ b/infrastructures/kubernetes/src/test/java/org/eclipse/che/workspace/infrastructure/kubernetes/namespace/KubernetesNamespaceFactoryTest.java
@@ -57,6 +57,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -76,6 +77,7 @@ import org.eclipse.che.commons.subject.SubjectImpl;
 import org.eclipse.che.inject.ConfigurationException;
 import org.eclipse.che.workspace.infrastructure.kubernetes.CheServerKubernetesClientFactory;
 import org.eclipse.che.workspace.infrastructure.kubernetes.KubernetesClientFactory;
+import org.eclipse.che.workspace.infrastructure.kubernetes.api.server.impls.KubernetesNamespaceMetaImpl;
 import org.eclipse.che.workspace.infrastructure.kubernetes.api.shared.KubernetesNamespaceMeta;
 import org.eclipse.che.workspace.infrastructure.kubernetes.util.KubernetesSharedPool;
 import org.mockito.ArgumentCaptor;
@@ -986,6 +988,117 @@ public class KubernetesNamespaceFactoryTest {
             new NamespaceResolutionContext("workspace123", "user123", "jondoe"));
 
     assertEquals(namespace, "ns1");
+  }
+
+  @Test
+  public void shouldHandleProvision() throws InfrastructureException {
+    // given
+    namespaceFactory =
+        spy(
+            new KubernetesNamespaceFactory(
+                "",
+                "",
+                "<username>-che",
+                false,
+                true,
+                NAMESPACE_LABELS,
+                NAMESPACE_ANNOTATIONS,
+                clientFactory,
+                cheClientFactory,
+                userManager,
+                preferenceManager,
+                pool));
+    KubernetesNamespace toReturnNamespace = mock(KubernetesNamespace.class);
+    when(toReturnNamespace.getName()).thenReturn("jondoe-che");
+    doReturn(toReturnNamespace).when(namespaceFactory).doCreateNamespaceAccess(any(), any());
+    KubernetesNamespaceMetaImpl namespaceMeta =
+        new KubernetesNamespaceMetaImpl(
+            "jondoe-che", ImmutableMap.of("phase", "active", "default", "true"));
+    doReturn(Optional.of(namespaceMeta)).when(namespaceFactory).fetchNamespace(eq("jondoe-che"));
+
+    // when
+    NamespaceResolutionContext context =
+        new NamespaceResolutionContext("workspace123", "user123", "jondoe");
+    KubernetesNamespaceMeta actual = namespaceFactory.provision(context);
+
+    // then
+    assertEquals(actual, namespaceMeta);
+  }
+
+  @Test(
+      expectedExceptions = InfrastructureException.class,
+      expectedExceptionsMessageRegExp = "Not able to find namespace jondoe-cha-cha-cha")
+  public void shouldFailToProvisionIfNotAbleToFindNamespace() throws InfrastructureException {
+    // given
+    namespaceFactory =
+        spy(
+            new KubernetesNamespaceFactory(
+                "",
+                "",
+                "<username>-cha-cha-cha",
+                false,
+                true,
+                NAMESPACE_LABELS,
+                NAMESPACE_ANNOTATIONS,
+                clientFactory,
+                cheClientFactory,
+                userManager,
+                preferenceManager,
+                pool));
+    KubernetesNamespace toReturnNamespace = mock(KubernetesNamespace.class);
+    when(toReturnNamespace.getName()).thenReturn("jondoe-cha-cha-cha");
+    doReturn(toReturnNamespace).when(namespaceFactory).doCreateNamespaceAccess(any(), any());
+    KubernetesNamespaceMetaImpl namespaceMeta =
+        new KubernetesNamespaceMetaImpl(
+            "jondoe-cha-cha-cha", ImmutableMap.of("phase", "active", "default", "true"));
+    doReturn(Optional.empty()).when(namespaceFactory).fetchNamespace(eq("jondoe-cha-cha-cha"));
+
+    // when
+    NamespaceResolutionContext context =
+        new NamespaceResolutionContext("workspace123", "user123", "jondoe");
+    KubernetesNamespaceMeta actual = namespaceFactory.provision(context);
+
+    // then
+    assertEquals(actual, namespaceMeta);
+  }
+
+  @Test(
+      expectedExceptions = InfrastructureException.class,
+      expectedExceptionsMessageRegExp = "Error occurred when tried to fetch default namespace")
+  public void shouldFail2ProvisionIfNotAbleToFindNamespace() throws InfrastructureException {
+    // given
+    namespaceFactory =
+        spy(
+            new KubernetesNamespaceFactory(
+                "",
+                "",
+                "<username>-cha-cha-cha",
+                false,
+                true,
+                NAMESPACE_LABELS,
+                NAMESPACE_ANNOTATIONS,
+                clientFactory,
+                cheClientFactory,
+                userManager,
+                preferenceManager,
+                pool));
+    KubernetesNamespace toReturnNamespace = mock(KubernetesNamespace.class);
+    when(toReturnNamespace.getName()).thenReturn("jondoe-cha-cha-cha");
+    doReturn(toReturnNamespace).when(namespaceFactory).doCreateNamespaceAccess(any(), any());
+    KubernetesNamespaceMetaImpl namespaceMeta =
+        new KubernetesNamespaceMetaImpl(
+            "jondoe-cha-cha-cha", ImmutableMap.of("phase", "active", "default", "true"));
+    doThrow(new InfrastructureException("Error occurred when tried to fetch default namespace"))
+        .when(namespaceFactory)
+        .fetchNamespace(eq("jondoe-cha-cha-cha"));
+
+    // when
+    NamespaceResolutionContext context =
+        new NamespaceResolutionContext("workspace123", "user123", "jondoe");
+    KubernetesNamespaceMeta actual = namespaceFactory.provision(context);
+
+    // then
+    assertEquals(actual, namespaceMeta);
   }
 
   @Test

--- a/infrastructures/kubernetes/src/test/java/org/eclipse/che/workspace/infrastructure/kubernetes/namespace/KubernetesNamespaceFactoryTest.java
+++ b/infrastructures/kubernetes/src/test/java/org/eclipse/che/workspace/infrastructure/kubernetes/namespace/KubernetesNamespaceFactoryTest.java
@@ -1022,7 +1022,8 @@ public class KubernetesNamespaceFactoryTest {
     KubernetesNamespaceMeta actual = namespaceFactory.provision(context);
 
     // then
-    assertEquals(actual, namespaceMeta);
+    assertEquals(actual.getName(), "jondoe-che");
+    assertEquals(actual.getAttributes(), ImmutableMap.of("phase", "active", "default", "true"));
   }
 
   @Test(
@@ -1059,7 +1060,8 @@ public class KubernetesNamespaceFactoryTest {
     KubernetesNamespaceMeta actual = namespaceFactory.provision(context);
 
     // then
-    assertEquals(actual, namespaceMeta);
+    assertEquals(actual.getName(), "jondoe-cha-cha-cha");
+    assertEquals(actual.getAttributes(), ImmutableMap.of("phase", "active", "default", "true"));
   }
 
   @Test(
@@ -1098,7 +1100,8 @@ public class KubernetesNamespaceFactoryTest {
     KubernetesNamespaceMeta actual = namespaceFactory.provision(context);
 
     // then
-    assertEquals(actual, namespaceMeta);
+    assertEquals(actual.getName(), "jondoe-cha-cha-cha");
+    assertEquals(actual.getAttributes(), ImmutableMap.of("phase", "active", "default", "true"));
   }
 
   @Test

--- a/infrastructures/kubernetes/src/test/java/org/eclipse/che/workspace/infrastructure/kubernetes/namespace/KubernetesNamespaceFactoryTest.java
+++ b/infrastructures/kubernetes/src/test/java/org/eclipse/che/workspace/infrastructure/kubernetes/namespace/KubernetesNamespaceFactoryTest.java
@@ -33,6 +33,7 @@ import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertFalse;
 import static org.testng.Assert.assertNull;
 import static org.testng.Assert.assertTrue;
+import static org.testng.Assert.fail;
 
 import ch.qos.logback.classic.spi.LoggingEvent;
 import ch.qos.logback.core.Appender;
@@ -1057,11 +1058,10 @@ public class KubernetesNamespaceFactoryTest {
     // when
     NamespaceResolutionContext context =
         new NamespaceResolutionContext("workspace123", "user123", "jondoe");
-    KubernetesNamespaceMeta actual = namespaceFactory.provision(context);
+    namespaceFactory.provision(context);
 
     // then
-    assertEquals(actual.getName(), "jondoe-cha-cha-cha");
-    assertEquals(actual.getAttributes(), ImmutableMap.of("phase", "active", "default", "true"));
+    fail("should not reach this point since exception has to be thrown");
   }
 
   @Test(
@@ -1097,11 +1097,10 @@ public class KubernetesNamespaceFactoryTest {
     // when
     NamespaceResolutionContext context =
         new NamespaceResolutionContext("workspace123", "user123", "jondoe");
-    KubernetesNamespaceMeta actual = namespaceFactory.provision(context);
+    namespaceFactory.provision(context);
 
     // then
-    assertEquals(actual.getName(), "jondoe-cha-cha-cha");
-    assertEquals(actual.getAttributes(), ImmutableMap.of("phase", "active", "default", "true"));
+    fail("should not reach this point since exception has to be thrown");
   }
 
   @Test


### PR DESCRIPTION
### What does this PR do?
REST Service on the Che server-side that will initiate k8s namespace provisioning

### Screenshot/screencast of this PR
<!-- Please include a screenshot or a screencast explaining what is doing this PR -->


### What issues does this PR fix or reference?
Fixes https://github.com/eclipse/che/issues/20165


### How to test this PR?
1.  Build che-server image or deploy `quay.io/skabashn/che-server:che20165`
2. Run 

```
 curl -X POST 'https://che-eclipse-che.appsXXXXXX.opentlc.com/api/kubernetes/namespace/provision' \
  -H 'Connection: keep-alive' \
  -H 'Pragma: no-cache' \
  -H 'Cache-Control: no-cache' \
  -H 'sec-ch-ua: "Chromium";v="92", " Not A;Brand";v="99", "Google Chrome";v="92"' \
  -H 'Accept: application/json, text/plain, */*' \
  -H 'Authorization: Bearer eyJhbGcXXXXXX' \
  -H 'sec-ch-ua-mobile: ?0' \
  -H 'User-Agent: Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/92.0.4515.107 Safari/537.36' \
  -H 'Sec-Fetch-Site: same-origin' \
  -H 'Sec-Fetch-Mode: cors' \
  -H 'Sec-Fetch-Dest: empty' \
  -H 'Referer: https://che-eclipse-che.apps.cluster-2d72.2d72.sandbox321.opentlc.com/dashboard/' \
  -H 'Accept-Language: uk-UA,uk;q=0.9,ru-UA;q=0.8,ru;q=0.7,en-US;q=0.6,en;q=0.5' \
  -H 'Cookie: JSESSIONID=X; X=X; X=X' \
  --compressed
{"name":"user2-che","attributes":{"phase":"Active","description":"","displayName":""}}%

```
3. New k8s namespace has to be provisioned.



### PR Checklist

[As the author of this Pull Request I made sure that:](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#pull-request-template-and-its-checklist)

- [ ] [The Eclipse Contributor Agreement is valid](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-eclipse-contributor-agreement-is-valid)
- [ ] [Code produced is complete](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-produced-is-complete)
- [ ] [Code builds without errors](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-builds-without-errors)
- [ ] [Tests are covering the bugfix](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#tests-are-covering-the-bugfix)
- [ ] [The repository devfile is up to date and works](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-repository-devfile-is-up-to-date-and-works)
- [ ] [Sections `What issues does this PR fix or reference` and `How to test this PR` completed](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#sections-what-issues-does-this-pr-fix-or-reference-and-how-to-test-this-pr-completed)
- [ ] [Relevant user documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [Relevant contributing documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [CI/CD changes implemented, documented and communicated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#cicd-changes-implemented-documented-and-communicated)

### Reviewers

Reviewers, please comment how you tested the PR when approving it.
