### PR TITLE
fix: Fix url resolving in the bitbucket api client

### DIFF
--- a/wsmaster/che-core-api-factory-bitbucket-server/src/main/java/org/eclipse/che/api/factory/server/bitbucket/server/HttpBitbucketServerApiClient.java
+++ b/wsmaster/che-core-api-factory-bitbucket-server/src/main/java/org/eclipse/che/api/factory/server/bitbucket/server/HttpBitbucketServerApiClient.java
@@ -70,7 +70,7 @@ public class HttpBitbucketServerApiClient implements BitbucketServerApiClient {
   private final HttpClient httpClient;
 
   public HttpBitbucketServerApiClient(String serverUrl, OAuthAuthenticator authenticator) {
-    this.serverUri = URI.create(serverUrl);
+    this.serverUri = URI.create(serverUrl.endsWith("/") ? serverUrl : serverUrl + "/");
     this.authenticator = authenticator;
     this.httpClient =
         HttpClient.newBuilder()
@@ -131,7 +131,7 @@ public class HttpBitbucketServerApiClient implements BitbucketServerApiClient {
   @Override
   public BitbucketUser getUser(String slug, @Nullable String token)
       throws ScmItemNotFoundException, ScmUnauthorizedException, ScmCommunicationException {
-    URI uri = serverUri.resolve("/rest/api/1.0/users/" + slug);
+    URI uri = serverUri.resolve("./rest/api/1.0/users/" + slug);
     HttpRequest request =
         HttpRequest.newBuilder(uri)
             .headers(
@@ -163,7 +163,7 @@ public class HttpBitbucketServerApiClient implements BitbucketServerApiClient {
   public List<BitbucketUser> getUsers()
       throws ScmBadRequestException, ScmUnauthorizedException, ScmCommunicationException {
     try {
-      return doGetItems(BitbucketUser.class, "/rest/api/1.0/users", null);
+      return doGetItems(BitbucketUser.class, "./rest/api/1.0/users", null);
     } catch (ScmItemNotFoundException e) {
       throw new ScmCommunicationException(e.getMessage(), e);
     }
@@ -173,7 +173,7 @@ public class HttpBitbucketServerApiClient implements BitbucketServerApiClient {
   public List<BitbucketUser> getUsers(String filter)
       throws ScmBadRequestException, ScmUnauthorizedException, ScmCommunicationException {
     try {
-      return doGetItems(BitbucketUser.class, "/rest/api/1.0/users", filter);
+      return doGetItems(BitbucketUser.class, "./rest/api/1.0/users", filter);
     } catch (ScmItemNotFoundException e) {
       throw new ScmCommunicationException(e.getMessage(), e);
     }
@@ -182,7 +182,7 @@ public class HttpBitbucketServerApiClient implements BitbucketServerApiClient {
   @Override
   public void deletePersonalAccessTokens(String userSlug, Long tokenId)
       throws ScmItemNotFoundException, ScmUnauthorizedException, ScmCommunicationException {
-    URI uri = serverUri.resolve("/rest/access-tokens/1.0/users/" + userSlug + "/" + tokenId);
+    URI uri = serverUri.resolve("./rest/access-tokens/1.0/users/" + userSlug + "/" + tokenId);
     HttpRequest request =
         HttpRequest.newBuilder(uri)
             .DELETE()
@@ -217,7 +217,7 @@ public class HttpBitbucketServerApiClient implements BitbucketServerApiClient {
   public BitbucketPersonalAccessToken createPersonalAccessTokens(
       String userSlug, String tokenName, Set<String> permissions)
       throws ScmBadRequestException, ScmUnauthorizedException, ScmCommunicationException {
-    URI uri = serverUri.resolve("/rest/access-tokens/1.0/users/" + userSlug);
+    URI uri = serverUri.resolve("./rest/access-tokens/1.0/users/" + userSlug);
 
     try {
       HttpRequest request =
@@ -256,7 +256,7 @@ public class HttpBitbucketServerApiClient implements BitbucketServerApiClient {
       throws ScmItemNotFoundException, ScmUnauthorizedException, ScmCommunicationException {
     try {
       return doGetItems(
-          BitbucketPersonalAccessToken.class, "/rest/access-tokens/1.0/users/" + userSlug, null);
+          BitbucketPersonalAccessToken.class, "./rest/access-tokens/1.0/users/" + userSlug, null);
     } catch (ScmBadRequestException e) {
       throw new ScmCommunicationException(e.getMessage(), e);
     }
@@ -265,7 +265,7 @@ public class HttpBitbucketServerApiClient implements BitbucketServerApiClient {
   @Override
   public BitbucketPersonalAccessToken getPersonalAccessToken(String userSlug, Long tokenId)
       throws ScmItemNotFoundException, ScmUnauthorizedException, ScmCommunicationException {
-    URI uri = serverUri.resolve("/rest/access-tokens/1.0/users/" + userSlug + "/" + tokenId);
+    URI uri = serverUri.resolve("./rest/access-tokens/1.0/users/" + userSlug + "/" + tokenId);
     HttpRequest request =
         HttpRequest.newBuilder(uri)
             .headers(

--- a/wsmaster/che-core-api-factory-bitbucket-server/src/test/java/org/eclipse/che/security/oauth1/BitbucketServerApiClientProviderTest.java
+++ b/wsmaster/che-core-api-factory-bitbucket-server/src/test/java/org/eclipse/che/security/oauth1/BitbucketServerApiClientProviderTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012-2021 Red Hat, Inc.
+ * Copyright (c) 2012-2022 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/
@@ -57,15 +57,15 @@ public class BitbucketServerApiClientProviderTest {
     // given
     BitbucketServerApiProvider bitbucketServerApiProvider =
         new BitbucketServerApiProvider(
-            "https://bitbucket.server.com/, https://bitbucket2.server.com/",
-            "https://bitbucket.server.com/",
+            "https://bitbucket.server.com, https://bitbucket2.server.com",
+            "https://bitbucket.server.com",
             ImmutableSet.of(oAuthAuthenticator));
     // when
     BitbucketServerApiClient actual = bitbucketServerApiProvider.get();
     // then
     assertNotNull(actual);
     // internal representation always w/out slashes
-    assertTrue(actual.isConnected("https://bitbucket.server.com"));
+    assertTrue(actual.isConnected("https://bitbucket.server.com/"));
   }
 
   @Test(dataProvider = "noopConfig")


### PR DESCRIPTION
Signed-off-by: Igor Vinokur <ivinokur@redhat.com>

<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests
-->

### What does this PR do?
Fix a bug where url is not resolved correctly if a server url has path segments. `URI.create(https://server-url/path-segment).resolve(/second-path)` returns `https://server-url/second-path`, so the `path-segment` is ignored. [See](https://cdivilly.wordpress.com/2014/03/11/why-trailing-slashes-on-uris-are-important/)  for more details.

Add a trailing `/` to the server url and make the rest api segments reletive to fix the problem.

### Screenshot/screencast of this PR
<!-- Please include a screenshot or a screencast explaining what is doing this PR -->


### What issues does this PR fix or reference?
<!-- Please include any related issue from eclipse che repository (or from another issue tracker).
     Include link to other pull requests like documentation PR from [the docs repo](https://github.com/eclipse/che-docs)
-->


### How to test this PR?
<!-- Please explain for example :
  - The test platform (openshift, kubernetes, minikube, CodeReady Container, docker-desktop, etc)
  - Installation method: chectl / che-operator
  - steps to reproduce
 -->


### PR Checklist

[As the author of this Pull Request I made sure that:](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#pull-request-template-and-its-checklist)

- [ ] [The Eclipse Contributor Agreement is valid](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-eclipse-contributor-agreement-is-valid)
- [ ] [Code produced is complete](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-produced-is-complete)
- [ ] [Code builds without errors](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-builds-without-errors)
- [ ] [Tests are covering the bugfix](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#tests-are-covering-the-bugfix)
- [ ] [The repository devfile is up to date and works](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-repository-devfile-is-up-to-date-and-works)
- [ ] [Sections `What issues does this PR fix or reference` and `How to test this PR` completed](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#sections-what-issues-does-this-pr-fix-or-reference-and-how-to-test-this-pr-completed)
- [ ] [Relevant user documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [Relevant contributing documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [CI/CD changes implemented, documented and communicated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#cicd-changes-implemented-documented-and-communicated)

### Reviewers

Reviewers, please comment how you tested the PR when approving it.
