### PR TITLE
chore: Retrieve git user data from the user if no oAuth providers are registered

### DIFF
--- a/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/namespace/configurator/GitconfigUserDataConfigurator.java
+++ b/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/namespace/configurator/GitconfigUserDataConfigurator.java
@@ -20,12 +20,18 @@ import io.fabric8.kubernetes.api.model.ConfigMapBuilder;
 import java.util.Map;
 import java.util.Set;
 import javax.inject.Inject;
+import org.eclipse.che.api.core.NotFoundException;
+import org.eclipse.che.api.core.ServerException;
+import org.eclipse.che.api.core.model.user.User;
 import org.eclipse.che.api.factory.server.scm.GitUserData;
 import org.eclipse.che.api.factory.server.scm.GitUserDataFetcher;
 import org.eclipse.che.api.factory.server.scm.exception.ScmCommunicationException;
 import org.eclipse.che.api.factory.server.scm.exception.ScmUnauthorizedException;
+import org.eclipse.che.api.user.server.UserManager;
 import org.eclipse.che.api.workspace.server.spi.InfrastructureException;
 import org.eclipse.che.api.workspace.server.spi.NamespaceResolutionContext;
+import org.eclipse.che.commons.env.EnvironmentContext;
+import org.eclipse.che.commons.subject.Subject;
 import org.eclipse.che.workspace.infrastructure.kubernetes.KubernetesClientFactory;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -35,12 +41,16 @@ public class GitconfigUserDataConfigurator implements NamespaceConfigurator {
   private final KubernetesClientFactory clientFactory;
   private final Set<GitUserDataFetcher> gitUserDataFetchers;
   private static final String CONFIGMAP_DATA_KEY = "gitconfig";
+  private final UserManager userManager;
 
   @Inject
   public GitconfigUserDataConfigurator(
-      KubernetesClientFactory clientFactory, Set<GitUserDataFetcher> gitUserDataFetchers) {
+      KubernetesClientFactory clientFactory,
+      Set<GitUserDataFetcher> gitUserDataFetchers,
+      UserManager userManager) {
     this.clientFactory = clientFactory;
     this.gitUserDataFetchers = gitUserDataFetchers;
+    this.userManager = userManager;
   }
 
   @Override
@@ -69,6 +79,15 @@ public class GitconfigUserDataConfigurator implements NamespaceConfigurator {
             "true",
             "controller.devfile.io/watch-configmap",
             "true");
+    if (gitUserData == null) {
+      Subject cheSubject = EnvironmentContext.getCurrent().getSubject();
+      try {
+        User user = userManager.getById(cheSubject.getUserId());
+        gitUserData = new GitUserData(user.getName(), user.getEmail());
+      } catch (NotFoundException | ServerException e) {
+        LOG.error(e.getMessage());
+      }
+    }
     if (gitUserData != null
         && client
                 .configMaps()

--- a/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/namespace/configurator/GitconfigUserDataConfigurator.java
+++ b/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/namespace/configurator/GitconfigUserDataConfigurator.java
@@ -11,6 +11,7 @@
  */
 package org.eclipse.che.workspace.infrastructure.kubernetes.namespace.configurator;
 
+import static com.google.common.base.Strings.isNullOrEmpty;
 import static java.util.Collections.singletonMap;
 import static org.eclipse.che.workspace.infrastructure.kubernetes.namespace.AbstractWorkspaceServiceAccount.GIT_USERDATA_CONFIGMAP_NAME;
 
@@ -83,7 +84,9 @@ public class GitconfigUserDataConfigurator implements NamespaceConfigurator {
       Subject cheSubject = EnvironmentContext.getCurrent().getSubject();
       try {
         User user = userManager.getById(cheSubject.getUserId());
-        gitUserData = new GitUserData(user.getName(), user.getEmail());
+        if (!isNullOrEmpty(user.getName()) && !isNullOrEmpty(user.getEmail())) {
+          gitUserData = new GitUserData(user.getName(), user.getEmail());
+        }
       } catch (NotFoundException | ServerException e) {
         LOG.error(e.getMessage());
       }


### PR DESCRIPTION

Signed-off-by: Igor Vinokur <ivinokur@redhat.com>

<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests
-->

### What does this PR do?
There is `workspace-userdata-gitconfig-configmap` which mounts git user name and email from a registered oAuth provider. If no oAuth provider is registered get the user name and email from che user object.

### Screenshot/screencast of this PR
<!-- Please include a screenshot or a screencast explaining what is doing this PR -->


### What issues does this PR fix or reference?
<!-- Please include any related issue from eclipse che repository (or from another issue tracker).
     Include link to other pull requests like documentation PR from [the docs repo](https://github.com/eclipse/che-docs)
-->
fixes https://github.com/eclipse/che/issues/20937

### How to test this PR?
<!-- Please explain for example :
  - The test platform (openshift, kubernetes, minikube, CodeReady Container, docker-desktop, etc)
  - Installation method: chectl / che-operator
  - steps to reproduce
 -->
1. Deploy che to a cluster: `chectl server:deploy --platform=openshift -i=quay.io/ivinokur/che-server:next`
where `quay.io/ivinokur/che-server:next` is `che-server` image built from the PR.
3. Start any factory
4. Check that `workspace-userdata-gitconfig` configmap with che user name and email is created in the user namespace:

### PR Checklist

[As the author of this Pull Request I made sure that:](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#pull-request-template-and-its-checklist)

- [ ] [The Eclipse Contributor Agreement is valid](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-eclipse-contributor-agreement-is-valid)
- [ ] [Code produced is complete](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-produced-is-complete)
- [ ] [Code builds without errors](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-builds-without-errors)
- [ ] [Tests are covering the bugfix](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#tests-are-covering-the-bugfix)
- [ ] [The repository devfile is up to date and works](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-repository-devfile-is-up-to-date-and-works)
- [ ] [Sections `What issues does this PR fix or reference` and `How to test this PR` completed](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#sections-what-issues-does-this-pr-fix-or-reference-and-how-to-test-this-pr-completed)
- [ ] [Relevant user documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [Relevant contributing documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [CI/CD changes implemented, documented and communicated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#cicd-changes-implemented-documented-and-communicated)

### Reviewers

Reviewers, please comment how you tested the PR when approving it.
