### PR TITLE
Added namespace configurator for existing user SSH keys

### DIFF
--- a/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/Constants.java
+++ b/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/Constants.java
@@ -50,6 +50,9 @@ public final class Constants {
   public static final String DEV_WORKSPACE_MOUNT_LABEL =
       "controller.devfile.io/mount-to-devworkspace";
 
+  public static final String DEV_WORKSPACE_WATCH_SECRET_LABEL =
+      "controller.devfile.io/watch-secret";
+
   public static final String DEV_WORKSPACE_MOUNT_PATH_ANNOTATION =
       "controller.devfile.io/mount-path";
   public static final String DEV_WORKSPACE_MOUNT_AS_ANNOTATION = "controller.devfile.io/mount-as";

--- a/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/KubernetesInfraModule.java
+++ b/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/KubernetesInfraModule.java
@@ -51,6 +51,7 @@ import org.eclipse.che.workspace.infrastructure.kubernetes.namespace.RemoveNames
 import org.eclipse.che.workspace.infrastructure.kubernetes.namespace.configurator.CredentialsSecretConfigurator;
 import org.eclipse.che.workspace.infrastructure.kubernetes.namespace.configurator.NamespaceConfigurator;
 import org.eclipse.che.workspace.infrastructure.kubernetes.namespace.configurator.PreferencesConfigMapConfigurator;
+import org.eclipse.che.workspace.infrastructure.kubernetes.namespace.configurator.SshKeysConfigurator;
 import org.eclipse.che.workspace.infrastructure.kubernetes.namespace.configurator.UserPermissionConfigurator;
 import org.eclipse.che.workspace.infrastructure.kubernetes.namespace.configurator.UserPreferencesConfigurator;
 import org.eclipse.che.workspace.infrastructure.kubernetes.namespace.configurator.UserProfileConfigurator;
@@ -116,6 +117,7 @@ public class KubernetesInfraModule extends AbstractModule {
     namespaceConfigurators.addBinding().to(WorkspaceServiceAccountConfigurator.class);
     namespaceConfigurators.addBinding().to(UserProfileConfigurator.class);
     namespaceConfigurators.addBinding().to(UserPreferencesConfigurator.class);
+    namespaceConfigurators.addBinding().to(SshKeysConfigurator.class);
 
     bind(KubernetesNamespaceService.class);
 

--- a/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/namespace/configurator/SshKeysConfigurator.java
+++ b/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/namespace/configurator/SshKeysConfigurator.java
@@ -51,9 +51,7 @@ public class SshKeysConfigurator implements NamespaceConfigurator {
   private static final String SSH_KEYS_WILL_NOT_BE_MOUNTED_MESSAGE =
       "Ssh keys %s have invalid names and can't be mounted to namespace %s.";
 
-  private static final String SSH_BASE_CONFIG_PATH = "/.ssh/";
-  private static final String SSH_PRIVATE_KEYS = "private";
-  private static final String SSH_PRIVATE_KEYS_PATH = SSH_BASE_CONFIG_PATH + SSH_PRIVATE_KEYS;
+  private static final String SSH_BASE_CONFIG_PATH = "/etc/ssh/";
 
   private final SshManager sshManager;
 
@@ -143,7 +141,7 @@ public class SshKeysConfigurator implements NamespaceConfigurator {
             Base64.getEncoder().encodeToString(sshPair.getPublicKey().getBytes()));
       }
     }
-    data.put("config", Base64.getEncoder().encodeToString(sshConfigData.toString().getBytes()));
+    data.put("ssh_config", Base64.getEncoder().encodeToString(sshConfigData.toString().getBytes()));
     Secret secret =
         new SecretBuilder()
             .addToData(data)
@@ -200,8 +198,7 @@ public class SshKeysConfigurator implements NamespaceConfigurator {
     return "host "
         + host
         + "\nIdentityFile "
-        + SSH_PRIVATE_KEYS_PATH
-        + "/"
+        + SSH_BASE_CONFIG_PATH
         + name
         + "\nStrictHostKeyChecking = no"
         + "\n\n";

--- a/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/namespace/configurator/SshKeysConfigurator.java
+++ b/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/namespace/configurator/SshKeysConfigurator.java
@@ -42,6 +42,10 @@ import org.eclipse.che.workspace.infrastructure.kubernetes.KubernetesClientFacto
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+/**
+ * This class mounts existing user SSH Keys into a special Kubernetes Secret on
+ * user-s namespace.
+ */
 public class SshKeysConfigurator implements NamespaceConfigurator {
 
   private static final String SSH_KEYS_WILL_NOT_BE_MOUNTED_MESSAGE =

--- a/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/namespace/configurator/SshKeysConfigurator.java
+++ b/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/namespace/configurator/SshKeysConfigurator.java
@@ -47,6 +47,7 @@ import org.slf4j.LoggerFactory;
  */
 public class SshKeysConfigurator implements NamespaceConfigurator {
 
+  public static final String SSH_KEY_SECRET_NAME = "che-git-ssh-key";
   private static final String SSH_KEYS_WILL_NOT_BE_MOUNTED_MESSAGE =
       "Ssh keys %s have invalid names and can't be mounted to namespace %s.";
 
@@ -116,20 +117,6 @@ public class SshKeysConfigurator implements NamespaceConfigurator {
       LOG.warn(message);
       throw new InfrastructureException(e);
     }
-    //    Q: do we need that generation for devworkspaces ?
-    //    if (sshPairs.isEmpty()) {
-    //      try {
-    //        sshPairs =
-    //            singletonList(
-    //                sshManager.generatePair(
-    //                    context.getUserId(), "vcs", "default-" + new Date().getTime()));
-    //      } catch (ServerException | ConflictException e) {
-    //        String message =
-    //            format("Unable to generate the initial SSH key. Cause: %s", e.getMessage());
-    //        LOG.warn(message);
-    //        throw new InfrastructureException(e);
-    //      }
-    //  }
     return sshPairs;
   }
 
@@ -169,7 +156,7 @@ public class SshKeysConfigurator implements NamespaceConfigurator {
 
   private ObjectMeta buildMetadata() {
     return new ObjectMetaBuilder()
-        .withName("git-ssh-key")
+        .withName(SSH_KEY_SECRET_NAME)
         .withLabels(
             Map.of(
                 DEV_WORKSPACE_MOUNT_LABEL, "true",

--- a/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/namespace/configurator/SshKeysConfigurator.java
+++ b/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/namespace/configurator/SshKeysConfigurator.java
@@ -43,8 +43,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /**
- * This class mounts existing user SSH Keys into a special Kubernetes Secret on
- * user-s namespace.
+ * This class mounts existing user SSH Keys into a special Kubernetes Secret on user-s namespace.
  */
 public class SshKeysConfigurator implements NamespaceConfigurator {
 

--- a/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/namespace/configurator/SshKeysConfigurator.java
+++ b/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/namespace/configurator/SshKeysConfigurator.java
@@ -1,0 +1,219 @@
+/*
+ * Copyright (c) 2012-2021 Red Hat, Inc.
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+package org.eclipse.che.workspace.infrastructure.kubernetes.namespace.configurator;
+
+import static com.google.common.base.Strings.isNullOrEmpty;
+import static java.lang.String.format;
+import static java.util.stream.Collectors.toList;
+import static org.eclipse.che.workspace.infrastructure.kubernetes.Constants.DEV_WORKSPACE_MOUNT_LABEL;
+import static org.eclipse.che.workspace.infrastructure.kubernetes.Constants.DEV_WORKSPACE_MOUNT_PATH_ANNOTATION;
+import static org.eclipse.che.workspace.infrastructure.kubernetes.Constants.DEV_WORKSPACE_WATCH_SECRET_LABEL;
+import static org.eclipse.che.workspace.infrastructure.kubernetes.namespace.KubernetesObjectUtil.isValidConfigMapKeyName;
+
+import com.google.common.annotations.VisibleForTesting;
+import io.fabric8.kubernetes.api.model.ObjectMeta;
+import io.fabric8.kubernetes.api.model.ObjectMetaBuilder;
+import io.fabric8.kubernetes.api.model.Secret;
+import io.fabric8.kubernetes.api.model.SecretBuilder;
+import io.fabric8.kubernetes.client.KubernetesClient;
+import jakarta.validation.constraints.NotNull;
+import java.util.Base64;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.regex.Pattern;
+import javax.inject.Inject;
+import org.eclipse.che.api.core.ServerException;
+import org.eclipse.che.api.ssh.server.SshManager;
+import org.eclipse.che.api.ssh.server.model.impl.SshPairImpl;
+import org.eclipse.che.api.ssh.shared.model.SshPair;
+import org.eclipse.che.api.workspace.server.spi.InfrastructureException;
+import org.eclipse.che.api.workspace.server.spi.NamespaceResolutionContext;
+import org.eclipse.che.workspace.infrastructure.kubernetes.KubernetesClientFactory;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class SshKeysConfigurator implements NamespaceConfigurator {
+
+  private static final String SSH_KEYS_WILL_NOT_BE_MOUNTED_MESSAGE =
+      "Ssh keys %s have invalid names and can't be mounted to namespace %s.";
+
+  private static final String SSH_BASE_CONFIG_PATH = "/.ssh/";
+  private static final String SSH_PRIVATE_KEYS = "private";
+  private static final String SSH_PRIVATE_KEYS_PATH = SSH_BASE_CONFIG_PATH + SSH_PRIVATE_KEYS;
+
+  private final SshManager sshManager;
+
+  private final KubernetesClientFactory clientFactory;
+
+  private static final Logger LOG = LoggerFactory.getLogger(SshKeysConfigurator.class);
+
+  public static final Pattern VALID_DOMAIN_PATTERN =
+      Pattern.compile("^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$");
+
+  @Inject
+  public SshKeysConfigurator(SshManager sshManager, KubernetesClientFactory clientFactory) {
+    this.sshManager = sshManager;
+    this.clientFactory = clientFactory;
+  }
+
+  @Override
+  public void configure(NamespaceResolutionContext namespaceResolutionContext, String namespaceName)
+      throws InfrastructureException {
+
+    var client = clientFactory.create();
+    List<SshPairImpl> vcsSshPairs = getVcsSshPairs(namespaceResolutionContext);
+
+    List<String> invalidSshKeyNames =
+        vcsSshPairs
+            .stream()
+            .filter(keyPair -> !isValidSshKeyPair(keyPair))
+            .map(SshPairImpl::getName)
+            .collect(toList());
+
+    if (!invalidSshKeyNames.isEmpty()) {
+      String message =
+          format(
+              SSH_KEYS_WILL_NOT_BE_MOUNTED_MESSAGE, invalidSshKeyNames.toString(), namespaceName);
+      LOG.warn(message);
+      // filter
+      vcsSshPairs = vcsSshPairs.stream().filter(this::isValidSshKeyPair).collect(toList());
+    }
+
+    if (vcsSshPairs.size() == 0) {
+      // nothing to provision
+      return;
+    }
+    doProvisionSshKeys(vcsSshPairs, client, namespaceName);
+  }
+
+  /**
+   * Return list of keys related to the VCS (Version Control Systems), Git, SVN and etc. Usually
+   * managed by user
+   *
+   * @param context NamespaceResolutionContext
+   * @return list of ssh pairs
+   */
+  private List<SshPairImpl> getVcsSshPairs(NamespaceResolutionContext context)
+      throws InfrastructureException {
+    List<SshPairImpl> sshPairs;
+    try {
+      sshPairs = sshManager.getPairs(context.getUserId(), "vcs");
+    } catch (ServerException e) {
+      String message = format("Unable to get SSH Keys. Cause: %s", e.getMessage());
+      LOG.warn(message);
+      throw new InfrastructureException(e);
+    }
+    //    Q: do we need that generation for devworkspaces ?
+    //    if (sshPairs.isEmpty()) {
+    //      try {
+    //        sshPairs =
+    //            singletonList(
+    //                sshManager.generatePair(
+    //                    context.getUserId(), "vcs", "default-" + new Date().getTime()));
+    //      } catch (ServerException | ConflictException e) {
+    //        String message =
+    //            format("Unable to generate the initial SSH key. Cause: %s", e.getMessage());
+    //        LOG.warn(message);
+    //        throw new InfrastructureException(e);
+    //      }
+    //  }
+    return sshPairs;
+  }
+
+  @VisibleForTesting
+  boolean isValidSshKeyPair(SshPairImpl keyPair) {
+    return isValidConfigMapKeyName(keyPair.getName())
+        && VALID_DOMAIN_PATTERN.matcher(keyPair.getName()).matches();
+  }
+
+  private void doProvisionSshKeys(
+      List<SshPairImpl> sshPairs, KubernetesClient client, String namespaceName) {
+
+    StringBuilder sshConfigData = new StringBuilder();
+    Map<String, String> data = new HashMap<>();
+
+    for (SshPair sshPair : sshPairs) {
+      sshConfigData.append(buildConfig(sshPair.getName()));
+      if (!isNullOrEmpty(sshPair.getPrivateKey())) {
+        data.put(
+            sshPair.getName(),
+            Base64.getEncoder().encodeToString(sshPair.getPrivateKey().getBytes()));
+        data.put(
+            sshPair.getName() + ".pub",
+            Base64.getEncoder().encodeToString(sshPair.getPublicKey().getBytes()));
+      }
+    }
+    data.put("config", Base64.getEncoder().encodeToString(sshConfigData.toString().getBytes()));
+    Secret secret =
+        new SecretBuilder()
+            .addToData(data)
+            .withType("generic")
+            .withMetadata(buildMetadata())
+            .build();
+
+    client.secrets().inNamespace(namespaceName).createOrReplace(secret);
+  }
+
+  private ObjectMeta buildMetadata() {
+    return new ObjectMetaBuilder()
+        .withName("git-ssh-key")
+        .withLabels(
+            Map.of(
+                DEV_WORKSPACE_MOUNT_LABEL, "true",
+                DEV_WORKSPACE_WATCH_SECRET_LABEL, "true"))
+        .withAnnotations(Map.of(DEV_WORKSPACE_MOUNT_PATH_ANNOTATION, SSH_BASE_CONFIG_PATH))
+        .build();
+  }
+
+  /**
+   * Returns the ssh configuration entry which includes host, identity file location and Host Key
+   * checking policy
+   *
+   * <p>Example of provided configuration:
+   *
+   * <pre>
+   * host github.com
+   * IdentityFile /.ssh/private/github-com/private
+   * StrictHostKeyChecking = no
+   * </pre>
+   *
+   * or
+   *
+   * <pre>
+   * host *
+   * IdentityFile /.ssh/private/default-123456/private
+   * StrictHostKeyChecking = no
+   * </pre>
+   *
+   * @param name the of key given during generate for vcs service we will consider it as host of
+   *     version control service (e.g. github.com, gitlab.com and etc) if name starts from
+   *     "default-{anyString}" it will be replaced on wildcard "*" host name. Name with format
+   *     "default-{anyString}" will be generated on client side by Theia SSH Plugin, if user doesn't
+   *     provide own name. Details see here:
+   *     https://github.com/eclipse/che/issues/13494#issuecomment-512761661. Note: behavior can be
+   *     improved in 7.x releases after 7.0.0
+   * @return the ssh configuration which include host, identity file location and Host Key checking
+   *     policy
+   */
+  private String buildConfig(@NotNull String name) {
+    String host = name.startsWith("default-") ? "*" : name;
+    return "host "
+        + host
+        + "\nIdentityFile "
+        + SSH_PRIVATE_KEYS_PATH
+        + "/"
+        + name
+        + "\nStrictHostKeyChecking = no"
+        + "\n\n";
+  }
+}

--- a/infrastructures/kubernetes/src/test/java/org/eclipse/che/workspace/infrastructure/kubernetes/namespace/configurator/SshKeysConfiguratorTest.java
+++ b/infrastructures/kubernetes/src/test/java/org/eclipse/che/workspace/infrastructure/kubernetes/namespace/configurator/SshKeysConfiguratorTest.java
@@ -95,9 +95,9 @@ public class SshKeysConfiguratorTest {
         new String(Base64.getDecoder().decode(secrets.get(0).getData().get("github.com.pub"))),
         "public-key");
     assertEquals(
-        new String(Base64.getDecoder().decode(secrets.get(0).getData().get("config"))),
+        new String(Base64.getDecoder().decode(secrets.get(0).getData().get("ssh_config"))),
         "host github.com\n"
-            + "IdentityFile /.ssh/private/github.com\n"
+            + "IdentityFile /etc/ssh/github.com\n"
             + "StrictHostKeyChecking = no\n\n");
   }
 

--- a/infrastructures/kubernetes/src/test/java/org/eclipse/che/workspace/infrastructure/kubernetes/namespace/configurator/SshKeysConfiguratorTest.java
+++ b/infrastructures/kubernetes/src/test/java/org/eclipse/che/workspace/infrastructure/kubernetes/namespace/configurator/SshKeysConfiguratorTest.java
@@ -86,7 +86,7 @@ public class SshKeysConfiguratorTest {
             .list()
             .getItems();
     assertEquals(secrets.size(), 1);
-    assertEquals(secrets.get(0).getMetadata().getName(), "git-ssh-key");
+    assertEquals(secrets.get(0).getMetadata().getName(), "che-git-ssh-key");
     assertEquals(secrets.get(0).getData().size(), 3);
     assertEquals(
         new String(Base64.getDecoder().decode(secrets.get(0).getData().get("github.com"))),

--- a/infrastructures/kubernetes/src/test/java/org/eclipse/che/workspace/infrastructure/kubernetes/namespace/configurator/SshKeysConfiguratorTest.java
+++ b/infrastructures/kubernetes/src/test/java/org/eclipse/che/workspace/infrastructure/kubernetes/namespace/configurator/SshKeysConfiguratorTest.java
@@ -1,0 +1,123 @@
+/*
+ * Copyright (c) 2012-2021 Red Hat, Inc.
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+package org.eclipse.che.workspace.infrastructure.kubernetes.namespace.configurator;
+
+import static org.eclipse.che.workspace.infrastructure.kubernetes.Constants.DEV_WORKSPACE_MOUNT_LABEL;
+import static org.eclipse.che.workspace.infrastructure.kubernetes.Constants.DEV_WORKSPACE_WATCH_SECRET_LABEL;
+import static org.mockito.Mockito.when;
+import static org.testng.Assert.assertEquals;
+
+import io.fabric8.kubernetes.api.model.Secret;
+import io.fabric8.kubernetes.client.server.mock.KubernetesServer;
+import java.util.Base64;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import org.eclipse.che.api.core.NotFoundException;
+import org.eclipse.che.api.core.ServerException;
+import org.eclipse.che.api.ssh.server.SshManager;
+import org.eclipse.che.api.ssh.server.model.impl.SshPairImpl;
+import org.eclipse.che.api.workspace.server.spi.InfrastructureException;
+import org.eclipse.che.api.workspace.server.spi.NamespaceResolutionContext;
+import org.eclipse.che.workspace.infrastructure.kubernetes.KubernetesClientFactory;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.testng.MockitoTestNGListener;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Listeners;
+import org.testng.annotations.Test;
+
+@Listeners(MockitoTestNGListener.class)
+public class SshKeysConfiguratorTest {
+
+  private static final String USER_ID = "user-id";
+  private static final String USER_NAME = "user-name";
+  private static final String USER_NAMESPACE = "user-namespace";
+
+  @Mock private KubernetesClientFactory clientFactory;
+  @Mock private SshManager sshManager;
+
+  @InjectMocks private SshKeysConfigurator sshKeysConfigurator;
+
+  private KubernetesServer kubernetesServer;
+  private NamespaceResolutionContext context;
+
+  private final SshPairImpl sshPair =
+      new SshPairImpl(USER_ID, "vcs", "github.com", "public-key", "private-key");
+
+  @BeforeMethod
+  public void setUp() throws InfrastructureException, NotFoundException, ServerException {
+    context = new NamespaceResolutionContext(null, USER_ID, USER_NAME);
+    kubernetesServer = new KubernetesServer(true, true);
+    kubernetesServer.before();
+
+    when(sshManager.getPairs(USER_ID, "vcs")).thenReturn(Collections.singletonList(sshPair));
+    when(clientFactory.create()).thenReturn(kubernetesServer.getClient());
+  }
+
+  @AfterMethod
+  public void cleanUp() {
+    kubernetesServer.getClient().secrets().inNamespace(USER_NAMESPACE).delete();
+    kubernetesServer.after();
+  }
+
+  @Test
+  public void shouldCreateSSHKeysSecret() throws InfrastructureException {
+    sshKeysConfigurator.configure(context, USER_NAMESPACE);
+    List<Secret> secrets =
+        kubernetesServer
+            .getClient()
+            .secrets()
+            .inNamespace(USER_NAMESPACE)
+            .withLabels(
+                Map.of(
+                    DEV_WORKSPACE_MOUNT_LABEL, "true",
+                    DEV_WORKSPACE_WATCH_SECRET_LABEL, "true"))
+            .list()
+            .getItems();
+    assertEquals(secrets.size(), 1);
+    assertEquals(secrets.get(0).getMetadata().getName(), "git-ssh-key");
+    assertEquals(secrets.get(0).getData().size(), 3);
+    assertEquals(
+        new String(Base64.getDecoder().decode(secrets.get(0).getData().get("github.com"))),
+        "private-key");
+    assertEquals(
+        new String(Base64.getDecoder().decode(secrets.get(0).getData().get("github.com.pub"))),
+        "public-key");
+    assertEquals(
+        new String(Base64.getDecoder().decode(secrets.get(0).getData().get("config"))),
+        "host github.com\n"
+            + "IdentityFile /.ssh/private/github.com\n"
+            + "StrictHostKeyChecking = no\n\n");
+  }
+
+  @Test
+  public void shouldNotCreateSSHKeysSecretFromBadSecret() throws Exception {
+    SshPairImpl sshPairLocal =
+        new SshPairImpl(USER_ID, "vcs", "%sd$$$", "public-key", "private-key");
+    when(sshManager.getPairs(USER_ID, "vcs")).thenReturn(List.of(sshPairLocal));
+    sshKeysConfigurator.configure(context, USER_NAMESPACE);
+    List<Secret> secrets =
+        kubernetesServer
+            .getClient()
+            .secrets()
+            .inNamespace(USER_NAMESPACE)
+            .withLabels(
+                Map.of(
+                    DEV_WORKSPACE_MOUNT_LABEL, "true",
+                    DEV_WORKSPACE_WATCH_SECRET_LABEL, "true"))
+            .list()
+            .getItems();
+    assertEquals(secrets.size(), 0);
+  }
+}

--- a/infrastructures/openshift/src/main/java/org/eclipse/che/workspace/infrastructure/openshift/OpenShiftInfraModule.java
+++ b/infrastructures/openshift/src/main/java/org/eclipse/che/workspace/infrastructure/openshift/OpenShiftInfraModule.java
@@ -56,6 +56,7 @@ import org.eclipse.che.workspace.infrastructure.kubernetes.namespace.KubernetesN
 import org.eclipse.che.workspace.infrastructure.kubernetes.namespace.configurator.CredentialsSecretConfigurator;
 import org.eclipse.che.workspace.infrastructure.kubernetes.namespace.configurator.NamespaceConfigurator;
 import org.eclipse.che.workspace.infrastructure.kubernetes.namespace.configurator.PreferencesConfigMapConfigurator;
+import org.eclipse.che.workspace.infrastructure.kubernetes.namespace.configurator.SshKeysConfigurator;
 import org.eclipse.che.workspace.infrastructure.kubernetes.namespace.configurator.UserPreferencesConfigurator;
 import org.eclipse.che.workspace.infrastructure.kubernetes.namespace.configurator.UserProfileConfigurator;
 import org.eclipse.che.workspace.infrastructure.kubernetes.namespace.pvc.CommonPVCStrategy;
@@ -125,6 +126,7 @@ public class OpenShiftInfraModule extends AbstractModule {
     namespaceConfigurators.addBinding().to(PreferencesConfigMapConfigurator.class);
     namespaceConfigurators.addBinding().to(OpenShiftWorkspaceServiceAccountConfigurator.class);
     namespaceConfigurators.addBinding().to(OpenShiftStopWorkspaceRoleConfigurator.class);
+    namespaceConfigurators.addBinding().to(SshKeysConfigurator.class);
 
     bind(KubernetesNamespaceService.class);
 


### PR DESCRIPTION
Signed-off-by: Max Shaposhnik <mshaposh@redhat.com>

<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests
-->

### What does this PR do?
Added namespace configurator for mounting existing user SSH keys into namespace during provision

### Screenshot/screencast of this PR
Generated secret data will looks like:

![image](https://user-images.githubusercontent.com/1651062/145237346-87285c8b-8487-46e9-9dde-124905546e0f.png)


### What issues does this PR fix or reference?
[<!-- Please include any related issue from eclipse che repository (or from another issue tracker).
     Include link to other pull requests like documentation PR from [the docs repo](https://github.com/eclipse/che-docs)
-->](https://github.com/eclipse/che/issues/20832)
https://github.com/eclipse/che/issues/20832

### How to test this PR?
<!-- Please explain for example :
  - The test platform (openshift, kubernetes, minikube, CodeReady Container, docker-desktop, etc)
  - Installation method: chectl / che-operator
  - steps to reproduce
 -->
 - Deploy Che with devworkspaces enabled;
 - Add SSH key via Swagger API (since SSH plugin in Theia is disabled on DVW mode)
 - Remove user namespace and refresh dashboard to force namespace provision again
 - Check secret is created

### PR Checklist

[As the author of this Pull Request I made sure that:](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#pull-request-template-and-its-checklist)

- [x] [The Eclipse Contributor Agreement is valid](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-eclipse-contributor-agreement-is-valid)
- [x] [Code produced is complete](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-produced-is-complete)
- [x] [Code builds without errors](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-builds-without-errors)
- [x] [Tests are covering the bugfix](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#tests-are-covering-the-bugfix)
- [ ] [The repository devfile is up to date and works](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-repository-devfile-is-up-to-date-and-works)
- [ ] [Sections `What issues does this PR fix or reference` and `How to test this PR` completed](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#sections-what-issues-does-this-pr-fix-or-reference-and-how-to-test-this-pr-completed)
- [ ] [Relevant user documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [Relevant contributing documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [CI/CD changes implemented, documented and communicated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#cicd-changes-implemented-documented-and-communicated)

### Reviewers

Reviewers, please comment how you tested the PR when approving it.
