### PR TITLE
chore: Add an ability to manually configure bitbucket oAuth token

### DIFF
--- a/infrastructures/infrastructure-factory/src/main/java/org/eclipse/che/api/factory/server/scm/kubernetes/KubernetesPersonalAccessTokenManager.java
+++ b/infrastructures/infrastructure-factory/src/main/java/org/eclipse/che/api/factory/server/scm/kubernetes/KubernetesPersonalAccessTokenManager.java
@@ -135,13 +135,6 @@ public class KubernetesPersonalAccessTokenManager implements PersonalAccessToken
       throws ScmConfigurationPersistenceException, ScmUnauthorizedException,
           ScmCommunicationException {
 
-    return get(cheUser, scmServerUrl, true);
-  }
-
-  @Override
-  public Optional<PersonalAccessToken> get(Subject cheUser, String scmServerUrl, boolean validate)
-      throws ScmConfigurationPersistenceException, ScmUnauthorizedException,
-          ScmCommunicationException {
     try {
       for (KubernetesNamespaceMeta namespaceMeta : namespaceFactory.list()) {
         List<Secret> secrets =
@@ -163,7 +156,7 @@ public class KubernetesPersonalAccessTokenManager implements PersonalAccessToken
                     annotations.get(ANNOTATION_SCM_PERSONAL_ACCESS_TOKEN_NAME),
                     annotations.get(ANNOTATION_SCM_PERSONAL_ACCESS_TOKEN_ID),
                     new String(Base64.getDecoder().decode(secret.getData().get("token"))));
-            if (!validate || scmPersonalAccessTokenFetcher.isValid(token)) {
+            if (scmPersonalAccessTokenFetcher.isValid(token)) {
               return Optional.of(token);
             } else {
               // Removing token that is no longer valid. If several tokens exist the next one could

--- a/infrastructures/infrastructure-factory/src/main/java/org/eclipse/che/api/factory/server/scm/kubernetes/KubernetesPersonalAccessTokenManager.java
+++ b/infrastructures/infrastructure-factory/src/main/java/org/eclipse/che/api/factory/server/scm/kubernetes/KubernetesPersonalAccessTokenManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012-2021 Red Hat, Inc.
+ * Copyright (c) 2012-2022 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/
@@ -135,6 +135,13 @@ public class KubernetesPersonalAccessTokenManager implements PersonalAccessToken
       throws ScmConfigurationPersistenceException, ScmUnauthorizedException,
           ScmCommunicationException {
 
+    return get(cheUser, scmServerUrl, true);
+  }
+
+  @Override
+  public Optional<PersonalAccessToken> get(Subject cheUser, String scmServerUrl, boolean validate)
+      throws ScmConfigurationPersistenceException, ScmUnauthorizedException,
+          ScmCommunicationException {
     try {
       for (KubernetesNamespaceMeta namespaceMeta : namespaceFactory.list()) {
         List<Secret> secrets =
@@ -156,7 +163,7 @@ public class KubernetesPersonalAccessTokenManager implements PersonalAccessToken
                     annotations.get(ANNOTATION_SCM_PERSONAL_ACCESS_TOKEN_NAME),
                     annotations.get(ANNOTATION_SCM_PERSONAL_ACCESS_TOKEN_ID),
                     new String(Base64.getDecoder().decode(secret.getData().get("token"))));
-            if (scmPersonalAccessTokenFetcher.isValid(token)) {
+            if (!validate || scmPersonalAccessTokenFetcher.isValid(token)) {
               return Optional.of(token);
             } else {
               // Removing token that is no longer valid. If several tokens exist the next one could

--- a/wsmaster/che-core-api-auth-bitbucket/src/main/java/org/eclipse/che/security/oauth1/NoopOAuthAuthenticator.java
+++ b/wsmaster/che-core-api-auth-bitbucket/src/main/java/org/eclipse/che/security/oauth1/NoopOAuthAuthenticator.java
@@ -49,6 +49,6 @@ public class NoopOAuthAuthenticator extends OAuthAuthenticator {
 
   @Override
   public String getLocalAuthenticateUrl() {
-    return "Empty URL";
+    return "Noop URL";
   }
 }

--- a/wsmaster/che-core-api-auth-bitbucket/src/main/java/org/eclipse/che/security/oauth1/NoopOAuthAuthenticator.java
+++ b/wsmaster/che-core-api-auth-bitbucket/src/main/java/org/eclipse/che/security/oauth1/NoopOAuthAuthenticator.java
@@ -15,7 +15,7 @@ import java.net.URL;
 
 /**
  * Dummy implementation of @{@link OAuthAuthenticator} used in the case if no Bitbucket Server
- * integration is configured.
+ * integration is configured to register an empty @{@link BitbucketServerApiClient}.
  */
 public class NoopOAuthAuthenticator extends OAuthAuthenticator {
   public NoopOAuthAuthenticator() {

--- a/wsmaster/che-core-api-auth-bitbucket/src/main/java/org/eclipse/che/security/oauth1/NoopOAuthAuthenticator.java
+++ b/wsmaster/che-core-api-auth-bitbucket/src/main/java/org/eclipse/che/security/oauth1/NoopOAuthAuthenticator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012-2021 Red Hat, Inc.
+ * Copyright (c) 2012-2022 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/
@@ -49,7 +49,6 @@ public class NoopOAuthAuthenticator extends OAuthAuthenticator {
 
   @Override
   public String getLocalAuthenticateUrl() {
-    throw new RuntimeException(
-        "The fallback noop authenticator cannot be used for authentication. Make sure OAuth is properly configured.");
+    return "Empty URL";
   }
 }

--- a/wsmaster/che-core-api-factory-bitbucket-server/src/main/java/org/eclipse/che/api/factory/server/bitbucket/BitbucketServerPersonalAccessTokenFetcher.java
+++ b/wsmaster/che-core-api-factory-bitbucket-server/src/main/java/org/eclipse/che/api/factory/server/bitbucket/BitbucketServerPersonalAccessTokenFetcher.java
@@ -107,20 +107,20 @@ public class BitbucketServerPersonalAccessTokenFetcher implements PersonalAccess
       throws ScmCommunicationException, ScmUnauthorizedException {
     if (!bitbucketServerApiClient.isConnected(personalAccessToken.getScmProviderUrl())) {
       // If BitBucket oAuth is not configured check the manually added user namespace token.
-      if (personalAccessToken.getScmTokenName().equals("bitbucket-server")) {
-        HttpBitbucketServerApiClient apiClient =
-            new HttpBitbucketServerApiClient(
-                personalAccessToken.getScmProviderUrl(), new NoopOAuthAuthenticator());
-        try {
-          apiClient.getUser(personalAccessToken.getScmUserName(), personalAccessToken.getToken());
-          return Optional.of(Boolean.TRUE);
-        } catch (ScmItemNotFoundException exception) {
-          // Even if the user not found, it means that the token is valid.
-          return Optional.of(Boolean.TRUE);
-        }
+      HttpBitbucketServerApiClient apiClient =
+          new HttpBitbucketServerApiClient(
+              personalAccessToken.getScmProviderUrl(), new NoopOAuthAuthenticator());
+      try {
+        apiClient.getUser(personalAccessToken.getScmUserName(), personalAccessToken.getToken());
+        return Optional.of(Boolean.TRUE);
+      } catch (ScmItemNotFoundException exception) {
+        // Even if the user not found, it means that the token is valid.
+        return Optional.of(Boolean.TRUE);
+      } catch (ScmUnauthorizedException | ScmCommunicationException exception) {
+        LOG.debug(
+            "not a valid url {} for current fetcher ", personalAccessToken.getScmProviderUrl());
+        return Optional.empty();
       }
-      LOG.debug("not a valid url {} for current fetcher ", personalAccessToken.getScmProviderUrl());
-      return Optional.empty();
     }
     try {
       BitbucketPersonalAccessToken bitbucketPersonalAccessToken =

--- a/wsmaster/che-core-api-factory-bitbucket-server/src/main/java/org/eclipse/che/api/factory/server/bitbucket/BitbucketServerPersonalAccessTokenFetcher.java
+++ b/wsmaster/che-core-api-factory-bitbucket-server/src/main/java/org/eclipse/che/api/factory/server/bitbucket/BitbucketServerPersonalAccessTokenFetcher.java
@@ -113,10 +113,9 @@ public class BitbucketServerPersonalAccessTokenFetcher implements PersonalAccess
       try {
         apiClient.getUser(personalAccessToken.getScmUserName(), personalAccessToken.getToken());
         return Optional.of(Boolean.TRUE);
-      } catch (ScmItemNotFoundException exception) {
-        // Even if the user not found, it means that the token is valid.
-        return Optional.of(Boolean.TRUE);
-      } catch (ScmUnauthorizedException | ScmCommunicationException exception) {
+      } catch (ScmItemNotFoundException
+          | ScmUnauthorizedException
+          | ScmCommunicationException exception) {
         LOG.debug(
             "not a valid url {} for current fetcher ", personalAccessToken.getScmProviderUrl());
         return Optional.empty();

--- a/wsmaster/che-core-api-factory-bitbucket-server/src/main/java/org/eclipse/che/api/factory/server/bitbucket/BitbucketServerPersonalAccessTokenFetcher.java
+++ b/wsmaster/che-core-api-factory-bitbucket-server/src/main/java/org/eclipse/che/api/factory/server/bitbucket/BitbucketServerPersonalAccessTokenFetcher.java
@@ -107,7 +107,8 @@ public class BitbucketServerPersonalAccessTokenFetcher implements PersonalAccess
   public Optional<Boolean> isValid(PersonalAccessToken personalAccessToken)
       throws ScmCommunicationException, ScmUnauthorizedException {
     // If BitBucket oAuth is not configured try to find a manually added user namespace token.
-    if (bitbucketServerApiClient instanceof NoopBitbucketServerApiClient) {
+    if (bitbucketServerApiClient instanceof NoopBitbucketServerApiClient
+        && personalAccessToken.getScmTokenName().equals("bitbucket-server")) {
       HttpBitbucketServerApiClient apiClient =
           new HttpBitbucketServerApiClient(
               personalAccessToken.getScmProviderUrl(), new NoopOAuthAuthenticator());

--- a/wsmaster/che-core-api-factory-bitbucket-server/src/main/java/org/eclipse/che/api/factory/server/bitbucket/BitbucketURLParser.java
+++ b/wsmaster/che-core-api-factory-bitbucket-server/src/main/java/org/eclipse/che/api/factory/server/bitbucket/BitbucketURLParser.java
@@ -63,7 +63,7 @@ public class BitbucketURLParser {
     }
   }
 
-  private boolean userTokenExists(String url) {
+  private boolean isUserTokenExists(String repositoryUrl) {
     String serverUrl = getServerUrl(url);
     if (Pattern.compile(format(bitbucketUrlPatternTemplate, serverUrl)).matcher(url).matches()) {
       try {

--- a/wsmaster/che-core-api-factory-bitbucket-server/src/main/java/org/eclipse/che/api/factory/server/bitbucket/BitbucketURLParser.java
+++ b/wsmaster/che-core-api-factory-bitbucket-server/src/main/java/org/eclipse/che/api/factory/server/bitbucket/BitbucketURLParser.java
@@ -69,17 +69,21 @@ public class BitbucketURLParser {
     } else {
       // If Bitbucket server URL is not configured try to find it in a manually added user namespace
       // token.
-      String trimmedUrl = url.substring(0, url.indexOf("/scm"));
-      try {
-        Optional<PersonalAccessToken> token =
-            personalAccessTokenManager.get(
-                EnvironmentContext.getCurrent().getSubject(), trimmedUrl);
-        return token.isPresent() && token.get().getScmProviderUrl().equals(trimmedUrl);
-      } catch (ScmConfigurationPersistenceException
-          | ScmUnauthorizedException
-          | ScmCommunicationException exception) {
-        return false;
+      String serverUrl =
+          url.substring(0, url.indexOf("/scm") > 0 ? url.indexOf("/scm") : url.length());
+      if (Pattern.compile(format(bitbucketUrlPatternTemplate, serverUrl)).matcher(url).matches()) {
+        try {
+          Optional<PersonalAccessToken> token =
+              personalAccessTokenManager.get(
+                  EnvironmentContext.getCurrent().getSubject(), serverUrl, false);
+          return token.isPresent() && token.get().getScmTokenName().equals("bitbucket-server");
+        } catch (ScmConfigurationPersistenceException
+            | ScmUnauthorizedException
+            | ScmCommunicationException exception) {
+          return false;
+        }
       }
+      return false;
     }
   }
 

--- a/wsmaster/che-core-api-factory-bitbucket-server/src/main/java/org/eclipse/che/api/factory/server/bitbucket/BitbucketURLParser.java
+++ b/wsmaster/che-core-api-factory-bitbucket-server/src/main/java/org/eclipse/che/api/factory/server/bitbucket/BitbucketURLParser.java
@@ -64,7 +64,7 @@ public class BitbucketURLParser {
     }
   }
 
-  private boolean isUserTokenExists(String repositoryUrl) {
+  private boolean isUserTokenPresent(String repositoryUrl) {
     String serverUrl = getServerUrl(repositoryUrl);
     if (Pattern.compile(format(bitbucketUrlPatternTemplate, serverUrl))
         .matcher(repositoryUrl)
@@ -88,7 +88,7 @@ public class BitbucketURLParser {
     } else {
       // If Bitbucket server URL is not configured try to find it in a manually added user namespace
       // token.
-      return isUserTokenExists(url);
+      return isUserTokenPresent(url);
     }
   }
 

--- a/wsmaster/che-core-api-factory-bitbucket-server/src/main/java/org/eclipse/che/api/factory/server/bitbucket/BitbucketURLParser.java
+++ b/wsmaster/che-core-api-factory-bitbucket-server/src/main/java/org/eclipse/che/api/factory/server/bitbucket/BitbucketURLParser.java
@@ -90,7 +90,7 @@ public class BitbucketURLParser {
     }
   }
 
-  private String getServerUrl(String url) {
+  private String getServerUrl(String repositoryUrl) {
     return url.substring(0, url.indexOf("/scm") > 0 ? url.indexOf("/scm") : url.length());
   }
 

--- a/wsmaster/che-core-api-factory-bitbucket-server/src/main/java/org/eclipse/che/api/factory/server/bitbucket/server/BitbucketServerApiClient.java
+++ b/wsmaster/che-core-api-factory-bitbucket-server/src/main/java/org/eclipse/che/api/factory/server/bitbucket/server/BitbucketServerApiClient.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012-2021 Red Hat, Inc.
+ * Copyright (c) 2012-2022 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/
@@ -17,6 +17,7 @@ import org.eclipse.che.api.factory.server.scm.exception.ScmBadRequestException;
 import org.eclipse.che.api.factory.server.scm.exception.ScmCommunicationException;
 import org.eclipse.che.api.factory.server.scm.exception.ScmItemNotFoundException;
 import org.eclipse.che.api.factory.server.scm.exception.ScmUnauthorizedException;
+import org.eclipse.che.commons.annotation.Nullable;
 import org.eclipse.che.commons.subject.Subject;
 
 /** Bitbucket Server API client. */
@@ -36,13 +37,14 @@ public interface BitbucketServerApiClient {
       throws ScmUnauthorizedException, ScmCommunicationException, ScmItemNotFoundException;
 
   /**
-   * @param slug
+   * @param slug scm username.
+   * @param token token to override. Pass {@code null} to use token from the authentication flow.
    * @return - Retrieve the {@link BitbucketUser} matching the supplied userSlug.
    * @throws ScmItemNotFoundException
    * @throws ScmUnauthorizedException
    * @throws ScmCommunicationException
    */
-  BitbucketUser getUser(String slug)
+  BitbucketUser getUser(String slug, @Nullable String token)
       throws ScmItemNotFoundException, ScmUnauthorizedException, ScmCommunicationException;
 
   /**

--- a/wsmaster/che-core-api-factory-bitbucket-server/src/main/java/org/eclipse/che/api/factory/server/bitbucket/server/HttpBitbucketServerApiClient.java
+++ b/wsmaster/che-core-api-factory-bitbucket-server/src/main/java/org/eclipse/che/api/factory/server/bitbucket/server/HttpBitbucketServerApiClient.java
@@ -46,6 +46,7 @@ import org.eclipse.che.api.factory.server.scm.exception.ScmBadRequestException;
 import org.eclipse.che.api.factory.server.scm.exception.ScmCommunicationException;
 import org.eclipse.che.api.factory.server.scm.exception.ScmItemNotFoundException;
 import org.eclipse.che.api.factory.server.scm.exception.ScmUnauthorizedException;
+import org.eclipse.che.commons.annotation.Nullable;
 import org.eclipse.che.commons.env.EnvironmentContext;
 import org.eclipse.che.commons.lang.concurrent.LoggingUncaughtExceptionHandler;
 import org.eclipse.che.commons.subject.Subject;
@@ -128,12 +129,16 @@ public class HttpBitbucketServerApiClient implements BitbucketServerApiClient {
   }
 
   @Override
-  public BitbucketUser getUser(String slug)
+  public BitbucketUser getUser(String slug, @Nullable String token)
       throws ScmItemNotFoundException, ScmUnauthorizedException, ScmCommunicationException {
     URI uri = serverUri.resolve("/rest/api/1.0/users/" + slug);
     HttpRequest request =
         HttpRequest.newBuilder(uri)
-            .headers("Authorization", computeAuthorizationHeader("GET", uri.toString()))
+            .headers(
+                "Authorization",
+                token != null
+                    ? "Bearer " + token
+                    : computeAuthorizationHeader("GET", uri.toString()))
             .timeout(DEFAULT_HTTP_TIMEOUT)
             .build();
 
@@ -308,7 +313,7 @@ public class HttpBitbucketServerApiClient implements BitbucketServerApiClient {
       throws ScmCommunicationException, ScmUnauthorizedException, ScmItemNotFoundException {
 
     for (String userSlug : userSlugs) {
-      BitbucketUser user = getUser(userSlug);
+      BitbucketUser user = getUser(userSlug, null);
       try {
         getPersonalAccessTokens(userSlug);
         return Optional.of(user);

--- a/wsmaster/che-core-api-factory-bitbucket-server/src/main/java/org/eclipse/che/api/factory/server/bitbucket/server/NoopBitbucketServerApiClient.java
+++ b/wsmaster/che-core-api-factory-bitbucket-server/src/main/java/org/eclipse/che/api/factory/server/bitbucket/server/NoopBitbucketServerApiClient.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012-2021 Red Hat, Inc.
+ * Copyright (c) 2012-2022 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/
@@ -17,6 +17,7 @@ import org.eclipse.che.api.factory.server.scm.exception.ScmBadRequestException;
 import org.eclipse.che.api.factory.server.scm.exception.ScmCommunicationException;
 import org.eclipse.che.api.factory.server.scm.exception.ScmItemNotFoundException;
 import org.eclipse.che.api.factory.server.scm.exception.ScmUnauthorizedException;
+import org.eclipse.che.commons.annotation.Nullable;
 import org.eclipse.che.commons.subject.Subject;
 
 /**
@@ -37,7 +38,7 @@ public class NoopBitbucketServerApiClient implements BitbucketServerApiClient {
   }
 
   @Override
-  public BitbucketUser getUser(String slug)
+  public BitbucketUser getUser(String slug, @Nullable String token)
       throws ScmItemNotFoundException, ScmUnauthorizedException, ScmCommunicationException {
     throw new RuntimeException(
         "The fallback noop api client cannot be used for real operation. Make sure Bitbucket OAuth1 is properly configured.");

--- a/wsmaster/che-core-api-factory-bitbucket-server/src/test/java/org/eclipse/che/api/factory/server/bitbucket/BitbucketServerAuthorizingFactoryParametersResolverTest.java
+++ b/wsmaster/che-core-api-factory-bitbucket-server/src/test/java/org/eclipse/che/api/factory/server/bitbucket/BitbucketServerAuthorizingFactoryParametersResolverTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012-2021 Red Hat, Inc.
+ * Copyright (c) 2012-2022 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/
@@ -19,6 +19,7 @@ import static org.eclipse.che.dto.server.DtoFactory.newDto;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyMap;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.testng.Assert.assertEquals;
@@ -68,7 +69,10 @@ public class BitbucketServerAuthorizingFactoryParametersResolverTest {
   @BeforeMethod
   protected void init() {
     bitbucketURLParser =
-        new BitbucketURLParser("http://bitbucket.2mcl.com", devfileFilenamesProvider);
+        new BitbucketURLParser(
+            "http://bitbucket.2mcl.com",
+            devfileFilenamesProvider,
+            mock(PersonalAccessTokenManager.class));
     assertNotNull(this.bitbucketURLParser);
     bitbucketServerFactoryParametersResolver =
         new BitbucketServerAuthorizingFactoryParametersResolver(

--- a/wsmaster/che-core-api-factory-bitbucket-server/src/test/java/org/eclipse/che/api/factory/server/bitbucket/BitbucketServerPersonalAccessTokenFetcherTest.java
+++ b/wsmaster/che-core-api-factory-bitbucket-server/src/test/java/org/eclipse/che/api/factory/server/bitbucket/BitbucketServerPersonalAccessTokenFetcherTest.java
@@ -190,7 +190,6 @@ public class BitbucketServerPersonalAccessTokenFetcherTest {
       throws ScmUnauthorizedException, ScmCommunicationException {
     // given
     when(personalAccessToken.getScmProviderUrl()).thenReturn(someNotBitbucketURL);
-    when(personalAccessToken.getScmTokenName()).thenReturn("unknown");
     when(bitbucketServerApiClient.isConnected(eq(someNotBitbucketURL))).thenReturn(false);
     // when
     Optional<Boolean> result = fetcher.isValid(personalAccessToken);

--- a/wsmaster/che-core-api-factory-bitbucket-server/src/test/java/org/eclipse/che/api/factory/server/bitbucket/BitbucketServerPersonalAccessTokenFetcherTest.java
+++ b/wsmaster/che-core-api-factory-bitbucket-server/src/test/java/org/eclipse/che/api/factory/server/bitbucket/BitbucketServerPersonalAccessTokenFetcherTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012-2021 Red Hat, Inc.
+ * Copyright (c) 2012-2022 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/
@@ -190,6 +190,7 @@ public class BitbucketServerPersonalAccessTokenFetcherTest {
       throws ScmUnauthorizedException, ScmCommunicationException {
     // given
     when(personalAccessToken.getScmProviderUrl()).thenReturn(someNotBitbucketURL);
+    when(personalAccessToken.getScmTokenName()).thenReturn("unknown");
     when(bitbucketServerApiClient.isConnected(eq(someNotBitbucketURL))).thenReturn(false);
     // when
     Optional<Boolean> result = fetcher.isValid(personalAccessToken);

--- a/wsmaster/che-core-api-factory-bitbucket-server/src/test/java/org/eclipse/che/api/factory/server/bitbucket/BitbucketServerScmFileResolverTest.java
+++ b/wsmaster/che-core-api-factory-bitbucket-server/src/test/java/org/eclipse/che/api/factory/server/bitbucket/BitbucketServerScmFileResolverTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012-2021 Red Hat, Inc.
+ * Copyright (c) 2012-2022 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/
@@ -14,6 +14,7 @@ package org.eclipse.che.api.factory.server.bitbucket;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 import static org.testng.Assert.*;
 
@@ -47,7 +48,9 @@ public class BitbucketServerScmFileResolverTest {
 
   @BeforeMethod
   protected void init() {
-    bitbucketURLParser = new BitbucketURLParser(SCM_URL, devfileFilenamesProvider);
+    bitbucketURLParser =
+        new BitbucketURLParser(
+            SCM_URL, devfileFilenamesProvider, mock(PersonalAccessTokenManager.class));
     assertNotNull(this.bitbucketURLParser);
     serverScmFileResolver =
         new BitbucketServerScmFileResolver(

--- a/wsmaster/che-core-api-factory-bitbucket-server/src/test/java/org/eclipse/che/api/factory/server/bitbucket/BitbucketURLParserTest.java
+++ b/wsmaster/che-core-api-factory-bitbucket-server/src/test/java/org/eclipse/che/api/factory/server/bitbucket/BitbucketURLParserTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012-2021 Red Hat, Inc.
+ * Copyright (c) 2012-2022 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/
@@ -11,9 +11,11 @@
  */
 package org.eclipse.che.api.factory.server.bitbucket;
 
+import static org.mockito.Mockito.mock;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertTrue;
 
+import org.eclipse.che.api.factory.server.scm.PersonalAccessTokenManager;
 import org.eclipse.che.api.factory.server.urlfactory.DevfileFilenamesProvider;
 import org.mockito.Mock;
 import org.mockito.testng.MockitoTestNGListener;
@@ -34,7 +36,9 @@ public class BitbucketURLParserTest {
   public void setUp() {
     bitbucketURLParser =
         new BitbucketURLParser(
-            "https://bitbucket.2mcl.com,https://bbkt.com", devfileFilenamesProvider);
+            "https://bitbucket.2mcl.com,https://bbkt.com",
+            devfileFilenamesProvider,
+            mock(PersonalAccessTokenManager.class));
   }
 
   /** Check URLs are valid with regexp */

--- a/wsmaster/che-core-api-factory-bitbucket-server/src/test/java/org/eclipse/che/api/factory/server/bitbucket/HttpBitbucketServerApiClientTest.java
+++ b/wsmaster/che-core-api-factory-bitbucket-server/src/test/java/org/eclipse/che/api/factory/server/bitbucket/HttpBitbucketServerApiClientTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012-2021 Red Hat, Inc.
+ * Copyright (c) 2012-2022 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/
@@ -95,7 +95,7 @@ public class HttpBitbucketServerApiClientTest {
                     .withHeader("Content-Type", "application/json; charset=utf-8")
                     .withBodyFile("bitbucket/rest/api/1.0/users/ksmster/response.json")));
 
-    BitbucketUser user = bitbucketServer.getUser("ksmster");
+    BitbucketUser user = bitbucketServer.getUser("ksmster", null);
     assertNotNull(user);
   }
 

--- a/wsmaster/che-core-api-factory-gitlab/src/main/java/org/eclipse/che/api/factory/server/gitlab/GitlabOAuthTokenFetcher.java
+++ b/wsmaster/che-core-api-factory-gitlab/src/main/java/org/eclipse/che/api/factory/server/gitlab/GitlabOAuthTokenFetcher.java
@@ -149,9 +149,13 @@ public class GitlabOAuthTokenFetcher implements PersonalAccessTokenFetcher {
     GitlabApiClient gitlabApiClient = getApiClient(personalAccessToken.getScmProviderUrl());
     if (gitlabApiClient == null
         || !gitlabApiClient.isConnected(personalAccessToken.getScmProviderUrl())) {
-      LOG.debug(
-          "not a  valid url {} for current fetcher ", personalAccessToken.getScmProviderUrl());
-      return Optional.empty();
+      if (personalAccessToken.getScmTokenName().equals("gitlab")) {
+        gitlabApiClient = new GitlabApiClient(personalAccessToken.getScmProviderUrl());
+      } else {
+        LOG.debug(
+            "not a  valid url {} for current fetcher ", personalAccessToken.getScmProviderUrl());
+        return Optional.empty();
+      }
     }
     if (personalAccessToken.getScmTokenName() != null
         && personalAccessToken.getScmTokenName().startsWith(OAUTH_2_PREFIX)) {

--- a/wsmaster/che-core-api-factory-gitlab/src/main/java/org/eclipse/che/api/factory/server/gitlab/GitlabOAuthTokenFetcher.java
+++ b/wsmaster/che-core-api-factory-gitlab/src/main/java/org/eclipse/che/api/factory/server/gitlab/GitlabOAuthTokenFetcher.java
@@ -149,7 +149,7 @@ public class GitlabOAuthTokenFetcher implements PersonalAccessTokenFetcher {
     GitlabApiClient gitlabApiClient = getApiClient(personalAccessToken.getScmProviderUrl());
     if (gitlabApiClient == null
         || !gitlabApiClient.isConnected(personalAccessToken.getScmProviderUrl())) {
-      if (personalAccessToken.getScmTokenName().equals("gitlab")) {
+      if (personalAccessToken.getScmTokenName().equals(OAUTH_PROVIDER_NAME)) {
         gitlabApiClient = new GitlabApiClient(personalAccessToken.getScmProviderUrl());
       } else {
         LOG.debug(

--- a/wsmaster/che-core-api-factory-gitlab/src/main/java/org/eclipse/che/api/factory/server/gitlab/GitlabUrlParser.java
+++ b/wsmaster/che-core-api-factory-gitlab/src/main/java/org/eclipse/che/api/factory/server/gitlab/GitlabUrlParser.java
@@ -68,7 +68,7 @@ public class GitlabUrlParser {
     }
   }
 
-  private boolean isUserTokenExists(String repositoryUrl) {
+  private boolean isUserTokenPresent(String repositoryUrl) {
     Optional<String> serverUrlOptional = getServerUrl(repositoryUrl);
     if (serverUrlOptional.isPresent()) {
       String serverUrl = serverUrlOptional.get();
@@ -94,7 +94,7 @@ public class GitlabUrlParser {
     } else {
       // If Gitlab URL is not configured, try to find it in a manually added user namespace
       // token.
-      return isUserTokenExists(url);
+      return isUserTokenPresent(url);
     }
   }
 

--- a/wsmaster/che-core-api-factory-gitlab/src/main/java/org/eclipse/che/api/factory/server/gitlab/GitlabUrlParser.java
+++ b/wsmaster/che-core-api-factory-gitlab/src/main/java/org/eclipse/che/api/factory/server/gitlab/GitlabUrlParser.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012-2021 Red Hat, Inc.
+ * Copyright (c) 2012-2022 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/
@@ -17,12 +17,19 @@ import com.google.common.base.Splitter;
 import jakarta.validation.constraints.NotNull;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import javax.inject.Inject;
 import javax.inject.Named;
+import org.eclipse.che.api.factory.server.scm.PersonalAccessToken;
+import org.eclipse.che.api.factory.server.scm.PersonalAccessTokenManager;
+import org.eclipse.che.api.factory.server.scm.exception.ScmCommunicationException;
+import org.eclipse.che.api.factory.server.scm.exception.ScmConfigurationPersistenceException;
+import org.eclipse.che.api.factory.server.scm.exception.ScmUnauthorizedException;
 import org.eclipse.che.api.factory.server.urlfactory.DevfileFilenamesProvider;
 import org.eclipse.che.commons.annotation.Nullable;
+import org.eclipse.che.commons.env.EnvironmentContext;
 import org.eclipse.che.commons.lang.StringUtils;
 
 /**
@@ -33,6 +40,7 @@ import org.eclipse.che.commons.lang.StringUtils;
 public class GitlabUrlParser {
 
   private final DevfileFilenamesProvider devfileFilenamesProvider;
+  private final PersonalAccessTokenManager personalAccessTokenManager;
   private static final List<String> gitlabUrlPatternTemplates =
       List.of(
           "^(?<host>%s)/(?<user>[^/]++)/(?<project>[^./]++).git",
@@ -44,8 +52,10 @@ public class GitlabUrlParser {
   @Inject
   public GitlabUrlParser(
       @Nullable @Named("che.integration.gitlab.server_endpoints") String bitbucketEndpoints,
-      DevfileFilenamesProvider devfileFilenamesProvider) {
+      DevfileFilenamesProvider devfileFilenamesProvider,
+      PersonalAccessTokenManager personalAccessTokenManager) {
     this.devfileFilenamesProvider = devfileFilenamesProvider;
+    this.personalAccessTokenManager = personalAccessTokenManager;
     if (bitbucketEndpoints != null) {
       for (String bitbucketEndpoint : Splitter.on(",").split(bitbucketEndpoints)) {
         String trimmedEndpoint = StringUtils.trimEnd(bitbucketEndpoint, '/');
@@ -58,8 +68,30 @@ public class GitlabUrlParser {
   }
 
   public boolean isValid(@NotNull String url) {
-    return !gitlabUrlPatterns.isEmpty()
-        && gitlabUrlPatterns.stream().anyMatch(pattern -> pattern.matcher(url).matches());
+    if (!gitlabUrlPatterns.isEmpty()) {
+      return gitlabUrlPatterns.stream().anyMatch(pattern -> pattern.matcher(url).matches());
+    } else {
+      // If Gitlab URL is not configured, try to find it in a manually added user namespace
+      // token.
+      Matcher matcher = Pattern.compile("[^/|:]/").matcher(url);
+      if (matcher.find()) {
+        String serverUrl = url.substring(0, url.indexOf(matcher.group()) + 1);
+        try {
+          Optional<PersonalAccessToken> token =
+              personalAccessTokenManager.get(
+                  EnvironmentContext.getCurrent().getSubject(), serverUrl, false);
+          if (token.isPresent()) {
+            PersonalAccessToken accessToken = token.get();
+            return accessToken.getScmTokenName().equals("gitlab");
+          }
+        } catch (ScmConfigurationPersistenceException
+            | ScmUnauthorizedException
+            | ScmCommunicationException exception) {
+          return false;
+        }
+      }
+    }
+    return false;
   }
 
   /**
@@ -69,6 +101,20 @@ public class GitlabUrlParser {
   public GitlabUrl parse(String url) {
 
     if (gitlabUrlPatterns.isEmpty()) {
+      String trimmedEndpoint = StringUtils.trimEnd(url, '/');
+      Matcher matcher = Pattern.compile("[^/|:]/").matcher(url);
+      if (matcher.find()) {
+        String serverUrl =
+            trimmedEndpoint.substring(0, trimmedEndpoint.indexOf(matcher.group()) + 1);
+        Optional<Matcher> optional =
+            gitlabUrlPatternTemplates.stream()
+                .map(t -> Pattern.compile(format(t, serverUrl)).matcher(url))
+                .filter(Matcher::matches)
+                .findAny();
+        if (optional.isPresent()) {
+          return parse(optional.get());
+        }
+      }
       throw new UnsupportedOperationException(
           "The gitlab integration is not configured properly and cannot be used at this moment."
               + "Please refer to docs to check the Gitlab integration instructions");
@@ -85,6 +131,10 @@ public class GitlabUrlParser {
                         format(
                             "The given url %s is not a valid Gitlab server URL. Check either URL or server configuration.",
                             url)));
+    return parse(matcher);
+  }
+
+  private GitlabUrl parse(Matcher matcher) {
     String host = matcher.group("host");
     String userName = matcher.group("user");
     String project = matcher.group("project");

--- a/wsmaster/che-core-api-factory-gitlab/src/test/java/org/eclipse/che/api/factory/server/gitlab/GitlabFactoryParametersResolverTest.java
+++ b/wsmaster/che-core-api-factory-gitlab/src/test/java/org/eclipse/che/api/factory/server/gitlab/GitlabFactoryParametersResolverTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012-2021 Red Hat, Inc.
+ * Copyright (c) 2012-2022 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/
@@ -19,6 +19,7 @@ import static org.eclipse.che.dto.server.DtoFactory.newDto;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyMap;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.testng.Assert.assertEquals;
@@ -71,7 +72,11 @@ public class GitlabFactoryParametersResolverTest {
 
   @BeforeMethod
   protected void init() {
-    gitlabUrlParser = new GitlabUrlParser("http://gitlab.2mcl.com", devfileFilenamesProvider);
+    gitlabUrlParser =
+        new GitlabUrlParser(
+            "http://gitlab.2mcl.com",
+            devfileFilenamesProvider,
+            mock(PersonalAccessTokenManager.class));
     assertNotNull(this.gitlabUrlParser);
     gitlabFactoryParametersResolver =
         new GitlabFactoryParametersResolver(

--- a/wsmaster/che-core-api-factory-gitlab/src/test/java/org/eclipse/che/api/factory/server/gitlab/GitlabScmFileResolverTest.java
+++ b/wsmaster/che-core-api-factory-gitlab/src/test/java/org/eclipse/che/api/factory/server/gitlab/GitlabScmFileResolverTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012-2021 Red Hat, Inc.
+ * Copyright (c) 2012-2022 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/
@@ -14,6 +14,7 @@ package org.eclipse.che.api.factory.server.gitlab;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 import static org.testng.Assert.*;
 
@@ -47,7 +48,9 @@ public class GitlabScmFileResolverTest {
 
   @BeforeMethod
   protected void init() {
-    gitlabUrlParser = new GitlabUrlParser(SCM_URL, devfileFilenamesProvider);
+    gitlabUrlParser =
+        new GitlabUrlParser(
+            SCM_URL, devfileFilenamesProvider, mock(PersonalAccessTokenManager.class));
     assertNotNull(this.gitlabUrlParser);
     gitlabScmFileResolver =
         new GitlabScmFileResolver(

--- a/wsmaster/che-core-api-factory-gitlab/src/test/java/org/eclipse/che/api/factory/server/gitlab/GitlabUrlParserTest.java
+++ b/wsmaster/che-core-api-factory-gitlab/src/test/java/org/eclipse/che/api/factory/server/gitlab/GitlabUrlParserTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012-2021 Red Hat, Inc.
+ * Copyright (c) 2012-2022 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/
@@ -11,9 +11,11 @@
  */
 package org.eclipse.che.api.factory.server.gitlab;
 
+import static org.mockito.Mockito.mock;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertTrue;
 
+import org.eclipse.che.api.factory.server.scm.PersonalAccessTokenManager;
 import org.eclipse.che.api.factory.server.urlfactory.DevfileFilenamesProvider;
 import org.mockito.Mock;
 import org.mockito.testng.MockitoTestNGListener;
@@ -33,7 +35,10 @@ public class GitlabUrlParserTest {
   @BeforeMethod
   public void setUp() {
     gitlabUrlParser =
-        new GitlabUrlParser("https://gitlab1.com,https://gitlab.foo.xxx", devfileFilenamesProvider);
+        new GitlabUrlParser(
+            "https://gitlab1.com,https://gitlab.foo.xxx",
+            devfileFilenamesProvider,
+            mock(PersonalAccessTokenManager.class));
   }
 
   /** Check URLs are valid with regexp */

--- a/wsmaster/che-core-api-factory-gitlab/src/test/java/org/eclipse/che/api/factory/server/gitlab/GitlabUrlTest.java
+++ b/wsmaster/che-core-api-factory-gitlab/src/test/java/org/eclipse/che/api/factory/server/gitlab/GitlabUrlTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012-2021 Red Hat, Inc.
+ * Copyright (c) 2012-2022 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/
@@ -13,11 +13,13 @@ package org.eclipse.che.api.factory.server.gitlab;
 
 import static java.lang.String.format;
 import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 import static org.testng.Assert.assertEquals;
 
 import java.util.Arrays;
 import java.util.Iterator;
+import org.eclipse.che.api.factory.server.scm.PersonalAccessTokenManager;
 import org.eclipse.che.api.factory.server.urlfactory.DevfileFilenamesProvider;
 import org.eclipse.che.api.factory.server.urlfactory.RemoteFactoryUrl.DevfileLocation;
 import org.mockito.Mock;
@@ -45,7 +47,9 @@ public class GitlabUrlTest {
   protected void init() {
     when(devfileFilenamesProvider.getConfiguredDevfileFilenames())
         .thenReturn(Arrays.asList("devfile.yaml", "foo.bar"));
-    gitlabUrlParser = new GitlabUrlParser("https://gitlab.net", devfileFilenamesProvider);
+    gitlabUrlParser =
+        new GitlabUrlParser(
+            "https://gitlab.net", devfileFilenamesProvider, mock(PersonalAccessTokenManager.class));
   }
 
   /** Check when there is devfile in the repository */

--- a/wsmaster/che-core-api-factory/src/main/java/org/eclipse/che/api/factory/server/scm/PersonalAccessTokenManager.java
+++ b/wsmaster/che-core-api-factory/src/main/java/org/eclipse/che/api/factory/server/scm/PersonalAccessTokenManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012-2021 Red Hat, Inc.
+ * Copyright (c) 2012-2022 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/
@@ -49,6 +49,20 @@ public interface PersonalAccessTokenManager {
    *     permanent storage.
    */
   Optional<PersonalAccessToken> get(Subject cheUser, String scmServerUrl)
+      throws ScmConfigurationPersistenceException, ScmUnauthorizedException,
+          ScmCommunicationException;
+
+  /**
+   * Gets {@link PersonalAccessToken} from permanent storage.
+   *
+   * @param cheUser
+   * @param scmServerUrl
+   * @param validate
+   * @return personal access token
+   * @throws ScmConfigurationPersistenceException - problem occurred during communication with *
+   *     permanent storage.
+   */
+  Optional<PersonalAccessToken> get(Subject cheUser, String scmServerUrl, boolean validate)
       throws ScmConfigurationPersistenceException, ScmUnauthorizedException,
           ScmCommunicationException;
 }

--- a/wsmaster/che-core-api-factory/src/main/java/org/eclipse/che/api/factory/server/scm/PersonalAccessTokenManager.java
+++ b/wsmaster/che-core-api-factory/src/main/java/org/eclipse/che/api/factory/server/scm/PersonalAccessTokenManager.java
@@ -51,19 +51,4 @@ public interface PersonalAccessTokenManager {
   Optional<PersonalAccessToken> get(Subject cheUser, String scmServerUrl)
       throws ScmConfigurationPersistenceException, ScmUnauthorizedException,
           ScmCommunicationException;
-
-  /**
-   * Gets {@link PersonalAccessToken} from permanent storage.
-   *
-   * @param cheUser Che user object
-   * @param scmServerUrl Git provider endpoint
-   * @param validate {@code false} to skip the token validation and avoid API call, otherwise {@code
-   *     true}
-   * @return personal access token
-   * @throws ScmConfigurationPersistenceException - problem occurred during communication with *
-   *     permanent storage.
-   */
-  Optional<PersonalAccessToken> get(Subject cheUser, String scmServerUrl, boolean validate)
-      throws ScmConfigurationPersistenceException, ScmUnauthorizedException,
-          ScmCommunicationException;
 }

--- a/wsmaster/che-core-api-factory/src/main/java/org/eclipse/che/api/factory/server/scm/PersonalAccessTokenManager.java
+++ b/wsmaster/che-core-api-factory/src/main/java/org/eclipse/che/api/factory/server/scm/PersonalAccessTokenManager.java
@@ -42,8 +42,8 @@ public interface PersonalAccessTokenManager {
   /**
    * Gets {@link PersonalAccessToken} from permanent storage.
    *
-   * @param cheUser
-   * @param scmServerUrl
+   * @param cheUser Che user object
+   * @param scmServerUrl Git provider endpoint
    * @return personal access token
    * @throws ScmConfigurationPersistenceException - problem occurred during communication with *
    *     permanent storage.
@@ -55,9 +55,10 @@ public interface PersonalAccessTokenManager {
   /**
    * Gets {@link PersonalAccessToken} from permanent storage.
    *
-   * @param cheUser
-   * @param scmServerUrl
-   * @param validate
+   * @param cheUser Che user object
+   * @param scmServerUrl Git provider endpoint
+   * @param validate {@code false} to skip the token validation and avoid API call, otherwise {@code
+   *     true}
    * @return personal access token
    * @throws ScmConfigurationPersistenceException - problem occurred during communication with *
    *     permanent storage.


### PR DESCRIPTION
Signed-off-by: Igor Vinokur <ivinokur@redhat.com>

<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests
-->

### What does this PR do?
Read user namespace oauth token before checking the oAuth configuration in case when user manually added a bitbucket oAuth secret to the user namespace.

### Screenshot/screencast of this PR
<!-- Please include a screenshot or a screencast explaining what is doing this PR -->


### What issues does this PR fix or reference?
<!-- Please include any related issue from eclipse che repository (or from another issue tracker).
     Include link to other pull requests like documentation PR from [the docs repo](https://github.com/eclipse/che-docs)
-->
https://github.com/eclipse/che/issues/21189

### How to test this PR?
<!-- Please explain for example :
  - The test platform (openshift, kubernetes, minikube, CodeReady Container, docker-desktop, etc)
  - Installation method: chectl / che-operator
  - steps to reproduce
 -->
1. Deploy che with `quay.io/ivinokur/che-server:next` image.
2. [Deploy bitbucket server](https://github.com/skabashnyuk/gitsrv/tree/main/bitbucket).
3. Add a secret to the user namespace:
```
kind: Secret
apiVersion: v1
metadata:
  name: personal-access-token-<github/gitlab/bitbucket-server>
  namespace: <namespace name>
  labels:
    app.kubernetes.io/component: scm-personal-access-token
    app.kubernetes.io/part-of: che.eclipse.org
  annotations:
    che.eclipse.org/che-userid: <che user id>
    che.eclipse.org/scm-personal-access-token-name: <github/gitlab/bitbucket-server>
    che.eclipse.org/scm-userid: <github/gitlab/gitbucket-server user id>
    che.eclipse.org/scm-url: >-
      <github/gitlab/gitbucket-server endpoint Url>
    che.eclipse.org/scm-username: <github/gitlab/bitbucket-server username>
data:
  token: <base 64 encoded token>
type: Opaque

```
4. Try to create a factory from the bitbucket server repo.
### PR Checklist

[As the author of this Pull Request I made sure that:](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#pull-request-template-and-its-checklist)

- [ ] [The Eclipse Contributor Agreement is valid](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-eclipse-contributor-agreement-is-valid)
- [ ] [Code produced is complete](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-produced-is-complete)
- [ ] [Code builds without errors](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-builds-without-errors)
- [ ] [Tests are covering the bugfix](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#tests-are-covering-the-bugfix)
- [ ] [The repository devfile is up to date and works](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-repository-devfile-is-up-to-date-and-works)
- [ ] [Sections `What issues does this PR fix or reference` and `How to test this PR` completed](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#sections-what-issues-does-this-pr-fix-or-reference-and-how-to-test-this-pr-completed)
- [ ] [Relevant user documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [Relevant contributing documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [CI/CD changes implemented, documented and communicated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#cicd-changes-implemented-documented-and-communicated)

### Reviewers

Reviewers, please comment how you tested the PR when approving it.
