### PR TITLE
chore: Apply authentication status in the callback url

### DIFF
--- a/infrastructures/kubernetes/src/test/java/org/eclipse/che/workspace/infrastructure/kubernetes/devfile/KubernetesComponentIntegrityValidatorTest.java
+++ b/infrastructures/kubernetes/src/test/java/org/eclipse/che/workspace/infrastructure/kubernetes/devfile/KubernetesComponentIntegrityValidatorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012-2021 Red Hat, Inc.
+ * Copyright (c) 2012-2022 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/
@@ -22,6 +22,7 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
+import org.eclipse.che.api.workspace.server.devfile.FileContentProvider;
 import org.eclipse.che.api.workspace.server.devfile.exception.DevfileFormatException;
 import org.eclipse.che.api.workspace.server.model.impl.devfile.ComponentImpl;
 import org.eclipse.che.api.workspace.server.model.impl.devfile.EntrypointImpl;
@@ -36,6 +37,7 @@ import org.testng.annotations.Test;
 public class KubernetesComponentIntegrityValidatorTest {
 
   @Mock private KubernetesRecipeParser kubernetesRecipeParser;
+  @Mock private FileContentProvider contentProvider;
 
   private KubernetesComponentValidator validator;
 
@@ -69,7 +71,7 @@ public class KubernetesComponentIntegrityValidatorTest {
     component.setReferenceContent("content");
 
     // when
-    validator.validateComponent(component, __ -> "");
+    validator.validateComponent(component, contentProvider);
 
     // then no exception is thrown
   }
@@ -105,7 +107,7 @@ public class KubernetesComponentIntegrityValidatorTest {
     component.setEntrypoints(Collections.singletonList(entrypoint));
 
     // when
-    validator.validateComponent(component, __ -> "");
+    validator.validateComponent(component, contentProvider);
 
     // then no exception is thrown
   }
@@ -151,7 +153,7 @@ public class KubernetesComponentIntegrityValidatorTest {
     component.setEntrypoints(Collections.singletonList(entrypoint));
 
     // when
-    validator.validateComponent(component, __ -> "");
+    validator.validateComponent(component, contentProvider);
 
     // then no exception is thrown
   }
@@ -181,7 +183,7 @@ public class KubernetesComponentIntegrityValidatorTest {
     component.setReferenceContent("content");
 
     // when
-    validator.validateComponent(component, __ -> "");
+    validator.validateComponent(component, contentProvider);
 
     // then exception is thrown
   }
@@ -213,7 +215,7 @@ public class KubernetesComponentIntegrityValidatorTest {
     component.setEntrypoints(Collections.singletonList(entrypoint));
 
     // when
-    validator.validateComponent(component, __ -> "");
+    validator.validateComponent(component, contentProvider);
 
     // then exception is thrown
   }
@@ -263,7 +265,7 @@ public class KubernetesComponentIntegrityValidatorTest {
     component.setEntrypoints(Collections.singletonList(entrypoint));
 
     // when
-    validator.validateComponent(component, __ -> "");
+    validator.validateComponent(component, contentProvider);
 
     // then exception is thrown
   }

--- a/infrastructures/openshift/src/test/java/org/eclipse/che/workspace/infrastructure/openshift/devfile/OpenshiftComponentToWorkspaceApplierTest.java
+++ b/infrastructures/openshift/src/test/java/org/eclipse/che/workspace/infrastructure/openshift/devfile/OpenshiftComponentToWorkspaceApplierTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012-2021 Red Hat, Inc.
+ * Copyright (c) 2012-2022 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/
@@ -22,6 +22,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertFalse;
 import static org.testng.Assert.assertTrue;
@@ -34,6 +35,7 @@ import java.util.Map;
 import java.util.Set;
 import org.eclipse.che.api.core.ValidationException;
 import org.eclipse.che.api.core.model.workspace.config.ServerConfig;
+import org.eclipse.che.api.workspace.server.devfile.FileContentProvider;
 import org.eclipse.che.api.workspace.server.devfile.exception.DevfileException;
 import org.eclipse.che.api.workspace.server.model.impl.MachineConfigImpl;
 import org.eclipse.che.api.workspace.server.model.impl.WorkspaceConfigImpl;
@@ -63,6 +65,7 @@ public class OpenshiftComponentToWorkspaceApplierTest {
   private KubernetesComponentToWorkspaceApplier applier;
   @Mock private KubernetesEnvironmentProvisioner k8sEnvProvisioner;
   @Mock private KubernetesRecipeParser k8sRecipeParser;
+  @Mock private FileContentProvider contentProvider;
   @Mock private EnvVars envVars;
 
   @BeforeMethod
@@ -94,9 +97,10 @@ public class OpenshiftComponentToWorkspaceApplierTest {
     component.setType(KUBERNETES_COMPONENT_TYPE);
     component.setReference(REFERENCE_FILENAME);
     component.setAlias(COMPONENT_NAME);
+    when(contentProvider.fetchContent(anyString())).thenReturn("content");
 
     // when
-    applier.apply(workspaceConfig, component, s -> "content");
+    applier.apply(workspaceConfig, component, contentProvider);
 
     // then
     verify(k8sEnvProvisioner)
@@ -122,6 +126,7 @@ public class OpenshiftComponentToWorkspaceApplierTest {
             openshiftBasedComponents);
 
     String yamlRecipeContent = getResource("devfile/petclinic.yaml");
+    when(contentProvider.fetchContent(anyString())).thenReturn(yamlRecipeContent);
     doReturn(toK8SList(yamlRecipeContent).getItems()).when(k8sRecipeParser).parse(anyString());
 
     // given
@@ -134,7 +139,7 @@ public class OpenshiftComponentToWorkspaceApplierTest {
             new EndpointImpl("e1", 1111, emptyMap()), new EndpointImpl("e2", 2222, emptyMap())));
 
     // when
-    applier.apply(workspaceConfig, component, s -> yamlRecipeContent);
+    applier.apply(workspaceConfig, component, contentProvider);
 
     // then
     @SuppressWarnings("unchecked")
@@ -176,6 +181,7 @@ public class OpenshiftComponentToWorkspaceApplierTest {
             openshiftBasedComponents);
 
     String yamlRecipeContent = getResource("devfile/petclinic.yaml");
+    when(contentProvider.fetchContent(anyString())).thenReturn(yamlRecipeContent);
     doReturn(toK8SList(yamlRecipeContent).getItems()).when(k8sRecipeParser).parse(anyString());
 
     // given
@@ -188,7 +194,7 @@ public class OpenshiftComponentToWorkspaceApplierTest {
             new EndpointImpl("e1", 1111, emptyMap()), new EndpointImpl("e2", 2222, emptyMap())));
 
     // when
-    applier.apply(workspaceConfig, component, s -> yamlRecipeContent);
+    applier.apply(workspaceConfig, component, contentProvider);
 
     // then
     @SuppressWarnings("unchecked")

--- a/wsmaster/che-core-api-auth/src/main/java/org/eclipse/che/security/oauth1/OAuthAuthenticationService.java
+++ b/wsmaster/che-core-api-auth/src/main/java/org/eclipse/che/security/oauth1/OAuthAuthenticationService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012-2021 Red Hat, Inc.
+ * Copyright (c) 2012-2022 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/
@@ -44,7 +44,7 @@ public class OAuthAuthenticationService extends Service {
   private static final Logger LOG = LoggerFactory.getLogger(OAuthAuthenticationService.class);
 
   private static final String UNSUPPORTED_OAUTH_PROVIDER_ERROR = "Unsupported OAuth provider: %s";
-  private static final String ERROR_QUERY_NAME = "error_code";
+  public static final String ERROR_QUERY_NAME = "error_code";
   @Inject protected OAuthAuthenticatorProvider providers;
 
   @GET

--- a/wsmaster/che-core-api-factory-bitbucket-server/src/main/java/org/eclipse/che/api/factory/server/bitbucket/BitbucketServerAuthorizingFactoryParametersResolver.java
+++ b/wsmaster/che-core-api-factory-bitbucket-server/src/main/java/org/eclipse/che/api/factory/server/bitbucket/BitbucketServerAuthorizingFactoryParametersResolver.java
@@ -97,7 +97,10 @@ public class BitbucketServerAuthorizingFactoryParametersResolver
     // create factory from the following location if location exists, else create default factory
     return urlFactoryBuilder
         .createFactoryFromDevfile(
-            bitbucketServerUrl, fileContentProvider, extractOverrideParams(factoryParameters))
+            bitbucketServerUrl,
+            fileContentProvider,
+            extractOverrideParams(factoryParameters),
+            false)
         .orElseGet(() -> newDto(FactoryDto.class).withV(CURRENT_VERSION).withSource("repo"))
         .acceptVisitor(new BitbucketFactoryVisitor(bitbucketServerUrl));
   }

--- a/wsmaster/che-core-api-factory-bitbucket-server/src/test/java/org/eclipse/che/api/factory/server/bitbucket/BitbucketServerAuthorizingFactoryParametersResolverTest.java
+++ b/wsmaster/che-core-api-factory-bitbucket-server/src/test/java/org/eclipse/che/api/factory/server/bitbucket/BitbucketServerAuthorizingFactoryParametersResolverTest.java
@@ -17,6 +17,7 @@ import static org.eclipse.che.api.factory.shared.Constants.URL_PARAMETER_NAME;
 import static org.eclipse.che.api.workspace.server.devfile.Constants.CURRENT_API_VERSION;
 import static org.eclipse.che.dto.server.DtoFactory.newDto;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.ArgumentMatchers.anyMap;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
@@ -110,7 +111,8 @@ public class BitbucketServerAuthorizingFactoryParametersResolverTest {
 
     when(urlFactoryBuilder.buildDefaultDevfile(any())).thenReturn(computedFactory.getDevfile());
 
-    when(urlFactoryBuilder.createFactoryFromDevfile(any(RemoteFactoryUrl.class), any(), anyMap()))
+    when(urlFactoryBuilder.createFactoryFromDevfile(
+            any(RemoteFactoryUrl.class), any(), anyMap(), anyBoolean()))
         .thenReturn(Optional.empty());
     Map<String, String> params = ImmutableMap.of(URL_PARAMETER_NAME, bitbucketUrl);
     // when
@@ -131,7 +133,8 @@ public class BitbucketServerAuthorizingFactoryParametersResolverTest {
 
     FactoryDto computedFactory = generateDevfileFactory();
 
-    when(urlFactoryBuilder.createFactoryFromDevfile(any(RemoteFactoryUrl.class), any(), anyMap()))
+    when(urlFactoryBuilder.createFactoryFromDevfile(
+            any(RemoteFactoryUrl.class), any(), anyMap(), anyBoolean()))
         .thenReturn(Optional.of(computedFactory));
 
     Map<String, String> params = ImmutableMap.of(URL_PARAMETER_NAME, bitbucketUrl);
@@ -152,7 +155,8 @@ public class BitbucketServerAuthorizingFactoryParametersResolverTest {
 
     FactoryDevfileV2Dto computedFactory = generateDevfileV2Factory();
 
-    when(urlFactoryBuilder.createFactoryFromDevfile(any(RemoteFactoryUrl.class), any(), anyMap()))
+    when(urlFactoryBuilder.createFactoryFromDevfile(
+            any(RemoteFactoryUrl.class), any(), anyMap(), anyBoolean()))
         .thenReturn(Optional.of(computedFactory));
 
     Map<String, String> params = ImmutableMap.of(URL_PARAMETER_NAME, bitbucketUrl);

--- a/wsmaster/che-core-api-factory-bitbucket/src/main/java/org/eclipse/che/api/factory/server/bitbucket/BitbucketFactoryParametersResolver.java
+++ b/wsmaster/che-core-api-factory-bitbucket/src/main/java/org/eclipse/che/api/factory/server/bitbucket/BitbucketFactoryParametersResolver.java
@@ -104,7 +104,8 @@ public class BitbucketFactoryParametersResolver extends DefaultFactoryParameterR
             bitbucketUrl,
             new BitbucketAuthorizingFileContentProvider(
                 bitbucketUrl, urlFetcher, gitCredentialManager, personalAccessTokenManager),
-            extractOverrideParams(factoryParameters))
+            extractOverrideParams(factoryParameters),
+            false)
         .orElseGet(() -> newDto(FactoryDto.class).withV(CURRENT_VERSION).withSource("repo"))
         .acceptVisitor(new BitbucketFactoryVisitor(bitbucketUrl));
   }

--- a/wsmaster/che-core-api-factory-bitbucket/src/test/java/org/eclipse/che/api/factory/server/bitbucket/BitbucketFactoryParametersResolverTest.java
+++ b/wsmaster/che-core-api-factory-bitbucket/src/test/java/org/eclipse/che/api/factory/server/bitbucket/BitbucketFactoryParametersResolverTest.java
@@ -17,6 +17,7 @@ import static org.eclipse.che.api.factory.shared.Constants.URL_PARAMETER_NAME;
 import static org.eclipse.che.api.workspace.server.devfile.Constants.CURRENT_API_VERSION;
 import static org.eclipse.che.dto.server.DtoFactory.newDto;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.ArgumentMatchers.anyMap;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.never;
@@ -145,7 +146,8 @@ public class BitbucketFactoryParametersResolverTest {
 
     when(urlFactoryBuilder.buildDefaultDevfile(any())).thenReturn(computedFactory.getDevfile());
 
-    when(urlFactoryBuilder.createFactoryFromDevfile(any(RemoteFactoryUrl.class), any(), anyMap()))
+    when(urlFactoryBuilder.createFactoryFromDevfile(
+            any(RemoteFactoryUrl.class), any(), anyMap(), anyBoolean()))
         .thenReturn(Optional.empty());
     Map<String, String> params = ImmutableMap.of(URL_PARAMETER_NAME, bitbucketUrl);
     // when
@@ -168,7 +170,8 @@ public class BitbucketFactoryParametersResolverTest {
 
     FactoryDto computedFactory = generateDevfileFactory();
 
-    when(urlFactoryBuilder.createFactoryFromDevfile(any(RemoteFactoryUrl.class), any(), anyMap()))
+    when(urlFactoryBuilder.createFactoryFromDevfile(
+            any(RemoteFactoryUrl.class), any(), anyMap(), anyBoolean()))
         .thenReturn(Optional.of(computedFactory));
 
     Map<String, String> params = ImmutableMap.of(URL_PARAMETER_NAME, bitbucketUrl);
@@ -180,7 +183,8 @@ public class BitbucketFactoryParametersResolverTest {
 
     // check we called the builder with the following devfile file
     verify(urlFactoryBuilder)
-        .createFactoryFromDevfile(factoryUrlArgumentCaptor.capture(), any(), anyMap());
+        .createFactoryFromDevfile(
+            factoryUrlArgumentCaptor.capture(), any(), anyMap(), anyBoolean());
     verify(urlFactoryBuilder, never()).buildDefaultDevfile(eq("che"));
     assertEquals(
         factoryUrlArgumentCaptor.getValue().devfileFileLocations().iterator().next().location(),
@@ -194,7 +198,8 @@ public class BitbucketFactoryParametersResolverTest {
 
     FactoryDto computedFactory = generateDevfileFactory();
 
-    when(urlFactoryBuilder.createFactoryFromDevfile(any(RemoteFactoryUrl.class), any(), anyMap()))
+    when(urlFactoryBuilder.createFactoryFromDevfile(
+            any(RemoteFactoryUrl.class), any(), anyMap(), anyBoolean()))
         .thenReturn(Optional.of(computedFactory));
 
     Map<String, String> params = ImmutableMap.of(URL_PARAMETER_NAME, bitbucketUrl);
@@ -221,7 +226,8 @@ public class BitbucketFactoryParametersResolverTest {
                 .withSource(
                     newDto(SourceDto.class).withLocation("https://bitbucket.org/eclipse/che.git")));
 
-    when(urlFactoryBuilder.createFactoryFromDevfile(any(RemoteFactoryUrl.class), any(), anyMap()))
+    when(urlFactoryBuilder.createFactoryFromDevfile(
+            any(RemoteFactoryUrl.class), any(), anyMap(), anyBoolean()))
         .thenReturn(Optional.of(computedFactory));
 
     Map<String, String> params = ImmutableMap.of(URL_PARAMETER_NAME, bitbucketUrl);
@@ -240,7 +246,8 @@ public class BitbucketFactoryParametersResolverTest {
 
     FactoryDevfileV2Dto computedFactory = generateDevfileV2Factory();
 
-    when(urlFactoryBuilder.createFactoryFromDevfile(any(RemoteFactoryUrl.class), any(), anyMap()))
+    when(urlFactoryBuilder.createFactoryFromDevfile(
+            any(RemoteFactoryUrl.class), any(), anyMap(), anyBoolean()))
         .thenReturn(Optional.of(computedFactory));
 
     Map<String, String> params = ImmutableMap.of(URL_PARAMETER_NAME, bitbucketUrl);

--- a/wsmaster/che-core-api-factory-github/src/main/java/org/eclipse/che/api/factory/server/github/GithubScmFileResolver.java
+++ b/wsmaster/che-core-api-factory-github/src/main/java/org/eclipse/che/api/factory/server/github/GithubScmFileResolver.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012-2021 Red Hat, Inc.
+ * Copyright (c) 2012-2022 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/
@@ -55,13 +55,29 @@ public class GithubScmFileResolver implements ScmFileResolver {
       throws ApiException {
     final GithubUrl githubUrl = githubUrlParser.parse(repository);
     try {
-      return new GithubAuthorizingFileContentProvider(
-              githubUrl, urlFetcher, gitCredentialManager, personalAccessTokenManager)
-          .fetchContent(githubUrl.rawFileLocation(filePath));
+      return fetchContent(githubUrl, filePath, false);
+    } catch (DevfileException exception) {
+      // This catch might mean that the authentication was rejected by user, try to repeat the fetch
+      // without authentication flow.
+      try {
+        return fetchContent(githubUrl, filePath, true);
+      } catch (DevfileException devfileException) {
+        throw toApiException(devfileException);
+      }
+    }
+  }
+
+  private String fetchContent(GithubUrl githubUrl, String filePath, boolean skipAuthentication)
+      throws DevfileException, NotFoundException {
+    try {
+      GithubAuthorizingFileContentProvider contentProvider =
+          new GithubAuthorizingFileContentProvider(
+              githubUrl, urlFetcher, gitCredentialManager, personalAccessTokenManager);
+      return skipAuthentication
+          ? contentProvider.fetchContentWithoutAuthentication(filePath)
+          : contentProvider.fetchContent(filePath);
     } catch (IOException e) {
       throw new NotFoundException(e.getMessage());
-    } catch (DevfileException devfileException) {
-      throw toApiException(devfileException);
     }
   }
 }

--- a/wsmaster/che-core-api-factory-gitlab/src/main/java/org/eclipse/che/api/factory/server/gitlab/GitlabFactoryParametersResolver.java
+++ b/wsmaster/che-core-api-factory-gitlab/src/main/java/org/eclipse/che/api/factory/server/gitlab/GitlabFactoryParametersResolver.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012-2021 Red Hat, Inc.
+ * Copyright (c) 2012-2022 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/
@@ -91,7 +91,8 @@ public class GitlabFactoryParametersResolver extends DefaultFactoryParameterReso
             gitlabUrl,
             new GitlabAuthorizingFileContentProvider(
                 gitlabUrl, urlFetcher, gitCredentialManager, personalAccessTokenManager),
-            extractOverrideParams(factoryParameters))
+            extractOverrideParams(factoryParameters),
+            false)
         .orElseGet(() -> newDto(FactoryDto.class).withV(CURRENT_VERSION).withSource("repo"))
         .acceptVisitor(new GitlabFactoryVisitor(gitlabUrl));
   }

--- a/wsmaster/che-core-api-factory-gitlab/src/test/java/org/eclipse/che/api/factory/server/gitlab/GitlabFactoryParametersResolverTest.java
+++ b/wsmaster/che-core-api-factory-gitlab/src/test/java/org/eclipse/che/api/factory/server/gitlab/GitlabFactoryParametersResolverTest.java
@@ -17,6 +17,7 @@ import static org.eclipse.che.api.factory.shared.Constants.URL_PARAMETER_NAME;
 import static org.eclipse.che.api.workspace.server.devfile.Constants.CURRENT_API_VERSION;
 import static org.eclipse.che.dto.server.DtoFactory.newDto;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.ArgumentMatchers.anyMap;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
@@ -114,7 +115,8 @@ public class GitlabFactoryParametersResolverTest {
 
     when(urlFactoryBuilder.buildDefaultDevfile(any())).thenReturn(computedFactory.getDevfile());
 
-    when(urlFactoryBuilder.createFactoryFromDevfile(any(RemoteFactoryUrl.class), any(), anyMap()))
+    when(urlFactoryBuilder.createFactoryFromDevfile(
+            any(RemoteFactoryUrl.class), any(), anyMap(), anyBoolean()))
         .thenReturn(Optional.empty());
     Map<String, String> params = ImmutableMap.of(URL_PARAMETER_NAME, gitlabUrl);
     // when
@@ -134,7 +136,8 @@ public class GitlabFactoryParametersResolverTest {
 
     FactoryDto computedFactory = generateDevfileFactory();
 
-    when(urlFactoryBuilder.createFactoryFromDevfile(any(RemoteFactoryUrl.class), any(), anyMap()))
+    when(urlFactoryBuilder.createFactoryFromDevfile(
+            any(RemoteFactoryUrl.class), any(), anyMap(), anyBoolean()))
         .thenReturn(Optional.of(computedFactory));
 
     Map<String, String> params = ImmutableMap.of(URL_PARAMETER_NAME, gitlabUrl);
@@ -154,7 +157,8 @@ public class GitlabFactoryParametersResolverTest {
 
     FactoryDevfileV2Dto computedFactory = generateDevfileV2Factory();
 
-    when(urlFactoryBuilder.createFactoryFromDevfile(any(RemoteFactoryUrl.class), any(), anyMap()))
+    when(urlFactoryBuilder.createFactoryFromDevfile(
+            any(RemoteFactoryUrl.class), any(), anyMap(), anyBoolean()))
         .thenReturn(Optional.of(computedFactory));
 
     Map<String, String> params = ImmutableMap.of(URL_PARAMETER_NAME, gitlabUrl);

--- a/wsmaster/che-core-api-factory/src/main/java/org/eclipse/che/api/factory/server/DefaultFactoryParameterResolver.java
+++ b/wsmaster/che-core-api-factory/src/main/java/org/eclipse/che/api/factory/server/DefaultFactoryParameterResolver.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012-2021 Red Hat, Inc.
+ * Copyright (c) 2012-2022 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/
@@ -89,7 +89,8 @@ public class DefaultFactoryParameterResolver implements FactoryParametersResolve
         .createFactoryFromDevfile(
             new DefaultFactoryUrl().withDevfileFileLocation(devfileLocation),
             new URLFileContentProvider(devfileURI, urlFetcher),
-            extractOverrideParams(factoryParameters))
+            extractOverrideParams(factoryParameters),
+            false)
         .orElse(null);
   }
 

--- a/wsmaster/che-core-api-factory/src/main/java/org/eclipse/che/api/factory/server/urlfactory/URLFactoryBuilder.java
+++ b/wsmaster/che-core-api-factory/src/main/java/org/eclipse/che/api/factory/server/urlfactory/URLFactoryBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012-2021 Red Hat, Inc.
+ * Copyright (c) 2012-2022 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/
@@ -100,7 +100,8 @@ public class URLFactoryBuilder {
   public Optional<FactoryMetaDto> createFactoryFromDevfile(
       RemoteFactoryUrl remoteFactoryUrl,
       FileContentProvider fileContentProvider,
-      Map<String, String> overrideProperties)
+      Map<String, String> overrideProperties,
+      boolean skipAuthentication)
       throws ApiException {
     String devfileYamlContent;
 
@@ -111,7 +112,10 @@ public class URLFactoryBuilder {
 
     for (DevfileLocation location : remoteFactoryUrl.devfileFileLocations()) {
       try {
-        devfileYamlContent = fileContentProvider.fetchContent(location.location());
+        devfileYamlContent =
+            skipAuthentication
+                ? fileContentProvider.fetchContentWithoutAuthentication(location.location())
+                : fileContentProvider.fetchContent(location.location());
       } catch (IOException ex) {
         // try next location
         LOG.debug(
@@ -178,7 +182,7 @@ public class URLFactoryBuilder {
   /**
    * Creates devfile with only `generateName` and no `name`. We take `generateName` with precedence.
    * See doc of {@link URLFactoryBuilder#createFactoryFromDevfile(RemoteFactoryUrl,
-   * FileContentProvider, Map)} for explanation why.
+   * FileContentProvider, Map, Boolean)} for explanation why.
    */
   private DevfileImpl ensureToUseGenerateName(DevfileImpl devfile) {
     MetadataImpl devfileMetadata = new MetadataImpl(devfile.getMetadata());

--- a/wsmaster/che-core-api-factory/src/test/java/org/eclipse/che/api/factory/server/DefaultFactoryParameterResolverTest.java
+++ b/wsmaster/che-core-api-factory/src/test/java/org/eclipse/che/api/factory/server/DefaultFactoryParameterResolverTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012-2021 Red Hat, Inc.
+ * Copyright (c) 2012-2022 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/
@@ -18,6 +18,7 @@ import static org.eclipse.che.api.workspace.server.devfile.Constants.KUBERNETES_
 import static org.eclipse.che.api.workspace.server.devfile.Constants.OPENSHIFT_COMPONENT_TYPE;
 import static org.eclipse.che.api.workspace.server.devfile.Constants.PLUGIN_COMPONENT_TYPE;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
@@ -121,7 +122,10 @@ public class DefaultFactoryParameterResolverTest {
 
     verify(urlFactoryBuilder)
         .createFactoryFromDevfile(
-            any(RemoteFactoryUrl.class), any(URLFileContentProvider.class), captor.capture());
+            any(RemoteFactoryUrl.class),
+            any(URLFileContentProvider.class),
+            captor.capture(),
+            anyBoolean());
     Map<String, String> filteredOverrides = captor.getValue();
     assertEquals(2, filteredOverrides.size());
     assertEquals("bar", filteredOverrides.get("param.foo"));

--- a/wsmaster/che-core-api-factory/src/test/java/org/eclipse/che/api/factory/server/scm/AuthorizingFactoryParameterResolverTest.java
+++ b/wsmaster/che-core-api-factory/src/test/java/org/eclipse/che/api/factory/server/scm/AuthorizingFactoryParameterResolverTest.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright (c) 2012-2022 Red Hat, Inc.
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+package org.eclipse.che.api.factory.server.scm;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import org.eclipse.che.api.factory.server.urlfactory.RemoteFactoryUrl;
+import org.eclipse.che.api.workspace.server.devfile.URLFetcher;
+import org.eclipse.che.commons.subject.Subject;
+import org.mockito.Mock;
+import org.mockito.testng.MockitoTestNGListener;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Listeners;
+import org.testng.annotations.Test;
+
+@Listeners(value = {MockitoTestNGListener.class})
+public class AuthorizingFactoryParameterResolverTest {
+  @Mock private RemoteFactoryUrl remoteFactoryUrl;
+  @Mock private URLFetcher urlFetcher;
+  @Mock private PersonalAccessTokenManager personalAccessTokenManager;
+  @Mock private GitCredentialManager gitCredentialManager;
+  @Mock private PersonalAccessToken personalAccessToken;
+
+  private AuthorizingFileContentProvider provider;
+
+  @BeforeMethod
+  public void setUp() throws Exception {
+    provider =
+        new AuthorizingFileContentProvider(
+            remoteFactoryUrl, urlFetcher, personalAccessTokenManager, gitCredentialManager);
+    when(remoteFactoryUrl.getHostName()).thenReturn("hostName");
+    when(remoteFactoryUrl.rawFileLocation(anyString())).thenReturn("rawFileLocation");
+  }
+
+  @Test
+  public void shouldFetchContentWithAuthentication() throws Exception {
+    // given
+    when(urlFetcher.fetch(anyString(), anyString())).thenReturn("content");
+    when(personalAccessTokenManager.fetchAndSave(any(Subject.class), anyString()))
+        .thenReturn(personalAccessToken);
+
+    // when
+    provider.fetchContent("url");
+
+    // then
+    verify(personalAccessTokenManager).fetchAndSave(any(Subject.class), anyString());
+  }
+
+  @Test
+  public void shouldFetchContentWithoutAuthentication() throws Exception {
+    // given
+    when(urlFetcher.fetch(anyString())).thenReturn("content");
+
+    // when
+    provider.fetchContentWithoutAuthentication("url");
+
+    // then
+    verify(personalAccessTokenManager, never()).fetchAndSave(any(Subject.class), anyString());
+  }
+}

--- a/wsmaster/che-core-api-workspace/src/main/java/org/eclipse/che/api/workspace/server/devfile/FileContentProvider.java
+++ b/wsmaster/che-core-api-workspace/src/main/java/org/eclipse/che/api/workspace/server/devfile/FileContentProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012-2021 Red Hat, Inc.
+ * Copyright (c) 2012-2022 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/
@@ -38,6 +38,17 @@ public interface FileContentProvider {
   String fetchContent(String fileURL) throws IOException, DevfileException;
 
   /**
+   * Fetches content of the specified file without the authentication step.
+   *
+   * @param fileURL absolute or devfile-relative file URL to fetch content
+   * @return content of the specified file
+   * @throws IOException when there is an error during content retrieval
+   * @throws DevfileException when implementation does not support fetching of additional files
+   *     content
+   */
+  String fetchContentWithoutAuthentication(String fileURL) throws IOException, DevfileException;
+
+  /**
    * Short for {@code new CachingProvider(contentProvider);}. If the {@code contentProvider} is
    * itself an instance of the {@link CachingProvider}, no new instance is produced.
    *
@@ -67,8 +78,8 @@ public interface FileContentProvider {
       this.provider = provider;
     }
 
-    @Override
-    public String fetchContent(String fileURL) throws IOException, DevfileException {
+    private String fetchContent(String fileURL, boolean skipAuthentication)
+        throws IOException, DevfileException {
       SoftReference<String> ref = cache.get(fileURL);
       String ret = ref == null ? null : ref.get();
 
@@ -78,6 +89,17 @@ public interface FileContentProvider {
       }
 
       return ret;
+    }
+
+    @Override
+    public String fetchContent(String fileURL) throws IOException, DevfileException {
+      return fetchContent(fileURL, false);
+    }
+
+    @Override
+    public String fetchContentWithoutAuthentication(String fileURL)
+        throws IOException, DevfileException {
+      return fetchContent(fileURL, true);
     }
   }
 }

--- a/wsmaster/che-core-api-workspace/src/main/java/org/eclipse/che/api/workspace/server/devfile/URLFileContentProvider.java
+++ b/wsmaster/che-core-api-workspace/src/main/java/org/eclipse/che/api/workspace/server/devfile/URLFileContentProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012-2021 Red Hat, Inc.
+ * Copyright (c) 2012-2022 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/
@@ -33,8 +33,8 @@ public class URLFileContentProvider implements FileContentProvider {
     this.urlFetcher = urlFetcher;
   }
 
-  @Override
-  public String fetchContent(String fileURL) throws IOException, DevfileException {
+  private String fetchContent(String fileURL, boolean skipAuthentication)
+      throws IOException, DevfileException {
     URI fileURI;
     String requestURL;
     try {
@@ -70,5 +70,16 @@ public class URLFileContentProvider implements FileContentProvider {
               fileURL, e.getMessage()),
           e);
     }
+  }
+
+  @Override
+  public String fetchContent(String fileURL) throws IOException, DevfileException {
+    return fetchContent(fileURL, false);
+  }
+
+  @Override
+  public String fetchContentWithoutAuthentication(String fileURL)
+      throws IOException, DevfileException {
+    return fetchContent(fileURL, true);
   }
 }

--- a/wsmaster/che-core-api-workspace/src/test/java/org/eclipse/che/api/workspace/server/devfile/convert/CommandConverterTest.java
+++ b/wsmaster/che-core-api-workspace/src/test/java/org/eclipse/che/api/workspace/server/devfile/convert/CommandConverterTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012-2021 Red Hat, Inc.
+ * Copyright (c) 2012-2022 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/
@@ -14,6 +14,9 @@ package org.eclipse.che.api.workspace.server.devfile.convert;
 import static org.eclipse.che.api.core.model.workspace.config.Command.WORKING_DIRECTORY_ATTRIBUTE;
 import static org.eclipse.che.api.workspace.server.devfile.Constants.COMPONENT_ALIAS_COMMAND_ATTRIBUTE;
 import static org.eclipse.che.api.workspace.server.devfile.Constants.EXEC_ACTION_TYPE;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertFalse;
 import static org.testng.Assert.assertNull;
@@ -21,6 +24,7 @@ import static org.testng.Assert.assertNull;
 import com.google.common.collect.ImmutableMap;
 import java.util.HashMap;
 import org.eclipse.che.api.core.model.workspace.config.Command;
+import org.eclipse.che.api.workspace.server.devfile.FileContentProvider;
 import org.eclipse.che.api.workspace.server.devfile.exception.DevfileFormatException;
 import org.eclipse.che.api.workspace.server.devfile.exception.WorkspaceExportException;
 import org.eclipse.che.api.workspace.server.model.impl.devfile.ActionImpl;
@@ -171,9 +175,11 @@ public class CommandConverterTest {
     action.setReference("blah");
 
     devfileCommand.getActions().add(action);
+    FileContentProvider fileContentProvider = mock(FileContentProvider.class);
+    when(fileContentProvider.fetchContent(anyString())).thenReturn("content");
 
     // when
-    Command command = commandConverter.toWorkspaceCommand(devfileCommand, fileURL -> "content");
+    Command command = commandConverter.toWorkspaceCommand(devfileCommand, fileContentProvider);
 
     // then
     assertNull(command.getCommandLine());

--- a/wsmaster/che-core-api-workspace/src/test/java/org/eclipse/che/api/workspace/server/devfile/validator/DevfileIntegrityValidatorTest.java
+++ b/wsmaster/che-core-api-workspace/src/test/java/org/eclipse/che/api/workspace/server/devfile/validator/DevfileIntegrityValidatorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012-2021 Red Hat, Inc.
+ * Copyright (c) 2012-2022 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/
@@ -16,6 +16,7 @@ import static org.eclipse.che.api.workspace.server.devfile.Constants.EDITOR_COMP
 import static org.eclipse.che.api.workspace.server.devfile.Constants.KUBERNETES_COMPONENT_TYPE;
 import static org.eclipse.che.api.workspace.server.devfile.Constants.OPENSHIFT_COMPONENT_TYPE;
 import static org.eclipse.che.api.workspace.server.devfile.Constants.PLUGIN_COMPONENT_TYPE;
+import static org.mockito.Mockito.mock;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
@@ -24,6 +25,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.Map;
+import org.eclipse.che.api.workspace.server.devfile.FileContentProvider;
 import org.eclipse.che.api.workspace.server.devfile.exception.DevfileFormatException;
 import org.eclipse.che.api.workspace.server.model.impl.devfile.ActionImpl;
 import org.eclipse.che.api.workspace.server.model.impl.devfile.CommandImpl;
@@ -221,7 +223,7 @@ public class DevfileIntegrityValidatorTest {
     }
 
     // when
-    integrityValidator.validateContentReferences(devfile, __ -> "");
+    integrityValidator.validateContentReferences(devfile, mock(FileContentProvider.class));
 
     // then
     // no exception is thrown


### PR DESCRIPTION
Signed-off-by: Igor Vinokur <ivinokur@redhat.com>

<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests
-->

### What does this PR do?
When processing an authentication callback request set additional error query patameter to the callback url.
How it works:
1. User creates a factory form dashboard.
2. Dasboard requests che-server factory API with no error param in the request url. See https://github.com/eclipse-che/che-dashboard/pull/599
3. Che-server create factory API parses the url for the error param. No error query param means `skipAuthentication=false`. Authentication in progress.
https://github.com/eclipse-che/che-server/blob/74eb0a333d8a4c062fcc99253d4dc3f926c866d2/wsmaster/che-core-api-factory-github/src/main/java/org/eclipse/che/api/factory/server/github/GithubFactoryParametersResolver.java#L104-L106
4. GitHub shows the authentication page. If User rejects the authentication, authentication status is set to `access_denied`.
5. The error status is added to the redirect url as a query param.
https://github.com/eclipse-che/che-server/blob/74eb0a333d8a4c062fcc99253d4dc3f926c866d2/wsmaster/che-core-api-auth/src/main/java/org/eclipse/che/security/oauth/EmbeddedOAuthAPI.java#L85-L93
6. Dasboard is loaded from the redirect url. Dashboard requests the che-server to create factory by an api request with the error status query param from the redirect url.
https://github.com/eclipse-che/che-dashboard/blob/e2849d9d212c5055885b164ff05422005efc1e7d/packages/dashboard-frontend/src/containers/Loader/Factory/Steps/FetchDevfile/index.tsx#L208-L213
7. Che-server create factory API parses the url for the status param. If `skipAuthentication=true` the authentication flow is skiped and factory creation progress goes further. If `skipAuthentication=false` factory is created in a regular way.
https://github.com/eclipse-che/che-server/blob/74eb0a333d8a4c062fcc99253d4dc3f926c866d2/wsmaster/che-core-api-factory/src/main/java/org/eclipse/che/api/factory/server/scm/AuthorizingFileContentProvider.java#L70-L81
### Screenshot/screencast of this PR
<!-- Please include a screenshot or a screencast explaining what is doing this PR -->


### What issues does this PR fix or reference?
<!-- Please include any related issue from eclipse che repository (or from another issue tracker).
     Include link to other pull requests like documentation PR from [the docs repo](https://github.com/eclipse/che-docs)
-->
fixes https://github.com/eclipse/che/issues/21436

### How to test this PR?
<!-- Please explain for example :
  - The test platform (openshift, kubernetes, minikube, CodeReady Container, docker-desktop, etc)
  - Installation method: chectl / che-operator
  - steps to reproduce
 -->
1. Deploy Eclipse che with the PR image and specific operator image: `chectl server:deploy -p=openshift  -i=quay.io/ivinokur/che-server:next`
2. Apply the related dashboard pr: https://github.com/eclipse-che/che-dashboard/pull/599
3. Setup [github oauth configuration ](https://www.eclipse.org/che/docs/stable/administration-guide/configuring-oauth-2-for-github)
4. create a factory from public GH repo
5. Reject the GitHub Authentication

See: Factory is created without the authentication request.
### PR Checklist

[As the author of this Pull Request I made sure that:](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#pull-request-template-and-its-checklist)

- [ ] [The Eclipse Contributor Agreement is valid](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-eclipse-contributor-agreement-is-valid)
- [ ] [Code produced is complete](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-produced-is-complete)
- [ ] [Code builds without errors](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-builds-without-errors)
- [ ] [Tests are covering the bugfix](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#tests-are-covering-the-bugfix)
- [ ] [The repository devfile is up to date and works](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-repository-devfile-is-up-to-date-and-works)
- [ ] [Sections `What issues does this PR fix or reference` and `How to test this PR` completed](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#sections-what-issues-does-this-pr-fix-or-reference-and-how-to-test-this-pr-completed)
- [ ] [Relevant user documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [Relevant contributing documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [CI/CD changes implemented, documented and communicated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#cicd-changes-implemented-documented-and-communicated)

### Reviewers

Reviewers, please comment how you tested the PR when approving it.
