### PR TITLE
fix: workspaces must not fail on metrics roles creation when APi is disabled or unauthorized

### DIFF
--- a/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/namespace/AbstractWorkspaceServiceAccount.java
+++ b/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/namespace/AbstractWorkspaceServiceAccount.java
@@ -18,6 +18,7 @@ import io.fabric8.kubernetes.api.model.HasMetadata;
 import io.fabric8.kubernetes.api.model.KubernetesResourceList;
 import io.fabric8.kubernetes.api.model.ServiceAccountBuilder;
 import io.fabric8.kubernetes.client.KubernetesClient;
+import io.fabric8.kubernetes.client.KubernetesClientException;
 import io.fabric8.kubernetes.client.dsl.MixedOperation;
 import io.fabric8.kubernetes.client.dsl.Resource;
 import java.util.Arrays;
@@ -130,15 +131,27 @@ public abstract class AbstractWorkspaceServiceAccount<
         serviceAccountName + "-view");
 
     // metrics role
-    ensureRoleWithBinding(
-        k8sClient,
-        buildRole(
-            METRICS_ROLE_NAME,
-            Arrays.asList("pods", "nodes"),
-            emptyList(),
-            singletonList("metrics.k8s.io"),
-            Arrays.asList("list", "get", "watch")),
-        serviceAccountName + "-metrics");
+    if (k8sClient.supportsApiPath("/apis/metrics.k8s.io")) {
+      try {
+        ensureRoleWithBinding(
+            k8sClient,
+            buildRole(
+                METRICS_ROLE_NAME,
+                Arrays.asList("pods", "nodes"),
+                emptyList(),
+                singletonList("metrics.k8s.io"),
+                Arrays.asList("list", "get", "watch")),
+            serviceAccountName + "-metrics");
+      } catch (KubernetesClientException e) {
+        // workaround to unblock workspace start if no permissions for metrics
+        if (e.getCode() == 403) {
+          LOG.warn(
+              "Unable to add metrics roles due to insufficient permissions. Workspace metrics will be disabled.");
+        } else {
+          throw e;
+        }
+      }
+    }
 
     // credentials-secret role
     ensureRoleWithBinding(

--- a/infrastructures/kubernetes/src/test/java/org/eclipse/che/workspace/infrastructure/kubernetes/namespace/KubernetesNamespaceFactoryTest.java
+++ b/infrastructures/kubernetes/src/test/java/org/eclipse/che/workspace/infrastructure/kubernetes/namespace/KubernetesNamespaceFactoryTest.java
@@ -724,6 +724,7 @@ public class KubernetesNamespaceFactoryTest {
     when(toReturnNamespace.getWorkspaceId()).thenReturn("workspace123");
     when(toReturnNamespace.getName()).thenReturn("workspace123");
     doReturn(toReturnNamespace).when(namespaceFactory).doCreateNamespaceAccess(any(), any());
+    when(k8sClient.supportsApiPath(eq("/apis/metrics.k8s.io"))).thenReturn(true);
     when(clientFactory.create(any())).thenReturn(k8sClient);
 
     // pre-create the cluster roles
@@ -754,8 +755,8 @@ public class KubernetesNamespaceFactoryTest {
 
     RoleList roles = k8sClient.rbac().roles().inNamespace("workspace123").list();
     assertEquals(
-        Sets.newHashSet("workspace-view", "workspace-metrics", "workspace-secrets", "exec"),
-        roles.getItems().stream().map(r -> r.getMetadata().getName()).collect(Collectors.toSet()));
+        roles.getItems().stream().map(r -> r.getMetadata().getName()).collect(Collectors.toSet()),
+        Sets.newHashSet("workspace-view", "workspace-metrics", "workspace-secrets", "exec"));
     RoleBindingList bindings = k8sClient.rbac().roleBindings().inNamespace("workspace123").list();
     assertEquals(
         bindings
@@ -855,6 +856,7 @@ public class KubernetesNamespaceFactoryTest {
     when(toReturnNamespace.getWorkspaceId()).thenReturn("workspace123");
     when(toReturnNamespace.getName()).thenReturn("workspace123");
     doReturn(toReturnNamespace).when(namespaceFactory).doCreateNamespaceAccess(any(), any());
+    when(k8sClient.supportsApiPath(eq("/apis/metrics.k8s.io"))).thenReturn(true);
     when(clientFactory.create(any())).thenReturn(k8sClient);
 
     // when
@@ -871,8 +873,8 @@ public class KubernetesNamespaceFactoryTest {
 
     RoleList roles = k8sClient.rbac().roles().inNamespace("workspace123").list();
     assertEquals(
-        Sets.newHashSet("workspace-view", "workspace-metrics", "workspace-secrets", "exec"),
-        roles.getItems().stream().map(r -> r.getMetadata().getName()).collect(Collectors.toSet()));
+        roles.getItems().stream().map(r -> r.getMetadata().getName()).collect(Collectors.toSet()),
+        Sets.newHashSet("workspace-view", "workspace-metrics", "workspace-secrets", "exec"));
     Role role1 = roles.getItems().get(0);
     Role role2 = roles.getItems().get(1);
 

--- a/infrastructures/kubernetes/src/test/java/org/eclipse/che/workspace/infrastructure/kubernetes/namespace/KubernetesWorkspaceServiceAccountTest.java
+++ b/infrastructures/kubernetes/src/test/java/org/eclipse/che/workspace/infrastructure/kubernetes/namespace/KubernetesWorkspaceServiceAccountTest.java
@@ -120,7 +120,7 @@ public class KubernetesWorkspaceServiceAccountTest {
     serviceAccount.prepare();
 
     // then
-    // make sure metrics role & rb added
+    // make sure metrics role & rb not added
     RoleList rl = k8sClient.rbac().roles().inNamespace(NAMESPACE).list();
     assertTrue(
         rl.getItems().stream().noneMatch(r -> r.getMetadata().getName().equals(METRICS_ROLE_NAME)));

--- a/infrastructures/kubernetes/src/test/java/org/eclipse/che/workspace/infrastructure/kubernetes/namespace/KubernetesWorkspaceServiceAccountTest.java
+++ b/infrastructures/kubernetes/src/test/java/org/eclipse/che/workspace/infrastructure/kubernetes/namespace/KubernetesWorkspaceServiceAccountTest.java
@@ -11,8 +11,11 @@
  */
 package org.eclipse.che.workspace.infrastructure.kubernetes.namespace;
 
+import static org.eclipse.che.workspace.infrastructure.kubernetes.namespace.AbstractWorkspaceServiceAccount.METRICS_ROLE_NAME;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.when;
 
 import io.fabric8.kubernetes.api.model.ServiceAccountBuilder;
@@ -52,6 +55,7 @@ public class KubernetesWorkspaceServiceAccountTest {
 
     serverMock = new KubernetesServer(true, true);
     serverMock.before();
+
     k8sClient = serverMock.getClient();
     when(clientFactory.create(anyString())).thenReturn(k8sClient);
   }
@@ -82,5 +86,49 @@ public class KubernetesWorkspaceServiceAccountTest {
 
     RoleBindingList rbl = k8sClient.rbac().roleBindings().inNamespace(NAMESPACE).list();
     assertTrue(rbl.getItems().size() > 1);
+  }
+
+  @Test
+  public void shouldCreateMetricsRoleIfAPIEnabledOnServer() throws Exception {
+    KubernetesClient localK8sClient = spy(serverMock.getClient());
+    when(localK8sClient.supportsApiPath(eq("/apis/metrics.k8s.io"))).thenReturn(true);
+    when(clientFactory.create(anyString())).thenReturn(localK8sClient);
+
+    // when
+    serviceAccount.prepare();
+
+    // then
+    // make sure metrics role & rb added
+    RoleList rl = k8sClient.rbac().roles().inNamespace(NAMESPACE).list();
+    assertTrue(
+        rl.getItems().stream().anyMatch(r -> r.getMetadata().getName().equals(METRICS_ROLE_NAME)));
+
+    RoleBindingList rbl = k8sClient.rbac().roleBindings().inNamespace(NAMESPACE).list();
+    assertTrue(
+        rbl.getItems()
+            .stream()
+            .anyMatch(rb -> rb.getMetadata().getName().equals(SA_NAME + "-metrics")));
+  }
+
+  @Test
+  public void shouldNotCreateMetricsRoleIfAPIEnabledOnServer() throws Exception {
+    KubernetesClient localK8sClient = spy(serverMock.getClient());
+    when(localK8sClient.supportsApiPath(eq("/apis/metrics.k8s.io"))).thenReturn(false);
+    when(clientFactory.create(anyString())).thenReturn(localK8sClient);
+
+    // when
+    serviceAccount.prepare();
+
+    // then
+    // make sure metrics role & rb added
+    RoleList rl = k8sClient.rbac().roles().inNamespace(NAMESPACE).list();
+    assertTrue(
+        rl.getItems().stream().noneMatch(r -> r.getMetadata().getName().equals(METRICS_ROLE_NAME)));
+
+    RoleBindingList rbl = k8sClient.rbac().roleBindings().inNamespace(NAMESPACE).list();
+    assertTrue(
+        rbl.getItems()
+            .stream()
+            .noneMatch(rb -> rb.getMetadata().getName().equals(SA_NAME + "-metrics")));
   }
 }


### PR DESCRIPTION

### What does this PR do?
Workspace namespace is not prepared properly and startup is broken  if `metrics.k8s.io` API is not enabled on the cluster or Che SA cannot create appropriate roles due to lack of permissions.

### Screenshot/screencast of this PR
<!-- Please include a screenshot or a screencast explaining what is doing this PR -->


### What issues does this PR fix or reference?
https://issues.redhat.com/browse/CRW-2202

https://github.com/eclipse/che/issues/19869

### How to test this PR?
Run minishift 3.11 with metrica API disabled. User is unable to start any workspaces;
Chenge image to `mshaposh/che-server:nightly`. Workspaces run ok.


### PR Checklist

[As the author of this Pull Request I made sure that:](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#pull-request-template-and-its-checklist)

- [x] [The Eclipse Contributor Agreement is valid](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-eclipse-contributor-agreement-is-valid)
- [x] [Code produced is complete](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-produced-is-complete)
- [x] [Code builds without errors](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-builds-without-errors)
- [x] [Tests are covering the bugfix](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#tests-are-covering-the-bugfix)
- [ ] [The repository devfile is up to date and works](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-repository-devfile-is-up-to-date-and-works)
- [x] [Sections `What issues does this PR fix or reference` and `How to test this PR` completed](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#sections-what-issues-does-this-pr-fix-or-reference-and-how-to-test-this-pr-completed)
- [ ] [Relevant user documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [Relevant contributing documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [CI/CD changes implemented, documented and communicated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#cicd-changes-implemented-documented-and-communicated)

### Reviewers

Reviewers, please comment how you tested the PR when approving it.
