### PR TITLE
fix: Improve GitHub token validation check

### DIFF
--- a/wsmaster/che-core-api-factory-github/src/main/java/org/eclipse/che/api/factory/server/github/GithubPersonalAccessTokenFetcher.java
+++ b/wsmaster/che-core-api-factory-github/src/main/java/org/eclipse/che/api/factory/server/github/GithubPersonalAccessTokenFetcher.java
@@ -200,27 +200,22 @@ public class GithubPersonalAccessTokenFetcher implements PersonalAccessTokenFetc
       return Optional.empty();
     }
 
-    if (personalAccessToken.getScmTokenName() != null
-        && personalAccessToken.getScmTokenName().startsWith(OAUTH_2_PREFIX)) {
-      try {
+    try {
+      if (personalAccessToken.getScmTokenName() != null
+          && personalAccessToken.getScmTokenName().startsWith(OAUTH_2_PREFIX)) {
         String[] scopes = githubApiClient.getTokenScopes(personalAccessToken.getToken());
         return Optional.of(containsScopes(scopes, DEFAULT_TOKEN_SCOPES));
-      } catch (ScmItemNotFoundException | ScmCommunicationException | ScmBadRequestException e) {
-        LOG.error(e.getMessage(), e);
-        throw new ScmCommunicationException(e.getMessage(), e);
-      }
-    } else {
-      // No REST API for PAT-s in Github found yet. Just try to do some action.
-      try {
+      } else {
+        // No REST API for PAT-s in Github found yet. Just try to do some action.
         GithubUser user = githubApiClient.getUser(personalAccessToken.getToken());
         if (personalAccessToken.getScmUserId().equals(Long.toString(user.getId()))) {
           return Optional.of(Boolean.TRUE);
         } else {
           return Optional.of(Boolean.FALSE);
         }
-      } catch (ScmItemNotFoundException | ScmCommunicationException | ScmBadRequestException e) {
-        return Optional.of(Boolean.FALSE);
       }
+    } catch (ScmItemNotFoundException | ScmCommunicationException | ScmBadRequestException e) {
+      return Optional.of(Boolean.FALSE);
     }
   }
 


### PR DESCRIPTION
Signed-off-by: Igor Vinokur <ivinokur@redhat.com>

<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests
-->

### What does this PR do?
Do not throw an exception when validating an expired oauth token, return `false` instead.

When a factory starts and oauth token is found, che-server checks the token:
* current behaiviour: if the oauth token is not valid, the validation check throws an exception and the factory creation is interrupted.
* PR behaviour: if the oauth token is not valid, the validation check returns `false` instead of an error, so token regeneration mechanism starts and the factory is created successfully.

### Screenshot/screencast of this PR
<!-- Please include a screenshot or a screencast explaining what is doing this PR -->


### What issues does this PR fix or reference?
<!-- Please include any related issue from eclipse che repository (or from another issue tracker).
     Include link to other pull requests like documentation PR from [the docs repo](https://github.com/eclipse/che-docs)
-->
fixes https://github.com/eclipse/che/issues/21421

### How to test this PR?
<!-- Please explain for example :
  - The test platform (openshift, kubernetes, minikube, CodeReady Container, docker-desktop, etc)
  - Installation method: chectl / che-operator
  - steps to reproduce
 -->
1. Deploy Che with `quay.io/ivinokur/che-server:next` image e.g. `chectl server:deploy -p=minikube -i=quay.io/ivinokur/che-server:next`
2. [Configure GitHub oauth](https://www.eclipse.org/che/docs/stable/administration-guide/configuring-oauth-2-for-github/)
3. Start a factory from a GitHub repo to generate GitHub token in the user namespace.
4. Revoke the GitHub token: [step 1](https://help.osf.io/article/216-reauthorize-github)
5. Restart the factory.

See: Che will regenerate the token and start the facory.

### PR Checklist

[As the author of this Pull Request I made sure that:](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#pull-request-template-and-its-checklist)

- [x] [The Eclipse Contributor Agreement is valid](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-eclipse-contributor-agreement-is-valid)
- [x] [Code produced is complete](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-produced-is-complete)
- [x] [Code builds without errors](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-builds-without-errors)
- [x] [Tests are covering the bugfix](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#tests-are-covering-the-bugfix)
- [ ] [The repository devfile is up to date and works](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-repository-devfile-is-up-to-date-and-works)
- [x] [Sections `What issues does this PR fix or reference` and `How to test this PR` completed](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#sections-what-issues-does-this-pr-fix-or-reference-and-how-to-test-this-pr-completed)
- [ ] [Relevant user documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [Relevant contributing documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [CI/CD changes implemented, documented and communicated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#cicd-changes-implemented-documented-and-communicated)

### Reviewers

Reviewers, please comment how you tested the PR when approving it.
