### PR TITLE
fix: Adding 'FailedCreate' to the unrecoverable event list

### DIFF
--- a/assembly/assembly-wsmaster-war/src/main/webapp/WEB-INF/classes/che/che.properties
+++ b/assembly/assembly-wsmaster-war/src/main/webapp/WEB-INF/classes/che/che.properties
@@ -352,7 +352,7 @@ che.infra.kubernetes.ingress_start_timeout_min=5
 # stop the workspace immediately rather than waiting until timeout.
 # the {prod-short} Operator that this SHOULD NOT include a mere "Failed" reason, because that might catch events that are not unrecoverable.
 # A failed container startup is handled explicitly by {prod-short} server.
-che.infra.kubernetes.workspace_unrecoverable_events=FailedMount,FailedScheduling,MountVolume.SetUp failed,Failed to pull image,FailedCreate,ReplicaSetCreateError
+che.infra.kubernetes.workspace_unrecoverable_events=FailedMount,FailedScheduling,MountVolume.SetUp failed,Failed to pull image,FailedCreate,ReplicaSetCreateError,FailedCreate
 
 # Defines whether use the Persistent Volume Claim for {prod-short} workspace needs,
 # for example: backup projects, logs, or disable it.


### PR DESCRIPTION
Signed-off-by: Ilya Buziuk <ibuziuk@redhat.com>

<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests
-->

### What does this PR do?
 Adding 'FailedCreate' to the unrecoverable event list

### Screenshot/screencast of this PR

![image](https://user-images.githubusercontent.com/1461122/142632156-cac05b6b-f13f-482f-881f-b3963be00a4c.png)



### What issues does this PR fix or reference?
related to https://issues.redhat.com/browse/CRW-2480

### How to test this PR?

Event example:

```
16h         Warning   FailedCreate             replicaset/workspacewvf9n0woalm6b8d5.nodejs-b9d4677d8                 Error creating: pods "workspacewvf9n0woalm6b8d5.nodejs-b9d4677d8-sc25r" is forbidden: maximum cpu usage per Pod is 4, but limit is 4800m

```

Setup the limit ranges and try starting a multi-container workspace that will exceed the limit:
![image](https://user-images.githubusercontent.com/1461122/142632412-67502d9f-6b14-4cbe-9d0c-243f568f6dbc.png)


### PR Checklist

[As the author of this Pull Request I made sure that:](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#pull-request-template-and-its-checklist)

- [x] [The Eclipse Contributor Agreement is valid](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-eclipse-contributor-agreement-is-valid)
- [x] [Code produced is complete](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-produced-is-complete)
- [x] [Code builds without errors](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-builds-without-errors)
- [ ] [Tests are covering the bugfix](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#tests-are-covering-the-bugfix)
- [ ] [The repository devfile is up to date and works](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-repository-devfile-is-up-to-date-and-works)
- [ ] [Sections `What issues does this PR fix or reference` and `How to test this PR` completed](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#sections-what-issues-does-this-pr-fix-or-reference-and-how-to-test-this-pr-completed)
- [ ] [Relevant user documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [Relevant contributing documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [CI/CD changes implemented, documented and communicated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#cicd-changes-implemented-documented-and-communicated)

### Reviewers

Reviewers, please comment how you tested the PR when approving it.
