### PR TITLE
feat: Allow to override the path to the devfile from a given repository

### DIFF
--- a/wsmaster/che-core-api-factory-bitbucket-server/src/main/java/org/eclipse/che/api/factory/server/bitbucket/BitbucketUrl.java
+++ b/wsmaster/che-core-api-factory-bitbucket-server/src/main/java/org/eclipse/che/api/factory/server/bitbucket/BitbucketUrl.java
@@ -92,6 +92,12 @@ public class BitbucketUrl implements RemoteFactoryUrl {
     return this;
   }
 
+  @Override
+  public void setDevfileFilename(String devfileName) {
+    this.devfileFilenames.clear();
+    this.devfileFilenames.add(devfileName);
+  }
+
   protected BitbucketUrl withDevfileFilenames(List<String> devfileFilenames) {
     this.devfileFilenames.addAll(devfileFilenames);
     return this;

--- a/wsmaster/che-core-api-factory-github/src/main/java/org/eclipse/che/api/factory/server/github/GithubUrl.java
+++ b/wsmaster/che-core-api-factory-github/src/main/java/org/eclipse/che/api/factory/server/github/GithubUrl.java
@@ -94,6 +94,12 @@ public class GithubUrl implements RemoteFactoryUrl {
     return this;
   }
 
+  @Override
+  public void setDevfileFilename(String devfileName) {
+    this.devfileFilenames.clear();
+    this.devfileFilenames.add(devfileName);
+  }
+
   /**
    * Gets branch of this github url
    *

--- a/wsmaster/che-core-api-factory-gitlab/src/main/java/org/eclipse/che/api/factory/server/gitlab/GitlabUrl.java
+++ b/wsmaster/che-core-api-factory-gitlab/src/main/java/org/eclipse/che/api/factory/server/gitlab/GitlabUrl.java
@@ -127,6 +127,12 @@ public class GitlabUrl implements RemoteFactoryUrl {
     return this;
   }
 
+  @Override
+  public void setDevfileFilename(String devfileName) {
+    this.devfileFilenames.clear();
+    this.devfileFilenames.add(devfileName);
+  }
+
   /**
    * Gets branch of this gitlab url
    *

--- a/wsmaster/che-core-api-factory/src/main/java/org/eclipse/che/api/factory/server/urlfactory/DefaultFactoryUrl.java
+++ b/wsmaster/che-core-api-factory/src/main/java/org/eclipse/che/api/factory/server/urlfactory/DefaultFactoryUrl.java
@@ -65,4 +65,9 @@ public class DefaultFactoryUrl implements RemoteFactoryUrl {
     this.devfileFileLocation = devfileFileLocation;
     return this;
   }
+
+  @Override
+  public void setDevfileFilename(String devfileName) {
+    // do nothing as the devfile location is absolute
+  }
 }

--- a/wsmaster/che-core-api-factory/src/main/java/org/eclipse/che/api/factory/server/urlfactory/RemoteFactoryUrl.java
+++ b/wsmaster/che-core-api-factory/src/main/java/org/eclipse/che/api/factory/server/urlfactory/RemoteFactoryUrl.java
@@ -23,6 +23,9 @@ public interface RemoteFactoryUrl {
   /** Provider name for given URL. */
   String getProviderName();
 
+  /** Defines the devfile name */
+  void setDevfileFilename(String devfileName);
+
   /**
    * List of possible filenames and raw locations of devfile.
    *

--- a/wsmaster/che-core-api-factory/src/main/java/org/eclipse/che/api/factory/server/urlfactory/URLFactoryBuilder.java
+++ b/wsmaster/che-core-api-factory/src/main/java/org/eclipse/che/api/factory/server/urlfactory/URLFactoryBuilder.java
@@ -60,6 +60,8 @@ public class URLFactoryBuilder {
 
   private static final Logger LOG = LoggerFactory.getLogger(URLFactoryBuilder.class);
 
+  public static final String DEVFILE_NAME = "devfileName";
+
   private final String defaultCheEditor;
   private final String defaultChePlugins;
 
@@ -102,6 +104,12 @@ public class URLFactoryBuilder {
       Map<String, String> overrideProperties)
       throws ApiException {
     String devfileYamlContent;
+
+    // Apply the new devfile name to look for
+    if (overrideProperties.containsKey(DEVFILE_NAME)) {
+      remoteFactoryUrl.setDevfileFilename(overrideProperties.get(DEVFILE_NAME));
+    }
+
     for (DevfileLocation location : remoteFactoryUrl.devfileFileLocations()) {
       try {
         devfileYamlContent = fileContentProvider.fetchContent(location.location());


### PR DESCRIPTION
### What does this PR do?
Che-server is looking for .devfile.yaml or devfile.yaml by default when specifying a Remote repository
But sometimes you may want to give a hint on the file you want to look inside the repository

usecase: let say I want to have both devfile v1 and v2 in the same repository, I need to provide the custom path to either devfile v1 or v2.

to the question: Why I don't provide the path to the devfile directly, it's because it's not matching the "repository" handling anymore (raw link vs context aware of the devfile)


### Screenshot/screencast of this PR
<!-- Please include a screenshot or a screencast explaining what is doing this PR -->


### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/20607

### How to test this PR?
Call the resolver API with an optional overide devfileName parameter


### PR Checklist

[As the author of this Pull Request I made sure that:](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#pull-request-template-and-its-checklist)

- [x] [The Eclipse Contributor Agreement is valid](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-eclipse-contributor-agreement-is-valid)
- [x] [Code produced is complete](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-produced-is-complete)
- [x] [Code builds without errors](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-builds-without-errors)
- [x] [Tests are covering the bugfix](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#tests-are-covering-the-bugfix)
- [x] [The repository devfile is up to date and works](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-repository-devfile-is-up-to-date-and-works)
- [x] [Sections `What issues does this PR fix or reference` and `How to test this PR` completed](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#sections-what-issues-does-this-pr-fix-or-reference-and-how-to-test-this-pr-completed)
- [x] [Relevant user documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [x] [Relevant contributing documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [x] [CI/CD changes implemented, documented and communicated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#cicd-changes-implemented-documented-and-communicated)

### Reviewers

Reviewers, please comment how you tested the PR when approving it.
