### PR TITLE
feat: Always try to use oAuth token when fetching git repositories

### DIFF
--- a/wsmaster/che-core-api-factory-bitbucket-server/src/test/java/org/eclipse/che/api/factory/server/bitbucket/BitbucketServerAuthorizingFileContentProviderTest.java
+++ b/wsmaster/che-core-api-factory-bitbucket-server/src/test/java/org/eclipse/che/api/factory/server/bitbucket/BitbucketServerAuthorizingFileContentProviderTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012-2021 Red Hat, Inc.
+ * Copyright (c) 2012-2022 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/
@@ -17,7 +17,6 @@ import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-import java.io.IOException;
 import java.util.Collections;
 import java.util.Optional;
 import org.eclipse.che.api.factory.server.scm.GitCredentialManager;
@@ -71,7 +70,6 @@ public class BitbucketServerAuthorizingFileContentProviderTest {
         .thenReturn(Optional.empty());
     when(personalAccessTokenManager.fetchAndSave(any(Subject.class), eq(TEST_HOSTNAME)))
         .thenReturn(token);
-    when(urlFetcher.fetch(anyString())).thenThrow(new IOException("unauthorized"));
 
     String fileURL = "https://foo.bar/scm/repo/.devfile";
 

--- a/wsmaster/che-core-api-factory-github/src/main/java/org/eclipse/che/api/factory/server/github/GithubPersonalAccessTokenFetcher.java
+++ b/wsmaster/che-core-api-factory-github/src/main/java/org/eclipse/che/api/factory/server/github/GithubPersonalAccessTokenFetcher.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012-2021 Red Hat, Inc.
+ * Copyright (c) 2012-2022 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/
@@ -33,6 +33,7 @@ import org.eclipse.che.api.factory.server.scm.exception.ScmBadRequestException;
 import org.eclipse.che.api.factory.server.scm.exception.ScmCommunicationException;
 import org.eclipse.che.api.factory.server.scm.exception.ScmItemNotFoundException;
 import org.eclipse.che.api.factory.server.scm.exception.ScmUnauthorizedException;
+import org.eclipse.che.api.factory.server.scm.exception.UnknownScmProviderException;
 import org.eclipse.che.commons.lang.NameGenerator;
 import org.eclipse.che.commons.subject.Subject;
 import org.eclipse.che.security.oauth.OAuthAPI;
@@ -135,7 +136,7 @@ public class GithubPersonalAccessTokenFetcher implements PersonalAccessTokenFetc
 
   @Override
   public PersonalAccessToken fetchPersonalAccessToken(Subject cheSubject, String scmServerUrl)
-      throws ScmUnauthorizedException, ScmCommunicationException {
+      throws ScmUnauthorizedException, ScmCommunicationException, UnknownScmProviderException {
     OAuthToken oAuthToken;
 
     if (githubApiClient == null || !githubApiClient.isConnected(scmServerUrl)) {
@@ -178,8 +179,9 @@ public class GithubPersonalAccessTokenFetcher implements PersonalAccessTokenFetc
           OAUTH_PROVIDER_NAME,
           "2.0",
           getLocalAuthenticateUrl());
-    } catch (NotFoundException
-        | ServerException
+    } catch (NotFoundException nfe) {
+      throw new UnknownScmProviderException(nfe.getMessage(), scmServerUrl);
+    } catch (ServerException
         | ForbiddenException
         | BadRequestException
         | ScmItemNotFoundException

--- a/wsmaster/che-core-api-factory-github/src/test/java/org/eclipse/che/api/factory/server/github/GithubScmFileResolverTest.java
+++ b/wsmaster/che-core-api-factory-github/src/test/java/org/eclipse/che/api/factory/server/github/GithubScmFileResolverTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012-2021 Red Hat, Inc.
+ * Copyright (c) 2012-2022 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/
@@ -11,11 +11,13 @@
  */
 package org.eclipse.che.api.factory.server.github;
 
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.when;
 import static org.testng.Assert.*;
 
 import org.eclipse.che.api.factory.server.scm.GitCredentialManager;
+import org.eclipse.che.api.factory.server.scm.PersonalAccessToken;
 import org.eclipse.che.api.factory.server.scm.PersonalAccessTokenManager;
 import org.eclipse.che.api.factory.server.urlfactory.DevfileFilenamesProvider;
 import org.eclipse.che.api.workspace.server.devfile.URLFetcher;
@@ -56,7 +58,7 @@ public class GithubScmFileResolverTest {
     assertFalse(githubScmFileResolver.accept("http://foobar.com"));
   }
 
-  /** Check Gitlab url will be be accepted by this resolver */
+  /** Check <GitHub> url will be be accepted by this resolver */
   @Test
   public void checkValidAcceptUrl() {
     // should be accepted
@@ -67,7 +69,10 @@ public class GithubScmFileResolverTest {
   public void shouldReturnContentFromUrlFetcher() throws Exception {
     final String rawContent = "raw_content";
     final String filename = "devfile.yaml";
-    when(urlFetcher.fetch(anyString())).thenReturn(rawContent);
+    when(urlFetcher.fetch(anyString(), anyString())).thenReturn(rawContent);
+    var personalAccessToken = new PersonalAccessToken("foo", "che", "my-token");
+    when(personalAccessTokenManager.fetchAndSave(any(), anyString()))
+        .thenReturn(personalAccessToken);
 
     String content = githubScmFileResolver.fileContent("http://github.com/test/repo.git", filename);
 

--- a/wsmaster/che-core-api-factory-gitlab/src/main/java/org/eclipse/che/api/factory/server/gitlab/GitlabOAuthTokenFetcher.java
+++ b/wsmaster/che-core-api-factory-gitlab/src/main/java/org/eclipse/che/api/factory/server/gitlab/GitlabOAuthTokenFetcher.java
@@ -37,6 +37,7 @@ import org.eclipse.che.api.factory.server.scm.exception.ScmBadRequestException;
 import org.eclipse.che.api.factory.server.scm.exception.ScmCommunicationException;
 import org.eclipse.che.api.factory.server.scm.exception.ScmItemNotFoundException;
 import org.eclipse.che.api.factory.server.scm.exception.ScmUnauthorizedException;
+import org.eclipse.che.api.factory.server.scm.exception.UnknownScmProviderException;
 import org.eclipse.che.commons.annotation.Nullable;
 import org.eclipse.che.commons.lang.NameGenerator;
 import org.eclipse.che.commons.lang.StringUtils;
@@ -87,7 +88,7 @@ public class GitlabOAuthTokenFetcher implements PersonalAccessTokenFetcher {
 
   @Override
   public PersonalAccessToken fetchPersonalAccessToken(Subject cheSubject, String scmServerUrl)
-      throws ScmUnauthorizedException, ScmCommunicationException {
+      throws ScmUnauthorizedException, ScmCommunicationException, UnknownScmProviderException {
     scmServerUrl = StringUtils.trimEnd(scmServerUrl, '/');
     GitlabApiClient gitlabApiClient = getApiClient(scmServerUrl);
     if (gitlabApiClient == null || !gitlabApiClient.isConnected(scmServerUrl)) {
@@ -130,8 +131,9 @@ public class GitlabOAuthTokenFetcher implements PersonalAccessTokenFetcher {
           OAUTH_PROVIDER_NAME,
           "2.0",
           getLocalAuthenticateUrl());
-    } catch (NotFoundException
-        | ServerException
+    } catch (NotFoundException nfe) {
+      throw new UnknownScmProviderException(nfe.getMessage(), scmServerUrl);
+    } catch (ServerException
         | ForbiddenException
         | BadRequestException
         | ScmItemNotFoundException

--- a/wsmaster/che-core-api-factory/src/main/java/org/eclipse/che/api/factory/server/scm/PersonalAccessTokenFetcher.java
+++ b/wsmaster/che-core-api-factory/src/main/java/org/eclipse/che/api/factory/server/scm/PersonalAccessTokenFetcher.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012-2021 Red Hat, Inc.
+ * Copyright (c) 2012-2022 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/
@@ -14,6 +14,7 @@ package org.eclipse.che.api.factory.server.scm;
 import java.util.Optional;
 import org.eclipse.che.api.factory.server.scm.exception.ScmCommunicationException;
 import org.eclipse.che.api.factory.server.scm.exception.ScmUnauthorizedException;
+import org.eclipse.che.api.factory.server.scm.exception.UnknownScmProviderException;
 import org.eclipse.che.commons.subject.Subject;
 
 public interface PersonalAccessTokenFetcher {
@@ -34,7 +35,7 @@ public interface PersonalAccessTokenFetcher {
    *     scm provider.
    */
   PersonalAccessToken fetchPersonalAccessToken(Subject cheUser, String scmServerUrl)
-      throws ScmUnauthorizedException, ScmCommunicationException;
+      throws ScmUnauthorizedException, ScmCommunicationException, UnknownScmProviderException;
 
   /**
    * Checks whether the provided personal access token is valid and has expected scope of


### PR DESCRIPTION
### What does this PR do?
Use secrets when fetching git data and initiate oAuth workflow if possible

Before, it was done only in case of private repositories
Now it will try on all public and private repositories
If there is no oAuth configured for the current SCM URL, try to fetch
with unauthenticated access



### Screenshot/screencast of this PR
<!-- Please include a screenshot or a screencast explaining what is doing this PR -->


### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/21346

### How to test this PR?
- Try to import a  public project without any oAuth provider: should work as before (like a github URL)
- Setup github oAuth for example and then try to import a public project. You'll check that oAuth dialog is prompted and then we have github personal access token

### PR Checklist

[As the author of this Pull Request I made sure that:](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#pull-request-template-and-its-checklist)

- [x] [The Eclipse Contributor Agreement is valid](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-eclipse-contributor-agreement-is-valid)
- [x] [Code produced is complete](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-produced-is-complete)
- [x] [Code builds without errors](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-builds-without-errors)
- [x] [Tests are covering the bugfix](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#tests-are-covering-the-bugfix)
- [x] [The repository devfile is up to date and works](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-repository-devfile-is-up-to-date-and-works)
- [x] [Sections `What issues does this PR fix or reference` and `How to test this PR` completed](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#sections-what-issues-does-this-pr-fix-or-reference-and-how-to-test-this-pr-completed)
- [x] [Relevant user documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [x] [Relevant contributing documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [x] [CI/CD changes implemented, documented and communicated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#cicd-changes-implemented-documented-and-communicated)

### Reviewers

Reviewers, please comment how you tested the PR when approving it.
