### PR TITLE
chore: use rbac.authorization.k8s.io/v1 and networking.k8s.io/v1 API

### DIFF
--- a/deploy/kubernetes/helm/che/custom-charts/che-devfile-registry/templates/ingress.yaml
+++ b/deploy/kubernetes/helm/che/custom-charts/che-devfile-registry/templates/ingress.yaml
@@ -9,7 +9,7 @@
 
 {{- if not (and (eq .Values.global.serverStrategy "single-host") (eq .Values.global.singleHostExposure "gateway")) }}
 
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: devfile-registry
@@ -45,9 +45,12 @@ spec:
       paths:
       - path: /
 {{- end }}
+        pathType: ImplementationSpecific
         backend:
-          serviceName: devfile-registry
-          servicePort: 8080
+          service:
+            name: devfile-registry
+            port:
+              number: 8080
 {{- if .Values.global.tls.enabled }}
   tls:
   - hosts:

--- a/deploy/kubernetes/helm/che/custom-charts/che-jaeger/templates/ingress.yaml
+++ b/deploy/kubernetes/helm/che/custom-charts/che-jaeger/templates/ingress.yaml
@@ -10,7 +10,7 @@
 {{- printf "jaeger-%s.%s" .Release.Namespace .Values.global.ingressDomain }}
 {{- end }}
 
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: jaeger-query
@@ -40,6 +40,9 @@ spec:
     http:
       paths:
         - path: /
+          pathType: ImplementationSpecific
           backend:
-              serviceName: jaeger-query
-              servicePort: 16686
+              service:
+                name: jaeger-query
+                port:
+                  number: 16686

--- a/deploy/kubernetes/helm/che/custom-charts/che-keycloak/templates/endpoints-monitor-rolebinding.yaml
+++ b/deploy/kubernetes/helm/che/custom-charts/che-keycloak/templates/endpoints-monitor-rolebinding.yaml
@@ -8,7 +8,7 @@
 #
 
 kind: RoleBinding
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: {{ .Release.Namespace -}} -keycloak-role-binding
   labels:

--- a/deploy/kubernetes/helm/che/custom-charts/che-keycloak/templates/ingress.yaml
+++ b/deploy/kubernetes/helm/che/custom-charts/che-keycloak/templates/ingress.yaml
@@ -9,7 +9,7 @@
 
 {{- if not (and (eq .Values.global.serverStrategy "single-host") (eq .Values.global.singleHostExposure "gateway")) }}
 
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: keycloak-ingress
@@ -50,8 +50,11 @@ spec:
       paths:
       - path: /
 {{- end }}
+        pathType: ImplementationSpecific
         backend:
-          serviceName: keycloak
-          servicePort: 5050
+          service:
+            name: keycloak
+            port:
+              number: 5050
 
 {{- end }}

--- a/deploy/kubernetes/helm/che/custom-charts/che-plugin-registry/templates/ingress.yaml
+++ b/deploy/kubernetes/helm/che/custom-charts/che-plugin-registry/templates/ingress.yaml
@@ -9,7 +9,7 @@
 
 {{- if not (and (eq .Values.global.serverStrategy "single-host") (eq .Values.global.singleHostExposure "gateway")) }}
 
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: plugin-registry
@@ -45,9 +45,12 @@ spec:
       paths:
       - path: /
 {{- end }}
+        pathType: ImplementationSpecific
         backend:
-          serviceName: plugin-registry
-          servicePort: 8080
+          service:
+            name: plugin-registry
+            port:
+              number: 8080
 {{- if .Values.global.tls.enabled }}
   tls:
   - hosts:

--- a/deploy/kubernetes/helm/che/templates/cluster-role-binding.yaml
+++ b/deploy/kubernetes/helm/che/templates/cluster-role-binding.yaml
@@ -8,7 +8,7 @@
 #
 
 kind: ClusterRoleBinding
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: {{ .Release.Namespace -}} -che-clusterrole-binding
   labels:

--- a/deploy/kubernetes/helm/che/templates/dashboard-ingress.yaml
+++ b/deploy/kubernetes/helm/che/templates/dashboard-ingress.yaml
@@ -11,7 +11,7 @@
 # but not this ingress
 {{- if not (and (eq .Values.global.serverStrategy "single-host") (eq .Values.global.singleHostExposure "gateway")) }}
 
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: che-dashboard-ingress
@@ -46,7 +46,10 @@ spec:
       paths:
         # The path rule for Che Dashboard
       - path: {{ .Values.dashboard.ingressPath }}
+        pathType: ImplementationSpecific
         backend:
-          serviceName: che-dashboard
-          servicePort: 8080
+          service:
+            name: che-dashboard
+            port:
+              number: 8080
 {{- end }}

--- a/deploy/kubernetes/helm/che/templates/exec-role.yaml
+++ b/deploy/kubernetes/helm/che/templates/exec-role.yaml
@@ -9,7 +9,7 @@
 
 {{- if not (contains "<" .Values.global.cheWorkspacesNamespace) }}
 kind: Role
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: exec
   namespace: {{ .Values.global.cheWorkspacesNamespace }}

--- a/deploy/kubernetes/helm/che/templates/ingress.yaml
+++ b/deploy/kubernetes/helm/che/templates/ingress.yaml
@@ -7,7 +7,7 @@
 # SPDX-License-Identifier: EPL-2.0
 #
 
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: che-ingress
@@ -42,10 +42,13 @@ spec:
 {{- end }}
       paths:
       - path: /
+        pathType: ImplementationSpecific
         backend:
-          servicePort: 8080
+          service:
+            port:
+              number: 8080
 {{- if and (eq .Values.global.serverStrategy "single-host") (eq .Values.global.singleHostExposure "gateway") }}
-          serviceName: che-gateway
+            name: che-gateway
 {{- else }}
-          serviceName: che-host
+            name: che-host
 {{- end }}

--- a/deploy/kubernetes/helm/che/templates/metrics-ingress.yaml
+++ b/deploy/kubernetes/helm/che/templates/metrics-ingress.yaml
@@ -17,7 +17,7 @@
 
 {{- if .Values.global.metricsEnabled }}
 
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: che-metrics-ingress
@@ -45,15 +45,21 @@ spec:
     http:
       paths:
       - path: /
+        pathType: ImplementationSpecific
         backend:
-          serviceName: che-prometheus-server
-          servicePort: 80
+          service:
+            name: che-prometheus-server
+            port:
+              number: 80
   - host: {{ template "grafanaHost" . }}
     http:
       paths:
       - path: /
+        pathType: ImplementationSpecific
         backend:
-          serviceName: che-grafana
-          servicePort: 80
+          service:
+            name: che-grafana
+            port:
+              number: 80
 
 {{- end }}

--- a/deploy/kubernetes/helm/che/templates/resource-monitor-role-binding.yaml
+++ b/deploy/kubernetes/helm/che/templates/resource-monitor-role-binding.yaml
@@ -9,7 +9,7 @@
 
 {{- if not (contains "<" .Values.global.cheWorkspacesNamespace) }}
 kind: RoleBinding
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: che-resource-monitor
   namespace: {{ .Values.global.cheWorkspacesNamespace }}

--- a/deploy/kubernetes/helm/che/templates/resource-monitor-role.yaml
+++ b/deploy/kubernetes/helm/che/templates/resource-monitor-role.yaml
@@ -9,7 +9,7 @@
 
 {{- if not (contains "<" .Values.global.cheWorkspacesNamespace) }}
 kind: Role
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: resource-monitor
   namespace: {{ .Values.global.cheWorkspacesNamespace }}

--- a/deploy/kubernetes/helm/che/templates/workspace-exec-role-binding.yaml
+++ b/deploy/kubernetes/helm/che/templates/workspace-exec-role-binding.yaml
@@ -9,7 +9,7 @@
 
 {{- if not (contains "<" .Values.global.cheWorkspacesNamespace) }}
 kind: RoleBinding
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: che-workspace-exec
   namespace: {{ .Values.global.cheWorkspacesNamespace }}

--- a/deploy/kubernetes/helm/che/templates/workspace-view-role-binding.yaml
+++ b/deploy/kubernetes/helm/che/templates/workspace-view-role-binding.yaml
@@ -9,7 +9,7 @@
 
 {{- if not (contains "<" .Values.global.cheWorkspacesNamespace) }}
 kind: RoleBinding
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: che-workspace-view
   namespace: {{ .Values.global.cheWorkspacesNamespace }}

--- a/deploy/kubernetes/helm/che/templates/workspace-view-role.yaml
+++ b/deploy/kubernetes/helm/che/templates/workspace-view-role.yaml
@@ -9,7 +9,7 @@
 
 {{- if not (contains "<" .Values.global.cheWorkspacesNamespace) }}
 kind: Role
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: workspace-view
   namespace: {{ .Values.global.cheWorkspacesNamespace }}

--- a/deploy/kubernetes/helm/che/tiller-rbac.yaml
+++ b/deploy/kubernetes/helm/che/tiller-rbac.yaml
@@ -8,7 +8,7 @@
 #
 
 kind: ClusterRoleBinding
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: tiller-role-binding
 roleRef:


### PR DESCRIPTION
Signed-off-by: Anatolii Bazko <abazko@redhat.com>

<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests
-->

### What does this PR do?
Use `rbac.authorization.k8s.io/v1` and `networking.k8s.io/v1` API since  `rbac.authorization.k8s.io/v1beta` and `extensions/v1beta1` won't be available in kubernetes v1.22
See deprecation guide https://kubernetes.io/docs/reference/using-api/deprecation-guide/

### Screenshot/screencast of this PR
<!-- Please include a screenshot or a screencast explaining what is doing this PR -->
N/A

### What issues does this PR fix or reference?
<!-- Please include any related issue from eclipse che repository (or from another issue tracker).
     Include link to other pull requests like documentation PR from [the docs repo](https://github.com/eclipse/che-docs)
-->
https://github.com/eclipse/che/issues/20182

### How to test this PR?
<!-- Please explain for example :
  - The test platform (openshift, kubernetes, minikube, CodeReady Container, docker-desktop, etc)
  - Installation method: chectl / che-operator
  - steps to reproduce
 -->
1. start minikube
2. `cd <PATH_TO_PROJECT>deploy/kubernetes/helm/che && helm dependency update`
2. `chectl server:deploy --installer=helm --platform=minikube   --multiuser --domain=$(minikube ip).nip.io   --templates <PATH_TO_PROJECT>/deploy`

### PR Checklist

[As the author of this Pull Request I made sure that:](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#pull-request-template-and-its-checklist)

- [x] [The Eclipse Contributor Agreement is valid](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-eclipse-contributor-agreement-is-valid)
- [x] [Code produced is complete](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-produced-is-complete)
- [x] [Code builds without errors](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-builds-without-errors)
- [ ] [Tests are covering the bugfix](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#tests-are-covering-the-bugfix)
- [ ] [The repository devfile is up to date and works](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-repository-devfile-is-up-to-date-and-works)
- [ ] [Sections `What issues does this PR fix or reference` and `How to test this PR` completed](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#sections-what-issues-does-this-pr-fix-or-reference-and-how-to-test-this-pr-completed)
- [ ] [Relevant user documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [Relevant contributing documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [CI/CD changes implemented, documented and communicated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#cicd-changes-implemented-documented-and-communicated)

### Reviewers

Reviewers, please comment how you tested the PR when approving it.
