### PR TITLE
feat(oidc): email claim configuration

### DIFF
--- a/assembly/assembly-wsmaster-war/src/main/webapp/WEB-INF/classes/che/multiuser.properties
+++ b/assembly/assembly-wsmaster-war/src/main/webapp/WEB-INF/classes/che/multiuser.properties
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2012-2021 Red Hat, Inc.
+# Copyright (c) 2012-2022 Red Hat, Inc.
 # This program and the accompanying materials are made
 # available under the terms of the Eclipse Public License 2.0
 # which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/assembly/assembly-wsmaster-war/src/main/webapp/WEB-INF/classes/che/multiuser.properties
+++ b/assembly/assembly-wsmaster-war/src/main/webapp/WEB-INF/classes/che/multiuser.properties
@@ -110,8 +110,8 @@ che.oidc.allowed_clock_skew_sec=3
 # `name` in Dex installations.
 che.oidc.username_claim=NULL
 
-# Email claim to be used when parsing JWT token
-# if not defined the fallback value is 'email'.
+# Email claim to be used when parsing JWT token.
+# If not defined, the fallback value is 'email'.
 che.oidc.email_claim=NULL
 
 # Base URL of an alternate OIDC provider that provides

--- a/assembly/assembly-wsmaster-war/src/main/webapp/WEB-INF/classes/che/multiuser.properties
+++ b/assembly/assembly-wsmaster-war/src/main/webapp/WEB-INF/classes/che/multiuser.properties
@@ -110,6 +110,10 @@ che.oidc.allowed_clock_skew_sec=3
 # `name` in Dex installations.
 che.oidc.username_claim=NULL
 
+# Email claim to be used when parsing JWT token
+# if not defined the fallback value is 'email'.
+che.oidc.email_claim=NULL
+
 # Base URL of an alternate OIDC provider that provides
 # a discovery endpoint as detailed in the following specification
 # link:https://openid.net/specs/openid-connect-discovery-1_0.html#ProviderConfig[Obtaining OpenID Provider Configuration Information]

--- a/multiuser/oidc/src/main/java/org/eclipse/che/multiuser/oidc/OIDCInfoProvider.java
+++ b/multiuser/oidc/src/main/java/org/eclipse/che/multiuser/oidc/OIDCInfoProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012-2021 Red Hat, Inc.
+ * Copyright (c) 2012-2022 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/
@@ -43,6 +43,7 @@ public class OIDCInfoProvider implements Provider<OIDCInfo> {
       OIDC_SETTING_PREFIX + "auth_internal_server_url";
   public static final String OIDC_PROVIDER_SETTING = OIDC_SETTING_PREFIX + "oidc_provider";
   public static final String OIDC_USERNAME_CLAIM_SETTING = OIDC_SETTING_PREFIX + "username_claim";
+  public static final String OIDC_EMAIL_CLAIM_SETTING = OIDC_SETTING_PREFIX + "email_claim";
   public static final String OIDC_ALLOWED_CLOCK_SKEW_SEC =
       OIDC_SETTING_PREFIX + "allowed_clock_skew_sec";
 


### PR DESCRIPTION
<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests
-->

### What does this PR do?
This is a continuation of [improvements](https://github.com/eclipse/che/issues/21450) to deploy Che on Azure AKS in a way that after we taught Che to leverage `access_token` instead of `id_token` to access AKS, we need to able to configure email's claim's name (hardcoded to `email` and cannot be changed in current version) in Che-server. 

This PR adds support of `CHE_OIDC_EMAIL__CLAIM` to configure email's claim's name:
```
spec:
  components:
    cheServer:
      extraProperties:
        CHE_OIDC_EMAIL__CLAIM: unique_name
```

### Screenshot/screencast of this PR
<!-- Please include a screenshot or a screencast explaining what is doing this PR -->


### What issues does this PR fix or reference?
<!-- Please include any related issue from eclipse che repository (or from another issue tracker).
     Include link to other pull requests like documentation PR from [the docs repo](https://github.com/eclipse/che-docs)
-->
https://github.com/eclipse/che/issues/21515

### How to test this PR?
<!-- Please explain for example :
  - The test platform (openshift, kubernetes, minikube, CodeReady Container, docker-desktop, etc)
  - Installation method: chectl / che-operator
  - steps to reproduce
 -->
I have just tested this change on Azure AKS integrated with Azure AD. 
Che-server image: docker.io/karatkep/che-server:21515-email-claim-configuration
CheCluster patch:
```
spec:
  networking:
    auth:
      identityProviderURL: https://sts.windows.net/{TENANT_ID}/v2.0/
      identityToken: access_token
      oAuthClientName: {CLIENT_ID}
      oAuthSecret: {CLIENT_SECRET}
      oAuthScope: openid email profile 6dae42f8-4368-4678-94ff-3960e28e3630/.default
  components:
    cheServer:
      extraProperties:
        CHE_OIDC_AUTH__SERVER__URL: https://sts.windows.net/{TENANT_ID}/v2.0/
        CHE_OIDC_EMAIL__CLAIM: unique_name
```
chectl command to deploy:
```
chectl server:deploy --platform=k8s --installer=operator \
--cheimage=docker.io/karatkep/che-server:21515-email-claim-configuration \
--skip-oidc-provider-check \
--skip-cert-manager \
--che-operator-cr-patch-yaml=che.yml
```

### PR Checklist

[As the author of this Pull Request I made sure that:](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#pull-request-template-and-its-checklist)

- [ ] [The Eclipse Contributor Agreement is valid](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-eclipse-contributor-agreement-is-valid)
- [ ] [Code produced is complete](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-produced-is-complete)
- [ ] [Code builds without errors](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-builds-without-errors)
- [ ] [Tests are covering the bugfix](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#tests-are-covering-the-bugfix)
- [ ] [The repository devfile is up to date and works](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-repository-devfile-is-up-to-date-and-works)
- [ ] [Sections `What issues does this PR fix or reference` and `How to test this PR` completed](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#sections-what-issues-does-this-pr-fix-or-reference-and-how-to-test-this-pr-completed)
- [ ] [Relevant user documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [Relevant contributing documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [CI/CD changes implemented, documented and communicated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#cicd-changes-implemented-documented-and-communicated)

### Reviewers

Reviewers, please comment how you tested the PR when approving it.
