### PR TITLE
chore: Remove some outdated PVC storage properties

### DIFF
--- a/assembly/assembly-wsmaster-war/src/main/webapp/WEB-INF/classes/che/che.properties
+++ b/assembly/assembly-wsmaster-war/src/main/webapp/WEB-INF/classes/che/che.properties
@@ -33,11 +33,6 @@ che.websocket.internal.endpoint=NULL
 # workspace. This is the directory in the machine where your projects are placed.
 che.workspace.projects.storage=/projects
 
-# Used when {orch-name}-type components in a devfile request project PVC creation
-# (Applied in case of `unique` and `per workspace` PVC strategy. In case of the `common` PVC strategy,
-# it is rewritten with the value of the `che.infra.kubernetes.pvc.quantity` property.)
-che.workspace.projects.storage.default.size=1Gi
-
 # Defines the directory inside the machine where all the workspace logs are placed.
 # Provide this value into the machine, for example, as an environment variable.
 # This is to ensure that agent developers can use this directory to back up agent logs.
@@ -368,50 +363,6 @@ che.infra.kubernetes.ingress_start_timeout_min=5
 # A failed container startup is handled explicitly by {prod-short} server.
 che.infra.kubernetes.workspace_unrecoverable_events=FailedMount,FailedScheduling,MountVolume.SetUp failed,Failed to pull image,FailedCreate,ReplicaSetCreateError
 
-# Defines whether use the Persistent Volume Claim for {prod-short} workspace needs,
-# for example: backup projects, logs, or disable it.
-che.infra.kubernetes.pvc.enabled=true
-
-# Defined which strategy will be used while choosing PVC for workspaces.
-#
-# Supported strategies:
-# `common`::
-#        All workspaces in the same {orch-namespace} will reuse the same PVC.
-#        Name of PVC may be configured with `che.infra.kubernetes.pvc.name`.
-#        Existing PVC will be used or a new one will be created if it does not exist.
-#
-# `unique`::
-#        Separate PVC for each workspace's volume will be used.
-#        Name of PVC is evaluated as `'{che.infra.kubernetes.pvc.name} + '-' + {generated_8_chars}'`.
-#        Existing PVC will be used or a new one will be created if it does not exist.
-#
-# `per-workspace`::
-#        Separate PVC for each workspace will be used.
-#        Name of PVC is evaluated as `'{che.infra.kubernetes.pvc.name} + '-' + {WORKSPACE_ID}'`.
-#        Existing PVC will be used or a new one will be created if it doesn't exist.
-che.infra.kubernetes.pvc.strategy=common
-
-# Defines whether to run a job that creates workspace's subpath directories in persistent volume for the `common` strategy before launching a workspace.
-# Necessary in some versions of {orch-name} as workspace subpath volume mounts are created with root permissions,
-# and therefore cannot be modified by workspaces running as a user (presents an error importing projects into a workspace in {prod-short}).
-# The default is `true`, but should be set to `false` if the version of {orch-name} creates subdirectories with user permissions.
-# See: link:https://github.com/kubernetes/kubernetes/issues/41638[subPath in volumeMount is not writable for non-root users #41638]
-# the {prod-short} Operator that this property has effect only if the `common` PVC strategy used.
-che.infra.kubernetes.pvc.precreate_subpaths=true
-
-# Defines the settings of PVC name for {prod-short} workspaces.
-# Each PVC strategy supplies this value differently.
-# See documentation for `che.infra.kubernetes.pvc.strategy` property
-che.infra.kubernetes.pvc.name=claim-che-workspace
-
-# Defines the storage class of Persistent Volume Claim for the workspaces.
-# Empty strings means "use default".
-che.infra.kubernetes.pvc.storage_class_name=
-
-# Defines the size of Persistent Volume Claim of {prod-short} workspace.
-# See: link:https://docs.openshift.com/container-platform/4.4/storage/understanding-persistent-storage.html[Understanding persistent storage]
-che.infra.kubernetes.pvc.quantity=10Gi
-
 # Pod that is launched when performing persistent volume claim maintenance jobs on OpenShift
 che.infra.kubernetes.pvc.jobs.image=registry.access.redhat.com/ubi8-minimal:8.3-230
 
@@ -420,20 +371,6 @@ che.infra.kubernetes.pvc.jobs.image.pull_policy=IfNotPresent
 
 # Defines Pod memory limit for persistent volume claim maintenance jobs
 che.infra.kubernetes.pvc.jobs.memorylimit=250Mi
-
-# Defines Persistent Volume Claim access mode.
-# the {prod-short} Operator that for common PVC strategy changing of access mode affects the number of simultaneously running workspaces.
-# If the OpenShift instance running {prod-short} is using Persistent Volumes with RWX access mode, then a limit of running workspaces at the same time is bounded only by {prod-short} limits configuration: RAM, CPU, and so on.
-# See: link:https://docs.openshift.com/container-platform/4.4/storage/understanding-persistent-storage.html[Understanding persistent storage]
-che.infra.kubernetes.pvc.access_mode=ReadWriteOnce
-
-# Defines if {prod-short} Server should wait workspaces Persistent Volume Claims to become bound after creating.
-# Default value is `true`.
-# The parameter is used by all Persistent Volume Claim strategies.
-#
-# It should be set to `false` when `volumeBindingMode` is configured to `WaitForFirstConsumer` otherwise workspace starts will hangs up on phase of waiting PVCs.
-#
-che.infra.kubernetes.pvc.wait_bound=true
 
 # Defines annotations for ingresses which are used for servers exposing. Value depends on the kind of ingress
 # controller.
@@ -612,21 +549,6 @@ che.workspace.devfile_registry_url=https://che-devfile-registry.prod-preview.ope
 # Example: ++http://plugin-registry.che.svc.cluster.local:8080++
 # In case {prod-short} plug-ins registry is not needed value 'NULL' should be used
 che.workspace.devfile_registry_internal_url=NULL
-
-# The configuration property that defines available values for storage types that clients such as the Dashboard should propose to users during workspace creation and update.
-# Available values:
-#   - `persistent`: Persistent Storage slow I/O but persistent.
-#   - `ephemeral`: Ephemeral Storage allows for faster I/O but may have limited storage
-#       and is not persistent.
-#   - `async`: Experimental feature: Asynchronous storage is combination of Ephemeral
-#       and Persistent storage. Allows for faster I/O and keep your changes, will backup on stop
-#       and restore on start workspace.
-#       Will work only if:
-#           - `che.infra.kubernetes.pvc.strategy='common'`
-#           - `che.limits.user.workspaces.run.count=1`
-#           - `che.infra.kubernetes.namespace.default` contains `<username>`
-#      in other cases remove `async` from the list.
-che.workspace.storage.available_types=persistent,ephemeral,async
 
 # The configuration property that defines a default value for storage type that clients such as the Dashboard should propose to users during workspace creation and update.
 # The `async` value is an experimental feature, not recommended as default type.


### PR DESCRIPTION
### What does this PR do?
Removes the following Che-Server properties, as PVC configuration in Eclipse Che is now managed by the devworkspace-operator:
```
che.workspace.projects.storage.default.size
che.infra.kubernetes.pvc.enabled
che.infra.kubernetes.pvc.strategy
che.infra.kubernetes.pvc.precreate_subpaths
che.infra.kubernetes.pvc.name
che.infra.kubernetes.pvc.storage_class_name
che.infra.kubernetes.pvc.quantity
che.infra.kubernetes.pvc.access_mode
che.infra.kubernetes.pvc.wait_bound
che.workspace.storage.available_types
```


### Screenshot/screencast of this PR
n/a

### What issues does this PR fix or reference?
Part of eclipse/che#21405

### How to test this PR?
n/a


### Additional notes:
- I am not sure yet whether it is sufficient for https://github.com/eclipse-che/che-operator/pull/1442#issuecomment-1184638247 to simply remove these properties from the `.properties` file, or whether the PVC configuration code needs to be removed. Perhaps as a first step, removing the properties is sufficient.
- The tests are passing and build is working locally after this change, but I am not sure if there is a better way to manually test this change.
- The [Che-Docs will also require a PR](https://github.com/eclipse-che/che-operator/pull/1442#issuecomment-1184638247) to remove the mention of the properties that is PR removes. 

Additionally, there may be additional properties that can be removed as part of this PR, but I wasn't sure if they were still in use:
```
che.infra.kubernetes.pvc.jobs.image
che.infra.kubernetes.pvc.jobs.image.pull_policy
che.infra.kubernetes.pvc.jobs.memorylimit
```

I imagine the maintenance PVC job in che-server is to cleanup a workspace off the common PVC when a workspace is deleted. If that's the case, then this functionality already exists in DWO, and these properties can also be removed. 

### PR Checklist

[As the author of this Pull Request I made sure that:](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#pull-request-template-and-its-checklist)

- [x] [The Eclipse Contributor Agreement is valid](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-eclipse-contributor-agreement-is-valid)
- [ ] [Code produced is complete](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-produced-is-complete)
- [ ] [Code builds without errors](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-builds-without-errors)
- [ ] [Tests are covering the bugfix](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#tests-are-covering-the-bugfix)
- [ ] [The repository devfile is up to date and works](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-repository-devfile-is-up-to-date-and-works)
- [ ] [Sections `What issues does this PR fix or reference` and `How to test this PR` completed](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#sections-what-issues-does-this-pr-fix-or-reference-and-how-to-test-this-pr-completed)
- [ ] [Relevant user documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [Relevant contributing documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [CI/CD changes implemented, documented and communicated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#cicd-changes-implemented-documented-and-communicated)

### Reviewers

Reviewers, please comment how you tested the PR when approving it.
