### PR TITLE
Fix behavior for unexisting files for public repositories

### DIFF
--- a/wsmaster/che-core-api-auth-github/src/main/java/org/eclipse/che/security/oauth/GitHubOAuthAuthenticatorProvider.java
+++ b/wsmaster/che-core-api-auth-github/src/main/java/org/eclipse/che/security/oauth/GitHubOAuthAuthenticatorProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012-2021 Red Hat, Inc.
+ * Copyright (c) 2012-2022 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/wsmaster/che-core-api-auth-github/src/main/java/org/eclipse/che/security/oauth/GitHubOAuthAuthenticatorProvider.java
+++ b/wsmaster/che-core-api-auth-github/src/main/java/org/eclipse/che/security/oauth/GitHubOAuthAuthenticatorProvider.java
@@ -70,8 +70,8 @@ public class GitHubOAuthAuthenticatorProvider implements Provider<OAuthAuthentic
         && !isNullOrEmpty(tokenUri)
         && Objects.nonNull(redirectUris)
         && redirectUris.length != 0) {
-      String clientId = Files.readString(Path.of(clientIdPath));
-      String clientSecret = Files.readString(Path.of(clientSecretPath));
+      final String clientId = Files.readString(Path.of(clientIdPath)).trim();
+      final String clientSecret = Files.readString(Path.of(clientSecretPath)).trim();
       if (!isNullOrEmpty(clientId) && !isNullOrEmpty(clientSecret)) {
         return new GitHubOAuthAuthenticator(
             clientId, clientSecret, redirectUris, authUri, tokenUri);

--- a/wsmaster/che-core-api-factory-github/src/main/java/org/eclipse/che/api/factory/server/github/GithubAuthorizingFileContentProvider.java
+++ b/wsmaster/che-core-api-factory-github/src/main/java/org/eclipse/che/api/factory/server/github/GithubAuthorizingFileContentProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012-2021 Red Hat, Inc.
+ * Copyright (c) 2012-2022 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/wsmaster/che-core-api-factory-github/src/main/java/org/eclipse/che/api/factory/server/github/GithubAuthorizingFileContentProvider.java
+++ b/wsmaster/che-core-api-factory-github/src/main/java/org/eclipse/che/api/factory/server/github/GithubAuthorizingFileContentProvider.java
@@ -11,6 +11,7 @@
  */
 package org.eclipse.che.api.factory.server.github;
 
+import java.io.IOException;
 import org.eclipse.che.api.factory.server.scm.AuthorizingFileContentProvider;
 import org.eclipse.che.api.factory.server.scm.GitCredentialManager;
 import org.eclipse.che.api.factory.server.scm.PersonalAccessTokenManager;
@@ -36,5 +37,20 @@ class GithubAuthorizingFileContentProvider extends AuthorizingFileContentProvide
   @Override
   protected String formatAuthorization(String token) {
     return "token " + token;
+  }
+
+  @Override
+  protected boolean isPublicRepository(GithubUrl remoteFactoryUrl) {
+    try {
+      urlFetcher.fetch(
+          GithubApiClient.GITHUB_API_SERVER
+              + "/repos/"
+              + remoteFactoryUrl.getUsername()
+              + "/"
+              + remoteFactoryUrl.getRepository());
+      return true;
+    } catch (IOException e) {
+      return false;
+    }
   }
 }

--- a/wsmaster/che-core-api-factory-github/src/test/java/org/eclipse/che/api/factory/server/github/GithubAuthorizingFileContentProviderTest.java
+++ b/wsmaster/che-core-api-factory-github/src/test/java/org/eclipse/che/api/factory/server/github/GithubAuthorizingFileContentProviderTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012-2021 Red Hat, Inc.
+ * Copyright (c) 2012-2022 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/wsmaster/che-core-api-factory-github/src/test/java/org/eclipse/che/api/factory/server/github/GithubAuthorizingFileContentProviderTest.java
+++ b/wsmaster/che-core-api-factory-github/src/test/java/org/eclipse/che/api/factory/server/github/GithubAuthorizingFileContentProviderTest.java
@@ -13,7 +13,9 @@ package org.eclipse.che.api.factory.server.github;
 
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
+import java.io.FileNotFoundException;
 import org.eclipse.che.api.factory.server.scm.GitCredentialManager;
 import org.eclipse.che.api.factory.server.scm.PersonalAccessTokenManager;
 import org.eclipse.che.api.workspace.server.devfile.FileContentProvider;
@@ -52,5 +54,18 @@ public class GithubAuthorizingFileContentProviderTest {
     String url = "https://raw.githubusercontent.com/foo/bar/devfile.yaml";
     fileContentProvider.fetchContent(url);
     verify(urlFetcher).fetch(eq(url));
+  }
+
+  @Test(expectedExceptions = FileNotFoundException.class)
+  public void shouldThrowNotFoundForPublicRepos() throws Exception {
+    URLFetcher urlFetcher = Mockito.mock(URLFetcher.class);
+    String url = "https://raw.githubusercontent.com/foo/bar/devfile.yaml";
+    when(urlFetcher.fetch(eq(url))).thenThrow(FileNotFoundException.class);
+    when(urlFetcher.fetch(eq("https://api.github.com/repos/eclipse/che"))).thenReturn("OK");
+    GithubUrl githubUrl = new GithubUrl().withUsername("eclipse").withRepository("che");
+    FileContentProvider fileContentProvider =
+        new GithubAuthorizingFileContentProvider(
+            githubUrl, urlFetcher, gitCredentialManager, personalAccessTokenManager);
+    fileContentProvider.fetchContent(url);
   }
 }

--- a/wsmaster/che-core-api-factory/src/main/java/org/eclipse/che/api/factory/server/scm/AuthorizingFileContentProvider.java
+++ b/wsmaster/che-core-api-factory/src/main/java/org/eclipse/che/api/factory/server/scm/AuthorizingFileContentProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012-2021 Red Hat, Inc.
+ * Copyright (c) 2012-2022 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/wsmaster/che-core-api-factory/src/main/java/org/eclipse/che/api/factory/server/scm/AuthorizingFileContentProvider.java
+++ b/wsmaster/che-core-api-factory/src/main/java/org/eclipse/che/api/factory/server/scm/AuthorizingFileContentProvider.java
@@ -11,6 +11,7 @@
  */
 package org.eclipse.che.api.factory.server.scm;
 
+import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.net.URI;
 import java.net.URISyntaxException;
@@ -35,9 +36,9 @@ public class AuthorizingFileContentProvider<T extends RemoteFactoryUrl>
     implements FileContentProvider {
 
   private final T remoteFactoryUrl;
-  private final URLFetcher urlFetcher;
   private final PersonalAccessTokenManager personalAccessTokenManager;
   private final GitCredentialManager gitCredentialManager;
+  protected final URLFetcher urlFetcher;
 
   public AuthorizingFileContentProvider(
       T remoteFactoryUrl,
@@ -74,6 +75,11 @@ public class AuthorizingFileContentProvider<T extends RemoteFactoryUrl>
                         "Failed to fetch a content from URL %s due to TLS key misconfiguration. Please refer to the docs about how to correctly import it. ",
                         requestURL));
             throw new DevfileException(exception.getMessage(), cause);
+          } else if (exception instanceof FileNotFoundException) {
+            if (isPublicRepository(remoteFactoryUrl)) {
+              // for public repo-s return 404 as-is
+              throw exception;
+            }
           }
           // unable to determine exact cause, so let's just try to authorize...
           try {
@@ -107,6 +113,10 @@ public class AuthorizingFileContentProvider<T extends RemoteFactoryUrl>
         | ScmCommunicationException e) {
       throw new DevfileException(e.getMessage(), e);
     }
+  }
+
+  protected boolean isPublicRepository(T remoteFactoryUrl) {
+    return false;
   }
 
   private String formatUrl(String fileURL) throws DevfileException {


### PR DESCRIPTION
Signed-off-by: Max Shaposhnik <mshaposh@redhat.com>

<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests
-->

### What does this PR do?
 - Added check for unexisting files if the're hosted in the public repo. In this case a `404` response returned instead of OAuth login request.
 
 - Fixed OAuth credentials reading from file 
### Screenshot/screencast of this PR
<!-- Please include a screenshot or a screencast explaining what is doing this PR -->


### What issues does this PR fix or reference?
<!-- Please include any related issue from eclipse che repository (or from another issue tracker).
     Include link to other pull requests like documentation PR from [the docs repo](https://github.com/eclipse/che-docs)
-->
https://github.com/eclipse/che/issues/20994
https://github.com/eclipse/che/issues/21014

### How to test this PR?
Setup Che, configure OAuth, create factory from public repo with devfile v2.0 but some missing files like 
`/.che/che-theia-plugins.yaml`. 401 was returned on this file previously, and factory failed. After fix 404 is returned, and
factory is launched successfully.


### PR Checklist

[As the author of this Pull Request I made sure that:](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#pull-request-template-and-its-checklist)

- [x] [The Eclipse Contributor Agreement is valid](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-eclipse-contributor-agreement-is-valid)
- [x] [Code produced is complete](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-produced-is-complete)
- [x] [Code builds without errors](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-builds-without-errors)
- [x] [Tests are covering the bugfix](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#tests-are-covering-the-bugfix)
- [x] [The repository devfile is up to date and works](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-repository-devfile-is-up-to-date-and-works)
- [x] [Sections `What issues does this PR fix or reference` and `How to test this PR` completed](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#sections-what-issues-does-this-pr-fix-or-reference-and-how-to-test-this-pr-completed)
- [ ] [Relevant user documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [Relevant contributing documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [CI/CD changes implemented, documented and communicated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#cicd-changes-implemented-documented-and-communicated)

### Reviewers

Reviewers, please comment how you tested the PR when approving it.
