### PR TITLE
fix: add new label to user-profile secret

### DIFF
--- a/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/namespace/configurator/UserProfileConfigurator.java
+++ b/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/namespace/configurator/UserProfileConfigurator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012-2021 Red Hat, Inc.
+ * Copyright (c) 2012-2022 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/
@@ -14,6 +14,7 @@ package org.eclipse.che.workspace.infrastructure.kubernetes.namespace.configurat
 import static org.eclipse.che.workspace.infrastructure.kubernetes.Constants.DEV_WORKSPACE_MOUNT_AS_ANNOTATION;
 import static org.eclipse.che.workspace.infrastructure.kubernetes.Constants.DEV_WORKSPACE_MOUNT_LABEL;
 import static org.eclipse.che.workspace.infrastructure.kubernetes.Constants.DEV_WORKSPACE_MOUNT_PATH_ANNOTATION;
+import static org.eclipse.che.workspace.infrastructure.kubernetes.Constants.DEV_WORKSPACE_WATCH_SECRET_LABEL;
 
 import io.fabric8.kubernetes.api.model.Secret;
 import io.fabric8.kubernetes.api.model.SecretBuilder;
@@ -90,6 +91,7 @@ public class UserProfileConfigurator implements NamespaceConfigurator {
         .withNewMetadata()
         .withName(USER_PROFILE_SECRET_NAME)
         .addToLabels(DEV_WORKSPACE_MOUNT_LABEL, "true")
+        .addToLabels(DEV_WORKSPACE_WATCH_SECRET_LABEL, "true")
         .addToAnnotations(DEV_WORKSPACE_MOUNT_AS_ANNOTATION, "file")
         .addToAnnotations(DEV_WORKSPACE_MOUNT_PATH_ANNOTATION, USER_PROFILE_SECRET_MOUNT_PATH)
         .endMetadata()

--- a/infrastructures/kubernetes/src/test/java/org/eclipse/che/workspace/infrastructure/kubernetes/namespace/configurator/UserProfileConfiguratorTest.java
+++ b/infrastructures/kubernetes/src/test/java/org/eclipse/che/workspace/infrastructure/kubernetes/namespace/configurator/UserProfileConfiguratorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012-2021 Red Hat, Inc.
+ * Copyright (c) 2012-2022 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/
@@ -13,11 +13,13 @@ package org.eclipse.che.workspace.infrastructure.kubernetes.namespace.configurat
 
 import static org.mockito.Mockito.when;
 import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertTrue;
 import static org.testng.Assert.fail;
 
 import io.fabric8.kubernetes.api.model.Secret;
 import io.fabric8.kubernetes.client.server.mock.KubernetesServer;
 import java.util.List;
+import java.util.Map;
 import org.eclipse.che.api.core.NotFoundException;
 import org.eclipse.che.api.core.ServerException;
 import org.eclipse.che.api.user.server.UserManager;
@@ -75,6 +77,15 @@ public class UserProfileConfiguratorTest {
         kubernetesServer.getClient().secrets().inNamespace(USER_NAMESPACE).list().getItems();
     assertEquals(secrets.size(), 1);
     assertEquals(secrets.get(0).getMetadata().getName(), "user-profile");
+
+    Map<String, String> labels = secrets.get(0).getMetadata().getLabels();
+    String expectedMountLabel = "controller.devfile.io/mount-to-devworkspace";
+    assertTrue(labels.containsKey(expectedMountLabel));
+    assertEquals(labels.get(expectedMountLabel), "true");
+
+    String expectedWatchLabel = "controller.devfile.io/watch-secret";
+    assertTrue(labels.containsKey(expectedWatchLabel));
+    assertEquals(labels.get(expectedWatchLabel), "true");
   }
 
   @Test(


### PR DESCRIPTION
Signed-off-by: David Kwon <dakwon@redhat.com>

<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests
-->

### What does this PR do?
Adds the `controller.devfile.io/watch-secret: 'true'` label to the `user-profile` secret. This new label is needed for mounting the secret: https://github.com/devfile/devworkspace-operator/blob/d24da237bee2d2e43ac1fcdee1df34a49f96f15b/docs/additional-configuration.md#automatically-mounting-volumes-configmaps-and-secrets


### Screenshot/screencast of this PR
<!-- Please include a screenshot or a screencast explaining what is doing this PR -->
![image](https://user-images.githubusercontent.com/83611742/152264777-a1f0b95d-e350-4c16-bf38-6e713e8ee812.png)


### What issues does this PR fix or reference?
<!-- Please include any related issue from eclipse che repository (or from another issue tracker).
     Include link to other pull requests like documentation PR from [the docs repo](https://github.com/eclipse/che-docs)
-->


### How to test this PR?
<!-- Please explain for example :
  - The test platform (openshift, kubernetes, minikube, CodeReady Container, docker-desktop, etc)
  - Installation method: chectl / che-operator
  - steps to reproduce
 -->

Tested on CRC:

1. Deploy Che with this image: [quay.io/dkwon17/che-server:watch-secret](quay.io/dkwon17/che-server:watch-secret)
2. When starting a new workspace with a new user, the newly created `user-profile` secret should have the `controller.devfile.io/watch-secret: 'true'` label 

### PR Checklist

[As the author of this Pull Request I made sure that:](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#pull-request-template-and-its-checklist)

- [x] [The Eclipse Contributor Agreement is valid](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-eclipse-contributor-agreement-is-valid)
- [x] [Code produced is complete](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-produced-is-complete)
- [x] [Code builds without errors](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-builds-without-errors)
- [x] [Tests are covering the bugfix](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#tests-are-covering-the-bugfix)
- [ ] [The repository devfile is up to date and works](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-repository-devfile-is-up-to-date-and-works)
- [ ] [Sections `What issues does this PR fix or reference` and `How to test this PR` completed](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#sections-what-issues-does-this-pr-fix-or-reference-and-how-to-test-this-pr-completed)
- [ ] [Relevant user documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [Relevant contributing documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [CI/CD changes implemented, documented and communicated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#cicd-changes-implemented-documented-and-communicated)

### Reviewers

Reviewers, please comment how you tested the PR when approving it.
