### PR TITLE
feat: Add user-preferences/profile secrets to the workspace-secret role

### DIFF
--- a/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/namespace/AbstractWorkspaceServiceAccount.java
+++ b/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/namespace/AbstractWorkspaceServiceAccount.java
@@ -13,6 +13,8 @@ package org.eclipse.che.workspace.infrastructure.kubernetes.namespace;
 
 import static java.util.Collections.emptyList;
 import static java.util.Collections.singletonList;
+import static org.eclipse.che.workspace.infrastructure.kubernetes.namespace.configurator.UserPreferencesConfigurator.USER_PREFERENCES_SECRET_NAME;
+import static org.eclipse.che.workspace.infrastructure.kubernetes.namespace.configurator.UserProfileConfigurator.USER_PROFILE_SECRET_NAME;
 
 import io.fabric8.kubernetes.api.model.HasMetadata;
 import io.fabric8.kubernetes.api.model.KubernetesResourceList;
@@ -153,13 +155,14 @@ public abstract class AbstractWorkspaceServiceAccount<
       }
     }
 
-    // credentials-secret role
+    // workspace-secrets role
     ensureRoleWithBinding(
         k8sClient,
         buildRole(
             SECRETS_ROLE_NAME,
             singletonList("secrets"),
-            singletonList(CREDENTIALS_SECRET_NAME),
+            Arrays.asList(
+                CREDENTIALS_SECRET_NAME, USER_PREFERENCES_SECRET_NAME, USER_PROFILE_SECRET_NAME),
             singletonList(""),
             Arrays.asList("get", "patch")),
         serviceAccountName + "-secrets");

--- a/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/namespace/configurator/UserPreferencesConfigurator.java
+++ b/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/namespace/configurator/UserPreferencesConfigurator.java
@@ -40,7 +40,7 @@ import org.eclipse.che.workspace.infrastructure.kubernetes.namespace.KubernetesN
  * @author Pavol Baran
  */
 public class UserPreferencesConfigurator implements NamespaceConfigurator {
-  private static final String USER_PREFERENCES_SECRET_NAME = "user-preferences";
+  public static final String USER_PREFERENCES_SECRET_NAME = "user-preferences";
   private static final String USER_PREFERENCES_SECRET_MOUNT_PATH = "/config/user/preferences";
   private static final int PREFERENCE_NAME_MAX_LENGTH = 253;
 

--- a/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/namespace/configurator/UserProfileConfigurator.java
+++ b/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/namespace/configurator/UserProfileConfigurator.java
@@ -38,7 +38,7 @@ import org.eclipse.che.workspace.infrastructure.kubernetes.namespace.KubernetesN
  * @author Pavol Baran
  */
 public class UserProfileConfigurator implements NamespaceConfigurator {
-  private static final String USER_PROFILE_SECRET_NAME = "user-profile";
+  public static final String USER_PROFILE_SECRET_NAME = "user-profile";
   private static final String USER_PROFILE_SECRET_MOUNT_PATH = "/config/user/profile";
 
   private final KubernetesNamespaceFactory namespaceFactory;

--- a/infrastructures/kubernetes/src/test/java/org/eclipse/che/workspace/infrastructure/kubernetes/namespace/KubernetesNamespaceFactoryTest.java
+++ b/infrastructures/kubernetes/src/test/java/org/eclipse/che/workspace/infrastructure/kubernetes/namespace/KubernetesNamespaceFactoryTest.java
@@ -20,6 +20,8 @@ import static org.eclipse.che.workspace.infrastructure.kubernetes.api.shared.Kub
 import static org.eclipse.che.workspace.infrastructure.kubernetes.namespace.AbstractWorkspaceServiceAccount.CREDENTIALS_SECRET_NAME;
 import static org.eclipse.che.workspace.infrastructure.kubernetes.namespace.AbstractWorkspaceServiceAccount.SECRETS_ROLE_NAME;
 import static org.eclipse.che.workspace.infrastructure.kubernetes.namespace.KubernetesNamespaceFactory.NAMESPACE_TEMPLATE_ATTRIBUTE;
+import static org.eclipse.che.workspace.infrastructure.kubernetes.namespace.configurator.UserPreferencesConfigurator.USER_PREFERENCES_SECRET_NAME;
+import static org.eclipse.che.workspace.infrastructure.kubernetes.namespace.configurator.UserProfileConfigurator.USER_PROFILE_SECRET_NAME;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyMap;
 import static org.mockito.ArgumentMatchers.anyString;
@@ -841,7 +843,10 @@ public class KubernetesNamespaceFactoryTest {
     assertTrue(roleOptional.isPresent());
     PolicyRule rule = roleOptional.get().getRules().get(0);
     assertEquals(rule.getResources(), singletonList("secrets"));
-    assertEquals(rule.getResourceNames(), singletonList(CREDENTIALS_SECRET_NAME));
+    assertEquals(
+        rule.getResourceNames(),
+        Arrays.asList(
+            CREDENTIALS_SECRET_NAME, USER_PREFERENCES_SECRET_NAME, USER_PROFILE_SECRET_NAME));
     assertEquals(rule.getApiGroups(), singletonList(""));
     assertEquals(rule.getVerbs(), Arrays.asList("get", "patch"));
     assertTrue(


### PR DESCRIPTION
Signed-off-by: Igor Vinokur <ivinokur@redhat.com>

<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests
-->

### What does this PR do?
Include the `user-preferences` and `user-profile` secrets to the `workspace-secrets` role. This gives an ability to read and edit those secrets.

### Screenshot/screencast of this PR
<!-- Please include a screenshot or a screencast explaining what is doing this PR -->


### What issues does this PR fix or reference?
<!-- Please include any related issue from eclipse che repository (or from another issue tracker).
     Include link to other pull requests like documentation PR from [the docs repo](https://github.com/eclipse/che-docs)
-->
https://github.com/eclipse/che/issues/20622

### How to test this PR?
<!-- Please explain for example :
  - The test platform (openshift, kubernetes, minikube, CodeReady Container, docker-desktop, etc)
  - Installation method: chectl / che-operator
  - steps to reproduce
 -->
1. Start a workspace and open a terminal from the ide container.
2. Send an HTTP request to the kubernetes API to edit user-preferences secret: `curl -X POST <kubernetes API url>/api/v1/namespaces/<namespace name>/secrets/user-preferences --header "Content-Type: application/json-patch+json" -d '[{ "op": "add", "path": "/data", "value": { "key": "" } }]'`

### PR Checklist

[As the author of this Pull Request I made sure that:](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#pull-request-template-and-its-checklist)

- [x] [The Eclipse Contributor Agreement is valid](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-eclipse-contributor-agreement-is-valid)
- [x] [Code produced is complete](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-produced-is-complete)
- [x] [Code builds without errors](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-builds-without-errors)
- [x] [Tests are covering the bugfix](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#tests-are-covering-the-bugfix)
- [ ] [The repository devfile is up to date and works](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-repository-devfile-is-up-to-date-and-works)
- [x] [Sections `What issues does this PR fix or reference` and `How to test this PR` completed](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#sections-what-issues-does-this-pr-fix-or-reference-and-how-to-test-this-pr-completed)
- [ ] [Relevant user documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [Relevant contributing documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [CI/CD changes implemented, documented and communicated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#cicd-changes-implemented-documented-and-communicated)

### Reviewers

Reviewers, please comment how you tested the PR when approving it.
