### PR TITLE
feat: Resolve v2 devfile in case if devworkspace is disabled

### DIFF
--- a/wsmaster/che-core-api-factory/src/main/java/org/eclipse/che/api/factory/server/urlfactory/URLFactoryBuilder.java
+++ b/wsmaster/che-core-api-factory/src/main/java/org/eclipse/che/api/factory/server/urlfactory/URLFactoryBuilder.java
@@ -12,7 +12,6 @@
 package org.eclipse.che.api.factory.server.urlfactory;
 
 import static com.google.common.base.Strings.isNullOrEmpty;
-import static java.lang.String.format;
 import static org.eclipse.che.api.factory.server.DevfileToApiExceptionMapper.toApiException;
 import static org.eclipse.che.api.factory.shared.Constants.CURRENT_VERSION;
 import static org.eclipse.che.api.workspace.server.devfile.Constants.CURRENT_API_VERSION;
@@ -168,16 +167,11 @@ public class URLFactoryBuilder {
           .withDevfile(DtoConverter.asDto(devfile))
           .withSource(location.filename().isPresent() ? location.filename().get() : null);
 
-    } else if (devWorskspacesEnabled) {
+    } else {
       return newDto(FactoryDevfileV2Dto.class)
           .withV(CURRENT_VERSION)
           .withDevfile(devfileParser.convertYamlToMap(devfileJson))
           .withSource(location.filename().isPresent() ? location.filename().get() : null);
-    } else {
-      throw new DevfileException(
-          format(
-              "Devfile of version %s cannot be used in current deployment, because of DevWorkspaces feature is disabled. Only '1.0.0' version devfiles are supported for such installations.",
-              devfileVersionDetector.devfileVersion(devfileJson)));
     }
   }
 


### PR DESCRIPTION
### What does this PR do?
feat: Resolve v2 devfile in case if devworkspace is disabled

### Screenshot/screencast of this PR


<img width="1194" alt="Знімок екрана 2021-10-19 о 09 49 58" src="https://user-images.githubusercontent.com/1614429/137858469-489cc8ef-b096-490a-a457-fde27ed37be1.png">
<img width="1680" alt="Знімок екрана 2021-10-19 о 09 50 53" src="https://user-images.githubusercontent.com/1614429/137858495-49b689c4-2367-4505-9cc9-7a60fe2bfb88.png">

### What issues does this PR fix or reference?
 - Fixes https://github.com/eclipse/che/issues/20650

### How to test this PR?
- build che-server's image from branch or deploy `quay.io/skabashn/che-server:main_2021_10_19_09_45_15`
- start factory `https://host/f?url=https://github.com/redhat-developer/devfile-sample.git`
- 'api/factory/resolve' should return factory with devfile v2.
### PR Checklist

[As the author of this Pull Request I made sure that:](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#pull-request-template-and-its-checklist)

- [ ] [The Eclipse Contributor Agreement is valid](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-eclipse-contributor-agreement-is-valid)
- [ ] [Code produced is complete](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-produced-is-complete)
- [ ] [Code builds without errors](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-builds-without-errors)
- [ ] [Tests are covering the bugfix](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#tests-are-covering-the-bugfix)
- [ ] [The repository devfile is up to date and works](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-repository-devfile-is-up-to-date-and-works)
- [ ] [Sections `What issues does this PR fix or reference` and `How to test this PR` completed](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#sections-what-issues-does-this-pr-fix-or-reference-and-how-to-test-this-pr-completed)
- [ ] [Relevant user documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [Relevant contributing documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [CI/CD changes implemented, documented and communicated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#cicd-changes-implemented-documented-and-communicated)

### Reviewers

Reviewers, please comment how you tested the PR when approving it.
