### PR TITLE
fix: devfile endpoint with single-host exposure

### DIFF
--- a/infrastructures/kubernetes/src/test/java/org/eclipse/che/workspace/infrastructure/kubernetes/devfile/DockerimageComponentToWorkspaceApplierTest.java
+++ b/infrastructures/kubernetes/src/test/java/org/eclipse/che/workspace/infrastructure/kubernetes/devfile/DockerimageComponentToWorkspaceApplierTest.java
@@ -18,6 +18,7 @@ import static org.eclipse.che.api.workspace.server.devfile.Constants.DOCKERIMAGE
 import static org.eclipse.che.api.workspace.server.devfile.Constants.PUBLIC_ENDPOINT_ATTRIBUTE;
 import static org.eclipse.che.api.workspace.shared.Constants.PROJECTS_VOLUME_NAME;
 import static org.eclipse.che.workspace.infrastructure.kubernetes.devfile.DockerimageComponentToWorkspaceApplier.CHE_COMPONENT_NAME_LABEL;
+import static org.eclipse.che.workspace.infrastructure.kubernetes.server.external.MultiHostExternalServiceExposureStrategy.MULTI_HOST_STRATEGY;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.verify;
@@ -80,7 +81,7 @@ public class DockerimageComponentToWorkspaceApplierTest {
   public void setUp() throws Exception {
     dockerimageComponentApplier =
         new DockerimageComponentToWorkspaceApplier(
-            PROJECTS_MOUNT_PATH, "Always", k8sEnvProvisioner);
+            PROJECTS_MOUNT_PATH, "Always", MULTI_HOST_STRATEGY, k8sEnvProvisioner);
     workspaceConfig = new WorkspaceConfigImpl();
   }
 
@@ -135,7 +136,8 @@ public class DockerimageComponentToWorkspaceApplierTest {
     dockerimageComponent.setImage("eclipse/ubuntu_jdk8:latest");
     dockerimageComponent.setMemoryLimit("1G");
     dockerimageComponentApplier =
-        new DockerimageComponentToWorkspaceApplier(PROJECTS_MOUNT_PATH, "Never", k8sEnvProvisioner);
+        new DockerimageComponentToWorkspaceApplier(
+            PROJECTS_MOUNT_PATH, "Never", MULTI_HOST_STRATEGY, k8sEnvProvisioner);
 
     // when
     dockerimageComponentApplier.apply(workspaceConfig, dockerimageComponent, null);

--- a/infrastructures/kubernetes/src/test/java/org/eclipse/che/workspace/infrastructure/kubernetes/devfile/KubernetesComponentToWorkspaceApplierTest.java
+++ b/infrastructures/kubernetes/src/test/java/org/eclipse/che/workspace/infrastructure/kubernetes/devfile/KubernetesComponentToWorkspaceApplierTest.java
@@ -23,6 +23,7 @@ import static org.eclipse.che.api.workspace.server.devfile.Constants.COMPONENT_A
 import static org.eclipse.che.api.workspace.server.devfile.Constants.KUBERNETES_COMPONENT_TYPE;
 import static org.eclipse.che.api.workspace.server.devfile.Constants.OPENSHIFT_COMPONENT_TYPE;
 import static org.eclipse.che.api.workspace.shared.Constants.PROJECTS_VOLUME_NAME;
+import static org.eclipse.che.workspace.infrastructure.kubernetes.server.external.MultiHostExternalServiceExposureStrategy.MULTI_HOST_STRATEGY;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyMap;
 import static org.mockito.ArgumentMatchers.anyString;
@@ -110,6 +111,7 @@ public class KubernetesComponentToWorkspaceApplierTest {
             "ReadWriteOnce",
             "",
             "Always",
+            MULTI_HOST_STRATEGY,
             k8sBasedComponents);
 
     workspaceConfig = new WorkspaceConfigImpl();
@@ -560,6 +562,7 @@ public class KubernetesComponentToWorkspaceApplierTest {
             "ReadWriteOnce",
             "",
             "Never",
+            MULTI_HOST_STRATEGY,
             k8sBasedComponents);
     String yamlRecipeContent = getResource("devfile/petclinic.yaml");
     doReturn(toK8SList(yamlRecipeContent).getItems()).when(k8sRecipeParser).parse(anyString());

--- a/infrastructures/kubernetes/src/test/java/org/eclipse/che/workspace/infrastructure/kubernetes/devfile/KubernetesComponentToWorkspaceApplierTest.java
+++ b/infrastructures/kubernetes/src/test/java/org/eclipse/che/workspace/infrastructure/kubernetes/devfile/KubernetesComponentToWorkspaceApplierTest.java
@@ -24,6 +24,7 @@ import static org.eclipse.che.api.workspace.server.devfile.Constants.KUBERNETES_
 import static org.eclipse.che.api.workspace.server.devfile.Constants.OPENSHIFT_COMPONENT_TYPE;
 import static org.eclipse.che.api.workspace.shared.Constants.PROJECTS_VOLUME_NAME;
 import static org.eclipse.che.workspace.infrastructure.kubernetes.server.external.MultiHostExternalServiceExposureStrategy.MULTI_HOST_STRATEGY;
+import static org.eclipse.che.workspace.infrastructure.kubernetes.server.external.SingleHostExternalServiceExposureStrategy.SINGLE_HOST_STRATEGY;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyMap;
 import static org.mockito.ArgumentMatchers.anyString;
@@ -32,6 +33,7 @@ import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.verify;
 import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
 import static org.testng.Assert.assertNull;
 import static org.testng.Assert.assertTrue;
 
@@ -44,6 +46,7 @@ import io.fabric8.kubernetes.api.model.Pod;
 import io.fabric8.kubernetes.api.model.PodBuilder;
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
@@ -52,6 +55,7 @@ import java.util.Set;
 import java.util.stream.Stream;
 import org.eclipse.che.api.core.ValidationException;
 import org.eclipse.che.api.core.model.workspace.config.MachineConfig;
+import org.eclipse.che.api.core.model.workspace.config.ServerConfig;
 import org.eclipse.che.api.workspace.server.devfile.URLFileContentProvider;
 import org.eclipse.che.api.workspace.server.devfile.exception.DevfileException;
 import org.eclipse.che.api.workspace.server.model.impl.CommandImpl;
@@ -693,6 +697,110 @@ public class KubernetesComponentToWorkspaceApplierTest {
               assertEquals(
                   serverConfigs.get(endpointName).isInternal(),
                   !Boolean.parseBoolean(endpointPublic));
+            });
+  }
+
+  @Test
+  public void serverCantHaveRequireSubdomainWhenSinglehostDevfileExpose()
+      throws DevfileException, IOException, ValidationException, InfrastructureException {
+    applier =
+        new KubernetesComponentToWorkspaceApplier(
+            k8sRecipeParser,
+            k8sEnvProvisioner,
+            envVars,
+            PROJECT_MOUNT_PATH,
+            "1Gi",
+            "ReadWriteOnce",
+            "",
+            "Always",
+            SINGLE_HOST_STRATEGY,
+            k8sBasedComponents);
+
+    String yamlRecipeContent = getResource("devfile/petclinic.yaml");
+    doReturn(toK8SList(yamlRecipeContent).getItems()).when(k8sRecipeParser).parse(anyString());
+
+    // given
+    ComponentImpl component = new ComponentImpl();
+    component.setType(KUBERNETES_COMPONENT_TYPE);
+    component.setReference(REFERENCE_FILENAME);
+    component.setAlias(COMPONENT_NAME);
+    component.setEndpoints(
+        Arrays.asList(
+            new EndpointImpl("e1", 1111, emptyMap()), new EndpointImpl("e2", 2222, emptyMap())));
+
+    // when
+    applier.apply(workspaceConfig, component, s -> yamlRecipeContent);
+
+    // then
+    @SuppressWarnings("unchecked")
+    ArgumentCaptor<Map<String, MachineConfigImpl>> objectsCaptor =
+        ArgumentCaptor.forClass(Map.class);
+    verify(k8sEnvProvisioner).provision(any(), any(), any(), objectsCaptor.capture());
+    Map<String, MachineConfigImpl> machineConfigs = objectsCaptor.getValue();
+    assertEquals(machineConfigs.size(), 4);
+    machineConfigs
+        .values()
+        .forEach(
+            machineConfig -> {
+              assertEquals(machineConfig.getServers().size(), 2);
+              assertFalse(
+                  ServerConfig.isRequireSubdomain(
+                      machineConfig.getServers().get("e1").getAttributes()));
+              assertFalse(
+                  ServerConfig.isRequireSubdomain(
+                      machineConfig.getServers().get("e2").getAttributes()));
+            });
+  }
+
+  @Test
+  public void serverMustHaveRequireSubdomainWhenNonSinglehostDevfileExpose()
+      throws DevfileException, IOException, ValidationException, InfrastructureException {
+    applier =
+        new KubernetesComponentToWorkspaceApplier(
+            k8sRecipeParser,
+            k8sEnvProvisioner,
+            envVars,
+            PROJECT_MOUNT_PATH,
+            "1Gi",
+            "ReadWriteOnce",
+            "",
+            "Always",
+            MULTI_HOST_STRATEGY,
+            k8sBasedComponents);
+
+    String yamlRecipeContent = getResource("devfile/petclinic.yaml");
+    doReturn(toK8SList(yamlRecipeContent).getItems()).when(k8sRecipeParser).parse(anyString());
+
+    // given
+    ComponentImpl component = new ComponentImpl();
+    component.setType(KUBERNETES_COMPONENT_TYPE);
+    component.setReference(REFERENCE_FILENAME);
+    component.setAlias(COMPONENT_NAME);
+    component.setEndpoints(
+        Arrays.asList(
+            new EndpointImpl("e1", 1111, emptyMap()), new EndpointImpl("e2", 2222, emptyMap())));
+
+    // when
+    applier.apply(workspaceConfig, component, s -> yamlRecipeContent);
+
+    // then
+    @SuppressWarnings("unchecked")
+    ArgumentCaptor<Map<String, MachineConfigImpl>> objectsCaptor =
+        ArgumentCaptor.forClass(Map.class);
+    verify(k8sEnvProvisioner).provision(any(), any(), any(), objectsCaptor.capture());
+    Map<String, MachineConfigImpl> machineConfigs = objectsCaptor.getValue();
+    assertEquals(machineConfigs.size(), 4);
+    machineConfigs
+        .values()
+        .forEach(
+            machineConfig -> {
+              assertEquals(machineConfig.getServers().size(), 2);
+              assertTrue(
+                  ServerConfig.isRequireSubdomain(
+                      machineConfig.getServers().get("e1").getAttributes()));
+              assertTrue(
+                  ServerConfig.isRequireSubdomain(
+                      machineConfig.getServers().get("e2").getAttributes()));
             });
   }
 

--- a/infrastructures/openshift/src/main/java/org/eclipse/che/workspace/infrastructure/openshift/devfile/OpenshiftComponentToWorkspaceApplier.java
+++ b/infrastructures/openshift/src/main/java/org/eclipse/che/workspace/infrastructure/openshift/devfile/OpenshiftComponentToWorkspaceApplier.java
@@ -33,6 +33,8 @@ public class OpenshiftComponentToWorkspaceApplier extends KubernetesComponentToW
       @Named("che.infra.kubernetes.pvc.access_mode") String defaultPVCAccessMode,
       @Named("che.infra.kubernetes.pvc.storage_class_name") String pvcStorageClassName,
       @Named("che.workspace.sidecar.image_pull_policy") String imagePullPolicy,
+      @Named("che.infra.kubernetes.singlehost.workspace.devfile_endpoint_exposure")
+          String devfileEndpointsExposure,
       @Named(KUBERNETES_BASED_COMPONENTS_KEY_NAME) Set<String> kubernetesBasedComponentTypes) {
     super(
         objectsParser,
@@ -44,6 +46,7 @@ public class OpenshiftComponentToWorkspaceApplier extends KubernetesComponentToW
         defaultPVCAccessMode,
         pvcStorageClassName,
         imagePullPolicy,
+        devfileEndpointsExposure,
         kubernetesBasedComponentTypes);
   }
 }

--- a/infrastructures/openshift/src/test/java/org/eclipse/che/workspace/infrastructure/openshift/devfile/OpenshiftComponentToWorkspaceApplierTest.java
+++ b/infrastructures/openshift/src/test/java/org/eclipse/che/workspace/infrastructure/openshift/devfile/OpenshiftComponentToWorkspaceApplierTest.java
@@ -14,6 +14,7 @@ package org.eclipse.che.workspace.infrastructure.openshift.devfile;
 import static java.util.Collections.emptyList;
 import static java.util.Collections.emptyMap;
 import static org.eclipse.che.api.workspace.server.devfile.Constants.KUBERNETES_COMPONENT_TYPE;
+import static org.eclipse.che.workspace.infrastructure.kubernetes.server.external.MultiHostExternalServiceExposureStrategy.MULTI_HOST_STRATEGY;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.verify;
@@ -59,6 +60,7 @@ public class OpenshiftComponentToWorkspaceApplierTest {
             "ReadWriteOnce",
             "",
             "Always",
+            MULTI_HOST_STRATEGY,
             k8sBasedComponents);
 
     workspaceConfig = new WorkspaceConfigImpl();

--- a/infrastructures/openshift/src/test/java/org/eclipse/che/workspace/infrastructure/openshift/devfile/OpenshiftComponentToWorkspaceApplierTest.java
+++ b/infrastructures/openshift/src/test/java/org/eclipse/che/workspace/infrastructure/openshift/devfile/OpenshiftComponentToWorkspaceApplierTest.java
@@ -11,28 +11,47 @@
  */
 package org.eclipse.che.workspace.infrastructure.openshift.devfile;
 
+import static io.fabric8.kubernetes.client.utils.Serialization.unmarshal;
 import static java.util.Collections.emptyList;
 import static java.util.Collections.emptyMap;
 import static org.eclipse.che.api.workspace.server.devfile.Constants.KUBERNETES_COMPONENT_TYPE;
+import static org.eclipse.che.api.workspace.server.devfile.Constants.OPENSHIFT_COMPONENT_TYPE;
 import static org.eclipse.che.workspace.infrastructure.kubernetes.server.external.MultiHostExternalServiceExposureStrategy.MULTI_HOST_STRATEGY;
+import static org.eclipse.che.workspace.infrastructure.kubernetes.server.external.SingleHostExternalServiceExposureStrategy.SINGLE_HOST_STRATEGY;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.verify;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertTrue;
 
+import io.fabric8.kubernetes.api.model.KubernetesList;
+import java.io.IOException;
+import java.util.Arrays;
 import java.util.HashSet;
+import java.util.Map;
 import java.util.Set;
+import org.eclipse.che.api.core.ValidationException;
+import org.eclipse.che.api.core.model.workspace.config.ServerConfig;
+import org.eclipse.che.api.workspace.server.devfile.exception.DevfileException;
+import org.eclipse.che.api.workspace.server.model.impl.MachineConfigImpl;
 import org.eclipse.che.api.workspace.server.model.impl.WorkspaceConfigImpl;
 import org.eclipse.che.api.workspace.server.model.impl.devfile.ComponentImpl;
+import org.eclipse.che.api.workspace.server.model.impl.devfile.EndpointImpl;
+import org.eclipse.che.api.workspace.server.spi.InfrastructureException;
 import org.eclipse.che.workspace.infrastructure.kubernetes.devfile.KubernetesComponentToWorkspaceApplier;
 import org.eclipse.che.workspace.infrastructure.kubernetes.devfile.KubernetesEnvironmentProvisioner;
 import org.eclipse.che.workspace.infrastructure.kubernetes.environment.KubernetesRecipeParser;
 import org.eclipse.che.workspace.infrastructure.kubernetes.util.EnvVars;
 import org.eclipse.che.workspace.infrastructure.openshift.environment.OpenShiftEnvironment;
+import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.testng.MockitoTestNGListener;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Listeners;
 import org.testng.annotations.Test;
+import org.testng.reporters.Files;
 
 @Listeners(MockitoTestNGListener.class)
 public class OpenshiftComponentToWorkspaceApplierTest {
@@ -82,5 +101,121 @@ public class OpenshiftComponentToWorkspaceApplierTest {
     // then
     verify(k8sEnvProvisioner)
         .provision(workspaceConfig, OpenShiftEnvironment.TYPE, emptyList(), emptyMap());
+  }
+
+  @Test
+  public void serverCantHaveRequireSubdomainWhenSinglehostDevfileExpose()
+      throws DevfileException, IOException, ValidationException, InfrastructureException {
+    Set<String> openshiftBasedComponents = new HashSet<>();
+    openshiftBasedComponents.add(OPENSHIFT_COMPONENT_TYPE);
+    applier =
+        new OpenshiftComponentToWorkspaceApplier(
+            k8sRecipeParser,
+            k8sEnvProvisioner,
+            envVars,
+            "/projects",
+            "1Gi",
+            "ReadWriteOnce",
+            "",
+            "Always",
+            SINGLE_HOST_STRATEGY,
+            openshiftBasedComponents);
+
+    String yamlRecipeContent = getResource("devfile/petclinic.yaml");
+    doReturn(toK8SList(yamlRecipeContent).getItems()).when(k8sRecipeParser).parse(anyString());
+
+    // given
+    ComponentImpl component = new ComponentImpl();
+    component.setType(OPENSHIFT_COMPONENT_TYPE);
+    component.setReference(REFERENCE_FILENAME);
+    component.setAlias(COMPONENT_NAME);
+    component.setEndpoints(
+        Arrays.asList(
+            new EndpointImpl("e1", 1111, emptyMap()), new EndpointImpl("e2", 2222, emptyMap())));
+
+    // when
+    applier.apply(workspaceConfig, component, s -> yamlRecipeContent);
+
+    // then
+    @SuppressWarnings("unchecked")
+    ArgumentCaptor<Map<String, MachineConfigImpl>> objectsCaptor =
+        ArgumentCaptor.forClass(Map.class);
+    verify(k8sEnvProvisioner).provision(any(), any(), any(), objectsCaptor.capture());
+    Map<String, MachineConfigImpl> machineConfigs = objectsCaptor.getValue();
+    assertEquals(machineConfigs.size(), 4);
+    machineConfigs
+        .values()
+        .forEach(
+            machineConfig -> {
+              assertEquals(machineConfig.getServers().size(), 2);
+              assertFalse(
+                  ServerConfig.isRequireSubdomain(
+                      machineConfig.getServers().get("e1").getAttributes()));
+              assertFalse(
+                  ServerConfig.isRequireSubdomain(
+                      machineConfig.getServers().get("e2").getAttributes()));
+            });
+  }
+
+  @Test
+  public void serverMustHaveRequireSubdomainWhenNonSinglehostDevfileExpose()
+      throws DevfileException, IOException, ValidationException, InfrastructureException {
+    Set<String> openshiftBasedComponents = new HashSet<>();
+    openshiftBasedComponents.add(OPENSHIFT_COMPONENT_TYPE);
+    applier =
+        new OpenshiftComponentToWorkspaceApplier(
+            k8sRecipeParser,
+            k8sEnvProvisioner,
+            envVars,
+            "/projects",
+            "1Gi",
+            "ReadWriteOnce",
+            "",
+            "Always",
+            MULTI_HOST_STRATEGY,
+            openshiftBasedComponents);
+
+    String yamlRecipeContent = getResource("devfile/petclinic.yaml");
+    doReturn(toK8SList(yamlRecipeContent).getItems()).when(k8sRecipeParser).parse(anyString());
+
+    // given
+    ComponentImpl component = new ComponentImpl();
+    component.setType(OPENSHIFT_COMPONENT_TYPE);
+    component.setReference(REFERENCE_FILENAME);
+    component.setAlias(COMPONENT_NAME);
+    component.setEndpoints(
+        Arrays.asList(
+            new EndpointImpl("e1", 1111, emptyMap()), new EndpointImpl("e2", 2222, emptyMap())));
+
+    // when
+    applier.apply(workspaceConfig, component, s -> yamlRecipeContent);
+
+    // then
+    @SuppressWarnings("unchecked")
+    ArgumentCaptor<Map<String, MachineConfigImpl>> objectsCaptor =
+        ArgumentCaptor.forClass(Map.class);
+    verify(k8sEnvProvisioner).provision(any(), any(), any(), objectsCaptor.capture());
+    Map<String, MachineConfigImpl> machineConfigs = objectsCaptor.getValue();
+    assertEquals(machineConfigs.size(), 4);
+    machineConfigs
+        .values()
+        .forEach(
+            machineConfig -> {
+              assertEquals(machineConfig.getServers().size(), 2);
+              assertTrue(
+                  ServerConfig.isRequireSubdomain(
+                      machineConfig.getServers().get("e1").getAttributes()));
+              assertTrue(
+                  ServerConfig.isRequireSubdomain(
+                      machineConfig.getServers().get("e2").getAttributes()));
+            });
+  }
+
+  private KubernetesList toK8SList(String content) {
+    return unmarshal(content, KubernetesList.class);
+  }
+
+  private String getResource(String resourceName) throws IOException {
+    return Files.readFile(getClass().getClassLoader().getResourceAsStream(resourceName));
   }
 }

--- a/infrastructures/openshift/src/test/resources/devfile/petclinic.yaml
+++ b/infrastructures/openshift/src/test/resources/devfile/petclinic.yaml
@@ -1,0 +1,131 @@
+#
+# Copyright (c) 2012-2021 Red Hat, Inc.
+# This program and the accompanying materials are made
+# available under the terms of the Eclipse Public License 2.0
+# which is available at https://www.eclipse.org/legal/epl-2.0/
+#
+# SPDX-License-Identifier: EPL-2.0
+#
+# Contributors:
+#   Red Hat, Inc. - initial API and implementation
+#
+
+---
+apiVersion: v1
+kind: List
+items:
+- apiVersion: v1
+  kind: Pod
+  metadata:
+    name: petclinic
+    labels:
+      app.kubernetes.io/name: petclinic
+      app.kubernetes.io/component: webapp
+      app.kubernetes.io/part-of: petclinic
+  spec:
+    initContainers:
+    - command:
+          - "echo foo:bar"
+      image: "openjdk:11-jre-openjdk9"
+      name: "init"
+    containers:
+    - name: server
+      image: mariolet/petclinic
+      ports:
+      - containerPort: 8080
+        protocol: TCP
+      resources:
+        limits:
+          memory: 512Mi
+- apiVersion: v1
+  kind: Pod
+  metadata:
+    name: mysql
+    labels:
+      app.kubernetes.io/name: mysql
+      app.kubernetes.io/component: database
+      app.kubernetes.io/part-of: petclinic
+  spec:
+    containers:
+    - name: mysql
+      image: centos/mysql-57-centos7
+      env:
+      - name: MYSQL_USER
+        value: petclinic
+      - name: MYSQL_PASSWORD
+        value: petclinic
+      - name: MYSQL_ROOT_PASSWORD
+        value: petclinic
+      - name: MYSQL_DATABASE
+        value: petclinic
+      ports:
+      - containerPort: 3306
+        protocol: TCP
+      resources:
+        limits:
+          memory: 512Mi
+- apiVersion: v1
+  kind: Pod
+  metadata:
+    name: withoutLabels
+  spec:
+      containers:
+      - name: server
+        imagePullPolicy: Always
+        image: test/petclinic
+        ports:
+        - containerPort: 8080
+          protocol: TCP
+        resources:
+          limits:
+            memory: 512Mi
+        volumeMounts:
+          - name: foo_volume
+            mountPath: /foo/bar
+- kind: Service
+  apiVersion: v1
+  metadata:
+    name: mysql
+    labels:
+      app.kubernetes.io/name: mysql
+      app.kubernetes.io/component: database
+      app.kubernetes.io/part-of: petclinic
+  spec:
+    ports:
+      - name: mysql
+        port: 3306
+        targetPort: 3360
+    selector:
+      app.kubernetes.io/name: mysql
+      app.kubernetes.io/component: database
+      app.kubernetes.io/part-of: petclinic
+- kind: Service
+  apiVersion: v1
+  metadata:
+    name: petclinic
+    labels:
+      app.kubernetes.io/name: petclinic
+      app.kubernetes.io/component: webapp
+      app.kubernetes.io/part-of: petclinic
+  spec:
+    ports:
+      - name: web
+        port: 8080
+        targetPort: 8080
+    selector:
+      app: petclinic
+      component: webapp
+- kind: Route
+  apiVersion: v1
+  metadata:
+    name: petclinic
+    labels:
+      app.kubernetes.io/name: petclinic
+      app.kubernetes.io/component: webapp
+      app.kubernetes.io/part-of: petclinic
+  spec:
+    to:
+      kind: Service
+      name: petclinic
+    port:
+      targetPort: web

--- a/wsmaster/che-core-api-workspace/src/main/java/org/eclipse/che/api/workspace/server/devfile/convert/component/ComponentToWorkspaceApplier.java
+++ b/wsmaster/che-core-api-workspace/src/main/java/org/eclipse/che/api/workspace/server/devfile/convert/component/ComponentToWorkspaceApplier.java
@@ -11,8 +11,16 @@
  */
 package org.eclipse.che.api.workspace.server.devfile.convert.component;
 
+import static org.eclipse.che.api.core.model.workspace.config.ServerConfig.SERVER_NAME_ATTRIBUTE;
+
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+import org.eclipse.che.api.core.model.workspace.config.ServerConfig;
+import org.eclipse.che.api.core.model.workspace.devfile.Endpoint;
 import org.eclipse.che.api.workspace.server.devfile.FileContentProvider;
 import org.eclipse.che.api.workspace.server.devfile.exception.DevfileException;
+import org.eclipse.che.api.workspace.server.model.impl.ServerConfigImpl;
 import org.eclipse.che.api.workspace.server.model.impl.WorkspaceConfigImpl;
 import org.eclipse.che.api.workspace.server.model.impl.devfile.ComponentImpl;
 
@@ -41,4 +49,13 @@ public interface ComponentToWorkspaceApplier {
       ComponentImpl component,
       FileContentProvider contentProvider)
       throws DevfileException;
+
+  static Map<String, ServerConfigImpl> convertEndpointsIntoServers(
+      List<? extends Endpoint> endpoints, boolean requireSubdomain) {
+    return endpoints
+        .stream()
+        .map(ServerConfigImpl::createFromEndpoint)
+        .peek(s -> ServerConfig.setRequireSubdomain(s.getAttributes(), requireSubdomain))
+        .collect(Collectors.toMap(s -> s.getAttributes().get(SERVER_NAME_ATTRIBUTE), s -> s));
+  }
 }

--- a/wsmaster/che-core-api-workspace/src/main/java/org/eclipse/che/api/workspace/server/devfile/convert/component/ComponentToWorkspaceApplier.java
+++ b/wsmaster/che-core-api-workspace/src/main/java/org/eclipse/che/api/workspace/server/devfile/convert/component/ComponentToWorkspaceApplier.java
@@ -11,8 +11,6 @@
  */
 package org.eclipse.che.api.workspace.server.devfile.convert.component;
 
-import static org.eclipse.che.api.core.model.workspace.config.ServerConfig.SERVER_NAME_ATTRIBUTE;
-
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
@@ -54,8 +52,13 @@ public interface ComponentToWorkspaceApplier {
       List<? extends Endpoint> endpoints, boolean requireSubdomain) {
     return endpoints
         .stream()
-        .map(ServerConfigImpl::createFromEndpoint)
-        .peek(s -> ServerConfig.setRequireSubdomain(s.getAttributes(), requireSubdomain))
-        .collect(Collectors.toMap(s -> s.getAttributes().get(SERVER_NAME_ATTRIBUTE), s -> s));
+        .collect(
+            Collectors.toMap(
+                Endpoint::getName,
+                e -> {
+                  var cfg = ServerConfigImpl.createFromEndpoint(e);
+                  ServerConfig.setRequireSubdomain(cfg.getAttributes(), requireSubdomain);
+                  return cfg;
+                }));
   }
 }

--- a/wsmaster/che-core-api-workspace/src/main/java/org/eclipse/che/api/workspace/server/model/impl/ServerConfigImpl.java
+++ b/wsmaster/che-core-api-workspace/src/main/java/org/eclipse/che/api/workspace/server/model/impl/ServerConfigImpl.java
@@ -180,7 +180,7 @@ public class ServerConfigImpl implements ServerConfig {
         + '}';
   }
 
-  public static ServerConfigImpl createFromEndpoint(Endpoint endpoint, boolean devfileEndpoint) {
+  public static ServerConfigImpl createFromEndpoint(Endpoint endpoint) {
     HashMap<String, String> attributes = new HashMap<>(endpoint.getAttributes());
     attributes.put(SERVER_NAME_ATTRIBUTE, endpoint.getName());
 
@@ -196,12 +196,6 @@ public class ServerConfigImpl implements ServerConfig {
       ServerConfig.setInternal(attributes, true);
     }
 
-    ServerConfig.setRequireSubdomain(attributes, devfileEndpoint);
-
     return new ServerConfigImpl(Integer.toString(endpoint.getPort()), protocol, path, attributes);
-  }
-
-  public static ServerConfigImpl createFromEndpoint(Endpoint endpoint) {
-    return createFromEndpoint(endpoint, false);
   }
 }

--- a/wsmaster/che-core-api-workspace/src/test/java/org/eclipse/che/api/workspace/server/model/impl/ServerConfigImplTest.java
+++ b/wsmaster/che-core-api-workspace/src/test/java/org/eclipse/che/api/workspace/server/model/impl/ServerConfigImplTest.java
@@ -110,23 +110,6 @@ public class ServerConfigImplTest {
   }
 
   @Test
-  public void testCreateFromEndpointDevfileEndpointAttributeSet() {
-    ServerConfig serverConfig =
-        ServerConfigImpl.createFromEndpoint(new EndpointImpl("name", 123, new HashMap<>()), true);
-
-    assertTrue(serverConfig.getAttributes().containsKey(REQUIRE_SUBDOMAIN));
-    assertTrue(Boolean.parseBoolean(serverConfig.getAttributes().get(REQUIRE_SUBDOMAIN)));
-  }
-
-  @Test
-  public void testCreateFromEndpointDevfileEndpointAttributeNotSet() {
-    ServerConfig serverConfig =
-        ServerConfigImpl.createFromEndpoint(new EndpointImpl("name", 123, new HashMap<>()), false);
-
-    assertFalse(serverConfig.getAttributes().containsKey(REQUIRE_SUBDOMAIN));
-  }
-
-  @Test
   public void testCreateFromEndpointDevfileEndpointAttributeNotSetWhenDefault() {
     ServerConfig serverConfig =
         ServerConfigImpl.createFromEndpoint(new EndpointImpl("name", 123, new HashMap<>()));


### PR DESCRIPTION
…devfile endpoint exposure is enabled

Signed-off-by: Michal Vala <mvala@redhat.com>

<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests
-->

### What does this PR do?
See analysis of https://github.com/eclipse/che/issues/20593

This PR basically checks the `CHE_INFRA_KUBERNETES_SINGLEHOST_WORKSPACE_DEVFILE__ENDPOINT__EXPOSURE` and set `requireSubdomain` only for cases when it is not `single-host`.


### Screenshot/screencast of this PR
<!-- Please include a screenshot or a screencast explaining what is doing this PR -->


### What issues does this PR fix or reference?
<!-- Please include any related issue from eclipse che repository (or from another issue tracker).
     Include link to other pull requests like documentation PR from [the docs repo](https://github.com/eclipse/che-docs)
-->
https://github.com/eclipse/che/issues/20593

### How to test this PR?
<!-- Please explain for example :
  - The test platform (openshift, kubernetes, minikube, CodeReady Container, docker-desktop, etc)
  - Installation method: chectl / che-operator
  - steps to reproduce
 -->

latest image `quay.io/mvala/che-server:gh20593-singleHostDevfileEndpoint`

1. deploy with `chectl server:deploy --platform openshift --cheimage=quay.io/mvala/che-server:gh20593-singleHostDevfileEndpoint --che-operator-cr-patch-yaml=patch.yml` where patch.yml is:
```
spec:
  server:
    customCheProperties:
      CHE_INFRA_KUBERNETES_SINGLEHOST_WORKSPACE_DEVFILE__ENDPOINT__EXPOSURE: single-host
    serverExposureStrategy: single-host
```
2. Start any workspace that has endpoint defined in the devfile component
3. Workspace must start and be accessible from the browser (prone to fail is .net core sample devfile, but it's not failing 100%)
4. Run workspace task to use devfile endpoint and open it from theia, it must open on correct url and must work.
5. You can also observe browser network traffic for `GET /workspace` request, it must have server for the devfile endpoint with proper path suffix, like `/`


### PR Checklist

[As the author of this Pull Request I made sure that:](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#pull-request-template-and-its-checklist)

- [x] [The Eclipse Contributor Agreement is valid](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-eclipse-contributor-agreement-is-valid)
- [x] [Code produced is complete](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-produced-is-complete)
- [x] [Code builds without errors](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-builds-without-errors)
- [x] [Tests are covering the bugfix](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#tests-are-covering-the-bugfix)
- [x] [The repository devfile is up to date and works](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-repository-devfile-is-up-to-date-and-works)
- [x] [Sections `What issues does this PR fix or reference` and `How to test this PR` completed](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#sections-what-issues-does-this-pr-fix-or-reference-and-how-to-test-this-pr-completed)
- [x] [Relevant user documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [x] [Relevant contributing documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [x] [CI/CD changes implemented, documented and communicated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#cicd-changes-implemented-documented-and-communicated)

### Reviewers

Reviewers, please comment how you tested the PR when approving it.
