### PR TITLE
fix: always bind AdminPermissionInitializer regardless of the auth mode

### DIFF
--- a/assembly/assembly-wsmaster-war/src/main/java/org/eclipse/che/api/deploy/WsMasterModule.java
+++ b/assembly/assembly-wsmaster-war/src/main/java/org/eclipse/che/api/deploy/WsMasterModule.java
@@ -406,10 +406,10 @@ public class WsMasterModule extends AbstractModule {
     } else {
       install(new KeycloakModule());
       install(new KeycloakUserRemoverModule());
-      bind(AdminPermissionInitializer.class).asEagerSingleton();
       bind(RequestTokenExtractor.class).to(ChainedTokenExtractor.class);
     }
 
+    bind(AdminPermissionInitializer.class).asEagerSingleton();
     install(new MachineAuthModule());
 
     // User and profile - use profile from keycloak and other stuff is JPA


### PR DESCRIPTION
cherry-picking https://github.com/eclipse-che/che-server/pull/287 to 7.46.x