### PR TITLE
feat: Add a predefined configmap to store theia preferences

### DIFF
--- a/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/namespace/AbstractWorkspaceServiceAccount.java
+++ b/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/namespace/AbstractWorkspaceServiceAccount.java
@@ -50,8 +50,9 @@ public abstract class AbstractWorkspaceServiceAccount<
   public static final String VIEW_ROLE_NAME = "workspace-view";
   public static final String METRICS_ROLE_NAME = "workspace-metrics";
   public static final String SECRETS_ROLE_NAME = "workspace-secrets";
+  public static final String CONFIGMAPS_ROLE_NAME = "workspace-configmaps";
   public static final String CREDENTIALS_SECRET_NAME = "workspace-credentials-secret";
-  public static final String PREFERENCES_SECRET_NAME = "workspace-preferences-secret";
+  public static final String PREFERENCES_CONFIGMAP_NAME = "workspace-preferences-configmap";
 
   protected final String namespace;
   protected final String serviceAccountName;
@@ -160,10 +161,21 @@ public abstract class AbstractWorkspaceServiceAccount<
         buildRole(
             SECRETS_ROLE_NAME,
             singletonList("secrets"),
-            Arrays.asList(CREDENTIALS_SECRET_NAME, PREFERENCES_SECRET_NAME),
+            singletonList(CREDENTIALS_SECRET_NAME),
             singletonList(""),
             Arrays.asList("get", "patch")),
         serviceAccountName + "-secrets");
+
+    // preferences-configmap role
+    ensureRoleWithBinding(
+        k8sClient,
+        buildRole(
+            CONFIGMAPS_ROLE_NAME,
+            singletonList("configmaps"),
+            singletonList(PREFERENCES_CONFIGMAP_NAME),
+            singletonList(""),
+            Arrays.asList("get", "patch")),
+        serviceAccountName + "-configmaps");
   }
 
   private void ensureRoleWithBinding(Client k8sClient, R role, String bindingName) {

--- a/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/namespace/AbstractWorkspaceServiceAccount.java
+++ b/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/namespace/AbstractWorkspaceServiceAccount.java
@@ -51,6 +51,7 @@ public abstract class AbstractWorkspaceServiceAccount<
   public static final String METRICS_ROLE_NAME = "workspace-metrics";
   public static final String SECRETS_ROLE_NAME = "workspace-secrets";
   public static final String CREDENTIALS_SECRET_NAME = "workspace-credentials-secret";
+  public static final String THEIA_SECRET_NAME = "workspace-theia-secret";
 
   protected final String namespace;
   protected final String serviceAccountName;
@@ -159,7 +160,7 @@ public abstract class AbstractWorkspaceServiceAccount<
         buildRole(
             SECRETS_ROLE_NAME,
             singletonList("secrets"),
-            singletonList(CREDENTIALS_SECRET_NAME),
+            Arrays.asList(CREDENTIALS_SECRET_NAME, THEIA_SECRET_NAME),
             singletonList(""),
             Arrays.asList("get", "patch")),
         serviceAccountName + "-secrets");

--- a/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/namespace/AbstractWorkspaceServiceAccount.java
+++ b/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/namespace/AbstractWorkspaceServiceAccount.java
@@ -51,7 +51,7 @@ public abstract class AbstractWorkspaceServiceAccount<
   public static final String METRICS_ROLE_NAME = "workspace-metrics";
   public static final String SECRETS_ROLE_NAME = "workspace-secrets";
   public static final String CREDENTIALS_SECRET_NAME = "workspace-credentials-secret";
-  public static final String THEIA_SECRET_NAME = "workspace-theia-secret";
+  public static final String PREFERENCES_SECRET_NAME = "workspace-preferences-secret";
 
   protected final String namespace;
   protected final String serviceAccountName;
@@ -160,7 +160,7 @@ public abstract class AbstractWorkspaceServiceAccount<
         buildRole(
             SECRETS_ROLE_NAME,
             singletonList("secrets"),
-            Arrays.asList(CREDENTIALS_SECRET_NAME, THEIA_SECRET_NAME),
+            Arrays.asList(CREDENTIALS_SECRET_NAME, PREFERENCES_SECRET_NAME),
             singletonList(""),
             Arrays.asList("get", "patch")),
         serviceAccountName + "-secrets");

--- a/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/namespace/KubernetesNamespaceFactory.java
+++ b/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/namespace/KubernetesNamespaceFactory.java
@@ -21,6 +21,7 @@ import static org.eclipse.che.api.workspace.shared.Constants.WORKSPACE_INFRASTRU
 import static org.eclipse.che.workspace.infrastructure.kubernetes.api.shared.KubernetesNamespaceMeta.DEFAULT_ATTRIBUTE;
 import static org.eclipse.che.workspace.infrastructure.kubernetes.api.shared.KubernetesNamespaceMeta.PHASE_ATTRIBUTE;
 import static org.eclipse.che.workspace.infrastructure.kubernetes.namespace.AbstractWorkspaceServiceAccount.CREDENTIALS_SECRET_NAME;
+import static org.eclipse.che.workspace.infrastructure.kubernetes.namespace.AbstractWorkspaceServiceAccount.THEIA_SECRET_NAME;
 import static org.eclipse.che.workspace.infrastructure.kubernetes.namespace.NamespaceNameValidator.METADATA_NAME_MAX_LENGTH;
 
 import com.google.common.annotations.VisibleForTesting;
@@ -353,6 +354,24 @@ public class KubernetesNamespaceFactory {
               .withType("opaque")
               .withNewMetadata()
               .withName(CREDENTIALS_SECRET_NAME)
+              .endMetadata()
+              .build();
+      clientFactory
+          .create()
+          .secrets()
+          .inNamespace(identity.getInfrastructureNamespace())
+          .create(secret);
+    }
+    if (namespace
+        .secrets()
+        .get()
+        .stream()
+        .noneMatch(s -> s.getMetadata().getName().equals(THEIA_SECRET_NAME))) {
+      Secret secret =
+          new SecretBuilder()
+              .withType("opaque")
+              .withNewMetadata()
+              .withName(THEIA_SECRET_NAME)
               .endMetadata()
               .build();
       clientFactory

--- a/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/namespace/KubernetesNamespaceFactory.java
+++ b/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/namespace/KubernetesNamespaceFactory.java
@@ -21,7 +21,7 @@ import static org.eclipse.che.api.workspace.shared.Constants.WORKSPACE_INFRASTRU
 import static org.eclipse.che.workspace.infrastructure.kubernetes.api.shared.KubernetesNamespaceMeta.DEFAULT_ATTRIBUTE;
 import static org.eclipse.che.workspace.infrastructure.kubernetes.api.shared.KubernetesNamespaceMeta.PHASE_ATTRIBUTE;
 import static org.eclipse.che.workspace.infrastructure.kubernetes.namespace.AbstractWorkspaceServiceAccount.CREDENTIALS_SECRET_NAME;
-import static org.eclipse.che.workspace.infrastructure.kubernetes.namespace.AbstractWorkspaceServiceAccount.THEIA_SECRET_NAME;
+import static org.eclipse.che.workspace.infrastructure.kubernetes.namespace.AbstractWorkspaceServiceAccount.PREFERENCES_SECRET_NAME;
 import static org.eclipse.che.workspace.infrastructure.kubernetes.namespace.NamespaceNameValidator.METADATA_NAME_MAX_LENGTH;
 
 import com.google.common.annotations.VisibleForTesting;
@@ -362,16 +362,17 @@ public class KubernetesNamespaceFactory {
           .inNamespace(identity.getInfrastructureNamespace())
           .create(secret);
     }
+
     if (namespace
         .secrets()
         .get()
         .stream()
-        .noneMatch(s -> s.getMetadata().getName().equals(THEIA_SECRET_NAME))) {
+        .noneMatch(s -> s.getMetadata().getName().equals(PREFERENCES_SECRET_NAME))) {
       Secret secret =
           new SecretBuilder()
               .withType("opaque")
               .withNewMetadata()
-              .withName(THEIA_SECRET_NAME)
+              .withName(PREFERENCES_SECRET_NAME)
               .endMetadata()
               .build();
       clientFactory

--- a/infrastructures/kubernetes/src/test/java/org/eclipse/che/workspace/infrastructure/kubernetes/namespace/KubernetesNamespaceFactoryTest.java
+++ b/infrastructures/kubernetes/src/test/java/org/eclipse/che/workspace/infrastructure/kubernetes/namespace/KubernetesNamespaceFactoryTest.java
@@ -18,8 +18,8 @@ import static org.eclipse.che.api.workspace.shared.Constants.WORKSPACE_INFRASTRU
 import static org.eclipse.che.workspace.infrastructure.kubernetes.api.shared.KubernetesNamespaceMeta.DEFAULT_ATTRIBUTE;
 import static org.eclipse.che.workspace.infrastructure.kubernetes.api.shared.KubernetesNamespaceMeta.PHASE_ATTRIBUTE;
 import static org.eclipse.che.workspace.infrastructure.kubernetes.namespace.AbstractWorkspaceServiceAccount.CREDENTIALS_SECRET_NAME;
+import static org.eclipse.che.workspace.infrastructure.kubernetes.namespace.AbstractWorkspaceServiceAccount.PREFERENCES_SECRET_NAME;
 import static org.eclipse.che.workspace.infrastructure.kubernetes.namespace.AbstractWorkspaceServiceAccount.SECRETS_ROLE_NAME;
-import static org.eclipse.che.workspace.infrastructure.kubernetes.namespace.AbstractWorkspaceServiceAccount.THEIA_SECRET_NAME;
 import static org.eclipse.che.workspace.infrastructure.kubernetes.namespace.KubernetesNamespaceFactory.NAMESPACE_TEMPLATE_ATTRIBUTE;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyMap;
@@ -526,7 +526,7 @@ public class KubernetesNamespaceFactoryTest {
   }
 
   @Test
-  public void shouldCreateTheiaSecretIfNotExists() throws Exception {
+  public void shouldCreatePreferencesSecretIfNotExists() throws Exception {
     // given
     namespaceFactory =
         spy(
@@ -562,7 +562,7 @@ public class KubernetesNamespaceFactoryTest {
     ArgumentCaptor<Secret> secretsCaptor = ArgumentCaptor.forClass(Secret.class);
     verify(namespaceOperation, times(2)).create(secretsCaptor.capture());
     Secret secret = secretsCaptor.getAllValues().get(1);
-    Assert.assertEquals(secret.getMetadata().getName(), THEIA_SECRET_NAME);
+    Assert.assertEquals(secret.getMetadata().getName(), PREFERENCES_SECRET_NAME);
     Assert.assertEquals(secret.getType(), "opaque");
   }
 
@@ -840,7 +840,7 @@ public class KubernetesNamespaceFactoryTest {
   }
 
   @Test
-  public void shouldCreateAndBindCredentialsAndTheiaSecretsRole() throws Exception {
+  public void shouldCreateAndBindCredentialsAndPreferencesSecretsRole() throws Exception {
     // given
     namespaceFactory =
         spy(
@@ -885,7 +885,7 @@ public class KubernetesNamespaceFactoryTest {
     PolicyRule rule = roleOptional.get().getRules().get(0);
     assertEquals(rule.getResources(), singletonList("secrets"));
     assertEquals(
-        rule.getResourceNames(), Arrays.asList(CREDENTIALS_SECRET_NAME, THEIA_SECRET_NAME));
+        rule.getResourceNames(), Arrays.asList(CREDENTIALS_SECRET_NAME, PREFERENCES_SECRET_NAME));
     assertEquals(rule.getApiGroups(), singletonList(""));
     assertEquals(rule.getVerbs(), Arrays.asList("get", "patch"));
     assertTrue(
@@ -1567,7 +1567,7 @@ public class KubernetesNamespaceFactoryTest {
     when(namespace.secrets()).thenReturn(secrets);
     Secret secretMock = mock(Secret.class);
     ObjectMeta objectMeta = mock(ObjectMeta.class);
-    when(objectMeta.getName()).thenReturn(CREDENTIALS_SECRET_NAME, THEIA_SECRET_NAME);
+    when(objectMeta.getName()).thenReturn(CREDENTIALS_SECRET_NAME, PREFERENCES_SECRET_NAME);
     when(secretMock.getMetadata()).thenReturn(objectMeta);
     when(secrets.get()).thenReturn(Collections.singletonList(secretMock));
   }

--- a/infrastructures/kubernetes/src/test/java/org/eclipse/che/workspace/infrastructure/kubernetes/namespace/KubernetesNamespaceFactoryTest.java
+++ b/infrastructures/kubernetes/src/test/java/org/eclipse/che/workspace/infrastructure/kubernetes/namespace/KubernetesNamespaceFactoryTest.java
@@ -14,12 +14,12 @@ package org.eclipse.che.workspace.infrastructure.kubernetes.namespace;
 import static java.util.Collections.emptyMap;
 import static java.util.Collections.emptySet;
 import static java.util.Collections.singletonList;
+import static java.util.Optional.empty;
 import static org.eclipse.che.api.workspace.shared.Constants.WORKSPACE_INFRASTRUCTURE_NAMESPACE_ATTRIBUTE;
 import static org.eclipse.che.workspace.infrastructure.kubernetes.api.shared.KubernetesNamespaceMeta.DEFAULT_ATTRIBUTE;
 import static org.eclipse.che.workspace.infrastructure.kubernetes.api.shared.KubernetesNamespaceMeta.PHASE_ATTRIBUTE;
 import static org.eclipse.che.workspace.infrastructure.kubernetes.namespace.AbstractWorkspaceServiceAccount.CREDENTIALS_SECRET_NAME;
-import static org.eclipse.che.workspace.infrastructure.kubernetes.namespace.AbstractWorkspaceServiceAccount.PREFERENCES_SECRET_NAME;
-import static org.eclipse.che.workspace.infrastructure.kubernetes.namespace.AbstractWorkspaceServiceAccount.SECRETS_ROLE_NAME;
+import static org.eclipse.che.workspace.infrastructure.kubernetes.namespace.AbstractWorkspaceServiceAccount.PREFERENCES_CONFIGMAP_NAME;
 import static org.eclipse.che.workspace.infrastructure.kubernetes.namespace.KubernetesNamespaceFactory.NAMESPACE_TEMPLATE_ATTRIBUTE;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyMap;
@@ -31,7 +31,6 @@ import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.spy;
-import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.testng.Assert.assertEquals;
@@ -43,6 +42,7 @@ import static org.testng.Assert.fail;
 import ch.qos.logback.classic.spi.LoggingEvent;
 import ch.qos.logback.core.Appender;
 import com.google.common.collect.ImmutableMap;
+import io.fabric8.kubernetes.api.model.ConfigMap;
 import io.fabric8.kubernetes.api.model.Namespace;
 import io.fabric8.kubernetes.api.model.NamespaceBuilder;
 import io.fabric8.kubernetes.api.model.NamespaceList;
@@ -51,7 +51,6 @@ import io.fabric8.kubernetes.api.model.Secret;
 import io.fabric8.kubernetes.api.model.ServiceAccountList;
 import io.fabric8.kubernetes.api.model.Status;
 import io.fabric8.kubernetes.api.model.rbac.ClusterRoleBuilder;
-import io.fabric8.kubernetes.api.model.rbac.PolicyRule;
 import io.fabric8.kubernetes.api.model.rbac.Role;
 import io.fabric8.kubernetes.api.model.rbac.RoleBindingList;
 import io.fabric8.kubernetes.api.model.rbac.RoleList;
@@ -506,6 +505,7 @@ public class KubernetesNamespaceFactoryTest {
     KubernetesNamespace toReturnNamespace = mock(KubernetesNamespace.class);
     KubernetesSecrets secrets = mock(KubernetesSecrets.class);
     when(toReturnNamespace.secrets()).thenReturn(secrets);
+    when(toReturnNamespace.configMaps()).thenReturn(mock(KubernetesConfigsMaps.class));
     when(secrets.get()).thenReturn(Collections.emptyList());
     doReturn(toReturnNamespace).when(namespaceFactory).doCreateNamespaceAccess(any(), any());
     MixedOperation mixedOperation = mock(MixedOperation.class);
@@ -519,14 +519,14 @@ public class KubernetesNamespaceFactoryTest {
 
     // then
     ArgumentCaptor<Secret> secretsCaptor = ArgumentCaptor.forClass(Secret.class);
-    verify(namespaceOperation, times(2)).create(secretsCaptor.capture());
-    Secret secret = secretsCaptor.getAllValues().get(0);
+    verify(namespaceOperation).create(secretsCaptor.capture());
+    Secret secret = secretsCaptor.getValue();
     Assert.assertEquals(secret.getMetadata().getName(), CREDENTIALS_SECRET_NAME);
     Assert.assertEquals(secret.getType(), "opaque");
   }
 
   @Test
-  public void shouldCreatePreferencesSecretIfNotExists() throws Exception {
+  public void shouldCreatePreferencesConfigmapIfNotExists() throws Exception {
     // given
     namespaceFactory =
         spy(
@@ -545,12 +545,13 @@ public class KubernetesNamespaceFactoryTest {
                 preferenceManager,
                 pool));
     KubernetesNamespace toReturnNamespace = mock(KubernetesNamespace.class);
-    KubernetesSecrets secrets = mock(KubernetesSecrets.class);
-    when(toReturnNamespace.secrets()).thenReturn(secrets);
-    when(secrets.get()).thenReturn(Collections.emptyList());
+    KubernetesConfigsMaps configsMaps = mock(KubernetesConfigsMaps.class);
+    when(toReturnNamespace.secrets()).thenReturn(mock(KubernetesSecrets.class));
+    when(toReturnNamespace.configMaps()).thenReturn(configsMaps);
+    when(configsMaps.get(eq(PREFERENCES_CONFIGMAP_NAME))).thenReturn(empty());
     doReturn(toReturnNamespace).when(namespaceFactory).doCreateNamespaceAccess(any(), any());
     MixedOperation mixedOperation = mock(MixedOperation.class);
-    lenient().when(k8sClient.secrets()).thenReturn(mixedOperation);
+    lenient().when(k8sClient.configMaps()).thenReturn(mixedOperation);
     lenient().when(mixedOperation.inNamespace(anyString())).thenReturn(namespaceOperation);
 
     // when
@@ -559,11 +560,10 @@ public class KubernetesNamespaceFactoryTest {
     namespaceFactory.getOrCreate(identity);
 
     // then
-    ArgumentCaptor<Secret> secretsCaptor = ArgumentCaptor.forClass(Secret.class);
-    verify(namespaceOperation, times(2)).create(secretsCaptor.capture());
-    Secret secret = secretsCaptor.getAllValues().get(1);
-    Assert.assertEquals(secret.getMetadata().getName(), PREFERENCES_SECRET_NAME);
-    Assert.assertEquals(secret.getType(), "opaque");
+    ArgumentCaptor<ConfigMap> configMapCaptor = ArgumentCaptor.forClass(ConfigMap.class);
+    verify(namespaceOperation).create(configMapCaptor.capture());
+    ConfigMap configmap = configMapCaptor.getValue();
+    Assert.assertEquals(configmap.getMetadata().getName(), PREFERENCES_CONFIGMAP_NAME);
   }
 
   @Test
@@ -590,6 +590,41 @@ public class KubernetesNamespaceFactoryTest {
     doReturn(toReturnNamespace).when(namespaceFactory).doCreateNamespaceAccess(any(), any());
     MixedOperation mixedOperation = mock(MixedOperation.class);
     lenient().when(k8sClient.secrets()).thenReturn(mixedOperation);
+    lenient().when(mixedOperation.inNamespace(anyString())).thenReturn(namespaceOperation);
+
+    // when
+    RuntimeIdentity identity =
+        new RuntimeIdentityImpl("workspace123", null, USER_ID, "workspace123");
+    namespaceFactory.getOrCreate(identity);
+
+    // then
+    verify(namespaceOperation, never()).create(any());
+  }
+
+  @Test
+  public void shouldNotCreatePreferencesConfigmapIfExists() throws Exception {
+    // given
+    namespaceFactory =
+        spy(
+            new KubernetesNamespaceFactory(
+                "",
+                "",
+                "<username>-che",
+                true,
+                true,
+                true,
+                NAMESPACE_LABELS,
+                NAMESPACE_ANNOTATIONS,
+                clientFactory,
+                cheClientFactory,
+                userManager,
+                preferenceManager,
+                pool));
+    KubernetesNamespace toReturnNamespace = mock(KubernetesNamespace.class);
+    prepareNamespace(toReturnNamespace);
+    doReturn(toReturnNamespace).when(namespaceFactory).doCreateNamespaceAccess(any(), any());
+    MixedOperation mixedOperation = mock(MixedOperation.class);
+    lenient().when(k8sClient.configMaps()).thenReturn(mixedOperation);
     lenient().when(mixedOperation.inNamespace(anyString())).thenReturn(namespaceOperation);
 
     // when
@@ -822,7 +857,12 @@ public class KubernetesNamespaceFactoryTest {
     RoleList roles = k8sClient.rbac().roles().inNamespace("workspace123").list();
     assertEquals(
         roles.getItems().stream().map(r -> r.getMetadata().getName()).collect(Collectors.toSet()),
-        Sets.newHashSet("workspace-view", "workspace-metrics", "workspace-secrets", "exec"));
+        Sets.newHashSet(
+            "workspace-configmaps",
+            "workspace-view",
+            "workspace-metrics",
+            "workspace-secrets",
+            "exec"));
     RoleBindingList bindings = k8sClient.rbac().roleBindings().inNamespace("workspace123").list();
     assertEquals(
         bindings
@@ -834,69 +874,10 @@ public class KubernetesNamespaceFactoryTest {
             "serviceAccount-metrics",
             "serviceAccount-cluster0",
             "serviceAccount-cluster1",
+            "serviceAccount-configmaps",
             "serviceAccount-view",
             "serviceAccount-exec",
             "serviceAccount-secrets"));
-  }
-
-  @Test
-  public void shouldCreateAndBindCredentialsAndPreferencesSecretsRole() throws Exception {
-    // given
-    namespaceFactory =
-        spy(
-            new KubernetesNamespaceFactory(
-                "serviceAccount",
-                "cr2, cr3",
-                "<username>-che",
-                true,
-                true,
-                true,
-                NAMESPACE_LABELS,
-                NAMESPACE_ANNOTATIONS,
-                clientFactory,
-                cheClientFactory,
-                userManager,
-                preferenceManager,
-                pool));
-    KubernetesNamespace toReturnNamespace = mock(KubernetesNamespace.class);
-    prepareNamespace(toReturnNamespace);
-    when(toReturnNamespace.getWorkspaceId()).thenReturn("workspace123");
-    when(toReturnNamespace.getName()).thenReturn("workspace123");
-    doReturn(toReturnNamespace).when(namespaceFactory).doCreateNamespaceAccess(any(), any());
-    when(clientFactory.create(any())).thenReturn(k8sClient);
-
-    // when
-    RuntimeIdentity identity =
-        new RuntimeIdentityImpl("workspace123", null, USER_ID, "workspace123");
-    namespaceFactory.getOrCreate(identity);
-
-    // then
-    Optional<Role> roleOptional =
-        k8sClient
-            .rbac()
-            .roles()
-            .inNamespace("workspace123")
-            .list()
-            .getItems()
-            .stream()
-            .filter(r -> r.getMetadata().getName().equals(SECRETS_ROLE_NAME))
-            .findAny();
-    assertTrue(roleOptional.isPresent());
-    PolicyRule rule = roleOptional.get().getRules().get(0);
-    assertEquals(rule.getResources(), singletonList("secrets"));
-    assertEquals(
-        rule.getResourceNames(), Arrays.asList(CREDENTIALS_SECRET_NAME, PREFERENCES_SECRET_NAME));
-    assertEquals(rule.getApiGroups(), singletonList(""));
-    assertEquals(rule.getVerbs(), Arrays.asList("get", "patch"));
-    assertTrue(
-        k8sClient
-            .rbac()
-            .roleBindings()
-            .inNamespace("workspace123")
-            .list()
-            .getItems()
-            .stream()
-            .anyMatch(rb -> rb.getMetadata().getName().equals("serviceAccount-secrets")));
   }
 
   @Test
@@ -941,7 +922,12 @@ public class KubernetesNamespaceFactoryTest {
     RoleList roles = k8sClient.rbac().roles().inNamespace("workspace123").list();
     assertEquals(
         roles.getItems().stream().map(r -> r.getMetadata().getName()).collect(Collectors.toSet()),
-        Sets.newHashSet("workspace-view", "workspace-metrics", "workspace-secrets", "exec"));
+        Sets.newHashSet(
+            "workspace-configmaps",
+            "workspace-view",
+            "workspace-metrics",
+            "workspace-secrets",
+            "exec"));
     Role role1 = roles.getItems().get(0);
     Role role2 = roles.getItems().get(1);
 
@@ -961,6 +947,7 @@ public class KubernetesNamespaceFactoryTest {
             "serviceAccount-metrics",
             "serviceAccount-view",
             "serviceAccount-exec",
+            "serviceAccount-configmaps",
             "serviceAccount-secrets"));
   }
 
@@ -1146,7 +1133,7 @@ public class KubernetesNamespaceFactoryTest {
                 userManager,
                 preferenceManager,
                 pool));
-    doReturn(Optional.empty()).when(namespaceFactory).fetchNamespace(anyString());
+    doReturn(empty()).when(namespaceFactory).fetchNamespace(anyString());
 
     String namespace =
         namespaceFactory.evaluateNamespaceName(
@@ -1329,7 +1316,7 @@ public class KubernetesNamespaceFactoryTest {
     KubernetesNamespaceMetaImpl namespaceMeta =
         new KubernetesNamespaceMetaImpl(
             "jondoe-cha-cha-cha", ImmutableMap.of("phase", "active", "default", "true"));
-    doReturn(Optional.empty()).when(namespaceFactory).fetchNamespace(eq("jondoe-cha-cha-cha"));
+    doReturn(empty()).when(namespaceFactory).fetchNamespace(eq("jondoe-cha-cha-cha"));
 
     // when
     NamespaceResolutionContext context =
@@ -1564,10 +1551,12 @@ public class KubernetesNamespaceFactoryTest {
 
   private void prepareNamespace(KubernetesNamespace namespace) throws InfrastructureException {
     KubernetesSecrets secrets = mock(KubernetesSecrets.class);
+    KubernetesConfigsMaps configmaps = mock(KubernetesConfigsMaps.class);
     when(namespace.secrets()).thenReturn(secrets);
+    when(namespace.configMaps()).thenReturn(configmaps);
     Secret secretMock = mock(Secret.class);
     ObjectMeta objectMeta = mock(ObjectMeta.class);
-    when(objectMeta.getName()).thenReturn(CREDENTIALS_SECRET_NAME, PREFERENCES_SECRET_NAME);
+    when(objectMeta.getName()).thenReturn(CREDENTIALS_SECRET_NAME);
     when(secretMock.getMetadata()).thenReturn(objectMeta);
     when(secrets.get()).thenReturn(Collections.singletonList(secretMock));
   }

--- a/infrastructures/openshift/src/main/java/org/eclipse/che/workspace/infrastructure/openshift/project/OpenShiftProjectFactory.java
+++ b/infrastructures/openshift/src/main/java/org/eclipse/che/workspace/infrastructure/openshift/project/OpenShiftProjectFactory.java
@@ -17,7 +17,7 @@ import static java.util.Collections.emptyList;
 import static java.util.Collections.emptyMap;
 import static org.eclipse.che.workspace.infrastructure.kubernetes.api.shared.KubernetesNamespaceMeta.PHASE_ATTRIBUTE;
 import static org.eclipse.che.workspace.infrastructure.kubernetes.namespace.AbstractWorkspaceServiceAccount.CREDENTIALS_SECRET_NAME;
-import static org.eclipse.che.workspace.infrastructure.kubernetes.namespace.AbstractWorkspaceServiceAccount.THEIA_SECRET_NAME;
+import static org.eclipse.che.workspace.infrastructure.kubernetes.namespace.AbstractWorkspaceServiceAccount.PREFERENCES_SECRET_NAME;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.google.inject.Inject;
@@ -144,17 +144,17 @@ public class OpenShiftProjectFactory extends KubernetesNamespaceFactory {
           .create(secret);
     }
 
-    // create theia secret
+    // create preferences secret
     if (osProject
         .secrets()
         .get()
         .stream()
-        .noneMatch(s -> s.getMetadata().getName().equals(THEIA_SECRET_NAME))) {
+        .noneMatch(s -> s.getMetadata().getName().equals(PREFERENCES_SECRET_NAME))) {
       Secret secret =
           new SecretBuilder()
               .withType("opaque")
               .withNewMetadata()
-              .withName(THEIA_SECRET_NAME)
+              .withName(PREFERENCES_SECRET_NAME)
               .endMetadata()
               .build();
       clientFactory

--- a/infrastructures/openshift/src/main/java/org/eclipse/che/workspace/infrastructure/openshift/project/OpenShiftProjectFactory.java
+++ b/infrastructures/openshift/src/main/java/org/eclipse/che/workspace/infrastructure/openshift/project/OpenShiftProjectFactory.java
@@ -17,6 +17,7 @@ import static java.util.Collections.emptyList;
 import static java.util.Collections.emptyMap;
 import static org.eclipse.che.workspace.infrastructure.kubernetes.api.shared.KubernetesNamespaceMeta.PHASE_ATTRIBUTE;
 import static org.eclipse.che.workspace.infrastructure.kubernetes.namespace.AbstractWorkspaceServiceAccount.CREDENTIALS_SECRET_NAME;
+import static org.eclipse.che.workspace.infrastructure.kubernetes.namespace.AbstractWorkspaceServiceAccount.THEIA_SECRET_NAME;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.google.inject.Inject;
@@ -134,6 +135,26 @@ public class OpenShiftProjectFactory extends KubernetesNamespaceFactory {
               .withType("opaque")
               .withNewMetadata()
               .withName(CREDENTIALS_SECRET_NAME)
+              .endMetadata()
+              .build();
+      clientFactory
+          .createOC()
+          .secrets()
+          .inNamespace(identity.getInfrastructureNamespace())
+          .create(secret);
+    }
+
+    // create theia secret
+    if (osProject
+        .secrets()
+        .get()
+        .stream()
+        .noneMatch(s -> s.getMetadata().getName().equals(THEIA_SECRET_NAME))) {
+      Secret secret =
+          new SecretBuilder()
+              .withType("opaque")
+              .withNewMetadata()
+              .withName(THEIA_SECRET_NAME)
               .endMetadata()
               .build();
       clientFactory

--- a/infrastructures/openshift/src/main/java/org/eclipse/che/workspace/infrastructure/openshift/project/OpenShiftProjectFactory.java
+++ b/infrastructures/openshift/src/main/java/org/eclipse/che/workspace/infrastructure/openshift/project/OpenShiftProjectFactory.java
@@ -17,11 +17,13 @@ import static java.util.Collections.emptyList;
 import static java.util.Collections.emptyMap;
 import static org.eclipse.che.workspace.infrastructure.kubernetes.api.shared.KubernetesNamespaceMeta.PHASE_ATTRIBUTE;
 import static org.eclipse.che.workspace.infrastructure.kubernetes.namespace.AbstractWorkspaceServiceAccount.CREDENTIALS_SECRET_NAME;
-import static org.eclipse.che.workspace.infrastructure.kubernetes.namespace.AbstractWorkspaceServiceAccount.PREFERENCES_SECRET_NAME;
+import static org.eclipse.che.workspace.infrastructure.kubernetes.namespace.AbstractWorkspaceServiceAccount.PREFERENCES_CONFIGMAP_NAME;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.google.inject.Inject;
 import com.google.inject.Singleton;
+import io.fabric8.kubernetes.api.model.ConfigMap;
+import io.fabric8.kubernetes.api.model.ConfigMapBuilder;
 import io.fabric8.kubernetes.api.model.ObjectMeta;
 import io.fabric8.kubernetes.api.model.Secret;
 import io.fabric8.kubernetes.api.model.SecretBuilder;
@@ -144,24 +146,19 @@ public class OpenShiftProjectFactory extends KubernetesNamespaceFactory {
           .create(secret);
     }
 
-    // create preferences secret
-    if (osProject
-        .secrets()
-        .get()
-        .stream()
-        .noneMatch(s -> s.getMetadata().getName().equals(PREFERENCES_SECRET_NAME))) {
-      Secret secret =
-          new SecretBuilder()
-              .withType("opaque")
+    // create preferences configmap
+    if (osProject.configMaps().get(PREFERENCES_CONFIGMAP_NAME).isEmpty()) {
+      ConfigMap configMap =
+          new ConfigMapBuilder()
               .withNewMetadata()
-              .withName(PREFERENCES_SECRET_NAME)
+              .withName(PREFERENCES_CONFIGMAP_NAME)
               .endMetadata()
               .build();
       clientFactory
           .createOC()
-          .secrets()
+          .configMaps()
           .inNamespace(identity.getInfrastructureNamespace())
-          .create(secret);
+          .create(configMap);
     }
 
     if (!isNullOrEmpty(getServiceAccountName())) {

--- a/infrastructures/openshift/src/test/java/org/eclipse/che/workspace/infrastructure/openshift/project/OpenShiftProjectFactoryTest.java
+++ b/infrastructures/openshift/src/test/java/org/eclipse/che/workspace/infrastructure/openshift/project/OpenShiftProjectFactoryTest.java
@@ -17,7 +17,7 @@ import static java.util.Collections.singletonList;
 import static org.eclipse.che.workspace.infrastructure.kubernetes.api.shared.KubernetesNamespaceMeta.DEFAULT_ATTRIBUTE;
 import static org.eclipse.che.workspace.infrastructure.kubernetes.api.shared.KubernetesNamespaceMeta.PHASE_ATTRIBUTE;
 import static org.eclipse.che.workspace.infrastructure.kubernetes.namespace.AbstractWorkspaceServiceAccount.CREDENTIALS_SECRET_NAME;
-import static org.eclipse.che.workspace.infrastructure.kubernetes.namespace.AbstractWorkspaceServiceAccount.THEIA_SECRET_NAME;
+import static org.eclipse.che.workspace.infrastructure.kubernetes.namespace.AbstractWorkspaceServiceAccount.PREFERENCES_SECRET_NAME;
 import static org.eclipse.che.workspace.infrastructure.openshift.Constants.PROJECT_DESCRIPTION_ANNOTATION;
 import static org.eclipse.che.workspace.infrastructure.openshift.Constants.PROJECT_DESCRIPTION_ATTRIBUTE;
 import static org.eclipse.che.workspace.infrastructure.openshift.Constants.PROJECT_DISPLAY_NAME_ANNOTATION;
@@ -601,7 +601,7 @@ public class OpenShiftProjectFactoryTest {
   }
 
   @Test
-  public void shouldCreateTheiaPreferencesSecretIfNotExists() throws Exception {
+  public void shouldCreatePreferencesSecretIfNotExists() throws Exception {
     // given
     projectFactory =
         spy(
@@ -642,7 +642,7 @@ public class OpenShiftProjectFactoryTest {
     ArgumentCaptor<Secret> secretsCaptor = ArgumentCaptor.forClass(Secret.class);
     verify(namespaceOperation, times(2)).create(secretsCaptor.capture());
     Secret secret = secretsCaptor.getAllValues().get(1);
-    Assert.assertEquals(secret.getMetadata().getName(), THEIA_SECRET_NAME);
+    Assert.assertEquals(secret.getMetadata().getName(), PREFERENCES_SECRET_NAME);
     Assert.assertEquals(secret.getType(), "opaque");
   }
 
@@ -959,7 +959,7 @@ public class OpenShiftProjectFactoryTest {
     when(project.secrets()).thenReturn(secrets);
     Secret secretMock = mock(Secret.class);
     ObjectMeta objectMeta = mock(ObjectMeta.class);
-    when(objectMeta.getName()).thenReturn(CREDENTIALS_SECRET_NAME, THEIA_SECRET_NAME);
+    when(objectMeta.getName()).thenReturn(CREDENTIALS_SECRET_NAME, PREFERENCES_SECRET_NAME);
     when(secretMock.getMetadata()).thenReturn(objectMeta);
     when(secrets.get()).thenReturn(Collections.singletonList(secretMock));
   }

--- a/infrastructures/openshift/src/test/java/org/eclipse/che/workspace/infrastructure/openshift/project/OpenShiftProjectFactoryTest.java
+++ b/infrastructures/openshift/src/test/java/org/eclipse/che/workspace/infrastructure/openshift/project/OpenShiftProjectFactoryTest.java
@@ -14,10 +14,11 @@ package org.eclipse.che.workspace.infrastructure.openshift.project;
 import static java.util.Collections.emptyList;
 import static java.util.Collections.emptyMap;
 import static java.util.Collections.singletonList;
+import static java.util.Optional.empty;
 import static org.eclipse.che.workspace.infrastructure.kubernetes.api.shared.KubernetesNamespaceMeta.DEFAULT_ATTRIBUTE;
 import static org.eclipse.che.workspace.infrastructure.kubernetes.api.shared.KubernetesNamespaceMeta.PHASE_ATTRIBUTE;
 import static org.eclipse.che.workspace.infrastructure.kubernetes.namespace.AbstractWorkspaceServiceAccount.CREDENTIALS_SECRET_NAME;
-import static org.eclipse.che.workspace.infrastructure.kubernetes.namespace.AbstractWorkspaceServiceAccount.PREFERENCES_SECRET_NAME;
+import static org.eclipse.che.workspace.infrastructure.kubernetes.namespace.AbstractWorkspaceServiceAccount.PREFERENCES_CONFIGMAP_NAME;
 import static org.eclipse.che.workspace.infrastructure.openshift.Constants.PROJECT_DESCRIPTION_ANNOTATION;
 import static org.eclipse.che.workspace.infrastructure.openshift.Constants.PROJECT_DESCRIPTION_ATTRIBUTE;
 import static org.eclipse.che.workspace.infrastructure.openshift.Constants.PROJECT_DISPLAY_NAME_ANNOTATION;
@@ -38,6 +39,7 @@ import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertNull;
 
 import com.google.common.collect.ImmutableMap;
+import io.fabric8.kubernetes.api.model.ConfigMap;
 import io.fabric8.kubernetes.api.model.ObjectMeta;
 import io.fabric8.kubernetes.api.model.Secret;
 import io.fabric8.kubernetes.api.model.Status;
@@ -56,6 +58,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import org.eclipse.che.api.core.ValidationException;
 import org.eclipse.che.api.core.model.workspace.runtime.RuntimeIdentity;
 import org.eclipse.che.api.user.server.PreferenceManager;
@@ -71,6 +74,7 @@ import org.eclipse.che.commons.subject.SubjectImpl;
 import org.eclipse.che.inject.ConfigurationException;
 import org.eclipse.che.workspace.infrastructure.kubernetes.CheServerKubernetesClientFactory;
 import org.eclipse.che.workspace.infrastructure.kubernetes.api.shared.KubernetesNamespaceMeta;
+import org.eclipse.che.workspace.infrastructure.kubernetes.namespace.KubernetesConfigsMaps;
 import org.eclipse.che.workspace.infrastructure.kubernetes.namespace.KubernetesSecrets;
 import org.eclipse.che.workspace.infrastructure.kubernetes.util.KubernetesSharedPool;
 import org.eclipse.che.workspace.infrastructure.openshift.CheServerOpenshiftClientFactory;
@@ -582,8 +586,11 @@ public class OpenShiftProjectFactoryTest {
     NonNamespaceOperation namespaceOperation = mock(NonNamespaceOperation.class);
     MixedOperation mixedOperation = mock(MixedOperation.class);
     KubernetesSecrets secrets = mock(KubernetesSecrets.class);
+    KubernetesConfigsMaps configsMaps = mock(KubernetesConfigsMaps.class);
     when(toReturnProject.secrets()).thenReturn(secrets);
+    when(toReturnProject.configMaps()).thenReturn(configsMaps);
     when(secrets.get()).thenReturn(Collections.emptyList());
+    when(configsMaps.get(anyString())).thenReturn(Optional.of(mock(ConfigMap.class)));
     lenient().when(osClient.secrets()).thenReturn(mixedOperation);
     lenient().when(mixedOperation.inNamespace(anyString())).thenReturn(namespaceOperation);
 
@@ -594,14 +601,14 @@ public class OpenShiftProjectFactoryTest {
 
     // then
     ArgumentCaptor<Secret> secretsCaptor = ArgumentCaptor.forClass(Secret.class);
-    verify(namespaceOperation, times(2)).create(secretsCaptor.capture());
-    Secret secret = secretsCaptor.getAllValues().get(0);
+    verify(namespaceOperation).create(secretsCaptor.capture());
+    Secret secret = secretsCaptor.getValue();
     Assert.assertEquals(secret.getMetadata().getName(), CREDENTIALS_SECRET_NAME);
     Assert.assertEquals(secret.getType(), "opaque");
   }
 
   @Test
-  public void shouldCreatePreferencesSecretIfNotExists() throws Exception {
+  public void shouldCreatePreferencesConfigmapIfNotExists() throws Exception {
     // given
     projectFactory =
         spy(
@@ -628,9 +635,17 @@ public class OpenShiftProjectFactoryTest {
     NonNamespaceOperation namespaceOperation = mock(NonNamespaceOperation.class);
     MixedOperation mixedOperation = mock(MixedOperation.class);
     KubernetesSecrets secrets = mock(KubernetesSecrets.class);
+    Secret secret = mock(Secret.class);
+    ObjectMeta objectMeta = mock(ObjectMeta.class);
+    when(secret.getMetadata()).thenReturn(objectMeta);
+    when(objectMeta.getName()).thenReturn(CREDENTIALS_SECRET_NAME);
     when(toReturnProject.secrets()).thenReturn(secrets);
-    when(secrets.get()).thenReturn(Collections.emptyList());
+    when(secrets.get()).thenReturn(singletonList(secret));
     lenient().when(osClient.secrets()).thenReturn(mixedOperation);
+    KubernetesConfigsMaps configsMaps = mock(KubernetesConfigsMaps.class);
+    when(toReturnProject.configMaps()).thenReturn(configsMaps);
+    when(configsMaps.get(eq(PREFERENCES_CONFIGMAP_NAME))).thenReturn(empty());
+    lenient().when(osClient.configMaps()).thenReturn(mixedOperation);
     lenient().when(mixedOperation.inNamespace(anyString())).thenReturn(namespaceOperation);
 
     // when
@@ -639,11 +654,10 @@ public class OpenShiftProjectFactoryTest {
     projectFactory.getOrCreate(identity);
 
     // then
-    ArgumentCaptor<Secret> secretsCaptor = ArgumentCaptor.forClass(Secret.class);
-    verify(namespaceOperation, times(2)).create(secretsCaptor.capture());
-    Secret secret = secretsCaptor.getAllValues().get(1);
-    Assert.assertEquals(secret.getMetadata().getName(), PREFERENCES_SECRET_NAME);
-    Assert.assertEquals(secret.getType(), "opaque");
+    ArgumentCaptor<ConfigMap> configMapCaptor = ArgumentCaptor.forClass(ConfigMap.class);
+    verify(namespaceOperation).create(configMapCaptor.capture());
+    ConfigMap configmap = configMapCaptor.getValue();
+    Assert.assertEquals(configmap.getMetadata().getName(), PREFERENCES_CONFIGMAP_NAME);
   }
 
   @Test
@@ -675,6 +689,46 @@ public class OpenShiftProjectFactoryTest {
     NonNamespaceOperation namespaceOperation = mock(NonNamespaceOperation.class);
     MixedOperation mixedOperation = mock(MixedOperation.class);
     lenient().when(osClient.secrets()).thenReturn(mixedOperation);
+    lenient().when(mixedOperation.inNamespace(anyString())).thenReturn(namespaceOperation);
+
+    // when
+    RuntimeIdentity identity =
+        new RuntimeIdentityImpl("workspace123", null, USER_ID, "workspace123");
+    projectFactory.getOrCreate(identity);
+
+    // then
+    verify(namespaceOperation, never()).create(any());
+  }
+
+  @Test
+  public void shouldNotCreatePreferencesConfigmapIfExist() throws Exception {
+    // given
+    projectFactory =
+        spy(
+            new OpenShiftProjectFactory(
+                "",
+                null,
+                "<userid>-che",
+                true,
+                true,
+                true,
+                NAMESPACE_LABELS,
+                NAMESPACE_ANNOTATIONS,
+                true,
+                clientFactory,
+                cheClientFactory,
+                cheServerOpenshiftClientFactory,
+                stopWorkspaceRoleProvisioner,
+                userManager,
+                preferenceManager,
+                pool,
+                NO_OAUTH_IDENTITY_PROVIDER));
+    OpenShiftProject toReturnProject = mock(OpenShiftProject.class);
+    prepareProject(toReturnProject);
+    doReturn(toReturnProject).when(projectFactory).doCreateProjectAccess(any(), any());
+    NonNamespaceOperation namespaceOperation = mock(NonNamespaceOperation.class);
+    MixedOperation mixedOperation = mock(MixedOperation.class);
+    lenient().when(osClient.configMaps()).thenReturn(mixedOperation);
     lenient().when(mixedOperation.inNamespace(anyString())).thenReturn(namespaceOperation);
 
     // when
@@ -956,12 +1010,15 @@ public class OpenShiftProjectFactoryTest {
 
   private void prepareProject(OpenShiftProject project) throws InfrastructureException {
     KubernetesSecrets secrets = mock(KubernetesSecrets.class);
+    KubernetesConfigsMaps configsMaps = mock(KubernetesConfigsMaps.class);
     when(project.secrets()).thenReturn(secrets);
+    when(project.configMaps()).thenReturn(configsMaps);
+    when(configsMaps.get(anyString())).thenReturn(Optional.of(mock(ConfigMap.class)));
     Secret secretMock = mock(Secret.class);
     ObjectMeta objectMeta = mock(ObjectMeta.class);
-    when(objectMeta.getName()).thenReturn(CREDENTIALS_SECRET_NAME, PREFERENCES_SECRET_NAME);
+    when(objectMeta.getName()).thenReturn(CREDENTIALS_SECRET_NAME);
     when(secretMock.getMetadata()).thenReturn(objectMeta);
-    when(secrets.get()).thenReturn(Collections.singletonList(secretMock));
+    when(secrets.get()).thenReturn(singletonList(secretMock));
   }
 
   private void throwOnTryToGetProjectsList(Throwable e) throws Exception {


### PR DESCRIPTION
Signed-off-by: Igor Vinokur <ivinokur@redhat.com>

<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests
-->

### What does this PR do?
* Create a predefined K8s secret per nemaespace to store theia preferences.
* Include the preference secret to the `workspcae-secrets` role, to be able to manage it outside.

See https://github.com/eclipse-che/che-server/pull/172#issuecomment-953729818
### Screenshot/screencast of this PR
<!-- Please include a screenshot or a screencast explaining what is doing this PR -->


### What issues does this PR fix or reference?
<!-- Please include any related issue from eclipse che repository (or from another issue tracker).
     Include link to other pull requests like documentation PR from [the docs repo](https://github.com/eclipse/che-docs)
-->
https://github.com/eclipse/che/issues/20622

### How to test this PR?
<!-- Please explain for example :
  - The test platform (openshift, kubernetes, minikube, CodeReady Container, docker-desktop, etc)
  - Installation method: chectl / che-operator
  - steps to reproduce
 -->
1. Start a workspace and open a terminal from the ide container.
2. Send an HTTP request to the kubernetes API to edit user-preferences secret: `curl -X POST <kubernetes API url>/api/v1/namespaces/<namespace name>/secrets/workspace-theia-secret --header "Content-Type: application/json-patch+json" -d '[{ "op": "add", "path": "/data", "value": { "key": "" } }]'`

### PR Checklist

[As the author of this Pull Request I made sure that:](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#pull-request-template-and-its-checklist)

- [x] [The Eclipse Contributor Agreement is valid](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-eclipse-contributor-agreement-is-valid)
- [x] [Code produced is complete](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-produced-is-complete)
- [x] [Code builds without errors](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-builds-without-errors)
- [ ] [Tests are covering the bugfix](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#tests-are-covering-the-bugfix)
- [ ] [The repository devfile is up to date and works](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-repository-devfile-is-up-to-date-and-works)
- [x] [Sections `What issues does this PR fix or reference` and `How to test this PR` completed](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#sections-what-issues-does-this-pr-fix-or-reference-and-how-to-test-this-pr-completed)
- [ ] [Relevant user documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [Relevant contributing documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [CI/CD changes implemented, documented and communicated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#cicd-changes-implemented-documented-and-communicated)

### Reviewers

Reviewers, please comment how you tested the PR when approving it.
