### PR TITLE
chore: Support configuring the GitHub OAuth endpoint

### DIFF
--- a/assembly/assembly-wsmaster-war/src/main/webapp/WEB-INF/classes/che/che.properties
+++ b/assembly/assembly-wsmaster-war/src/main/webapp/WEB-INF/classes/che/che.properties
@@ -204,6 +204,9 @@ che.oauth.github.authuri= https://github.com/login/oauth/authorize
 # GitHub OAuth token URI.
 che.oauth.github.tokenuri= https://github.com/login/oauth/access_token
 
+# Address of the GitHub server with configured OAuth 2 integration
+che.integration.github.oauth_endpoint=NULL
+
 # GitHub OAuth redirect URIs.
 # Separate multiple values with comma, for example: URI,URI,URI
 che.oauth.github.redirecturis= http://localhost:${CHE_PORT}/api/oauth/callback

--- a/multiuser/keycloak/che-multiuser-keycloak-token-provider/src/main/java/org/eclipse/che/multiuser/keycloak/token/provider/oauth/OpenShiftGitHubOAuthAuthenticator.java
+++ b/multiuser/keycloak/che-multiuser-keycloak-token-provider/src/main/java/org/eclipse/che/multiuser/keycloak/token/provider/oauth/OpenShiftGitHubOAuthAuthenticator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012-2018 Red Hat, Inc.
+ * Copyright (c) 2012-2022 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/
@@ -33,7 +33,7 @@ public class OpenShiftGitHubOAuthAuthenticator extends GitHubOAuthAuthenticator 
       @Nullable @Named("che.oauth.github.tokenuri") String tokenUri)
       throws IOException {
 
-    super("NULL", "NULL", redirectUris, authUri, tokenUri);
+    super("NULL", "NULL", redirectUris, null, authUri, tokenUri);
 
     if (!isNullOrEmpty(authUri)
         && !isNullOrEmpty(tokenUri)

--- a/wsmaster/che-core-api-auth-github/pom.xml
+++ b/wsmaster/che-core-api-auth-github/pom.xml
@@ -60,6 +60,10 @@
             <artifactId>che-core-commons-inject</artifactId>
         </dependency>
         <dependency>
+            <groupId>org.eclipse.che.core</groupId>
+            <artifactId>che-core-commons-lang</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-api</artifactId>
         </dependency>

--- a/wsmaster/che-core-api-auth-github/src/test/java/org/eclipse/che/security/oauth/GitHubOAuthAuthenticatorProviderTest.java
+++ b/wsmaster/che-core-api-auth-github/src/test/java/org/eclipse/che/security/oauth/GitHubOAuthAuthenticatorProviderTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012-2021 Red Hat, Inc.
+ * Copyright (c) 2012-2022 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/
@@ -41,13 +41,19 @@ public class GitHubOAuthAuthenticatorProviderTest {
       String gitHubClientIdPath,
       String gitHubClientSecretPath,
       String[] redirectUris,
+      String oauthEndpoint,
       String authUri,
       String tokenUri)
       throws IOException {
     // given
     GitHubOAuthAuthenticatorProvider provider =
         new GitHubOAuthAuthenticatorProvider(
-            gitHubClientIdPath, gitHubClientSecretPath, redirectUris, authUri, tokenUri);
+            gitHubClientIdPath,
+            gitHubClientSecretPath,
+            redirectUris,
+            oauthEndpoint,
+            authUri,
+            tokenUri);
     // when
     OAuthAuthenticator authenticator = provider.get();
     // then
@@ -62,7 +68,12 @@ public class GitHubOAuthAuthenticatorProviderTest {
     // given
     GitHubOAuthAuthenticatorProvider provider =
         new GitHubOAuthAuthenticatorProvider(
-            emptyFile.getPath(), emptyFile.getPath(), new String[] {TEST_URI}, TEST_URI, TEST_URI);
+            emptyFile.getPath(),
+            emptyFile.getPath(),
+            new String[] {TEST_URI},
+            null,
+            TEST_URI,
+            TEST_URI);
     // when
     OAuthAuthenticator authenticator = provider.get();
     // then
@@ -80,6 +91,27 @@ public class GitHubOAuthAuthenticatorProviderTest {
             credentialFile.getPath(),
             credentialFile.getPath(),
             new String[] {TEST_URI},
+            null,
+            TEST_URI,
+            TEST_URI);
+    // when
+    OAuthAuthenticator authenticator = provider.get();
+
+    // then
+    assertNotNull(authenticator);
+    assertTrue(GitHubOAuthAuthenticator.class.isAssignableFrom(authenticator.getClass()));
+  }
+
+  @Test
+  public void shouldProvideValidGitHubOAuthAuthenticatorWithConfiguredOAuthEndpoint()
+      throws IOException {
+    // given
+    GitHubOAuthAuthenticatorProvider provider =
+        new GitHubOAuthAuthenticatorProvider(
+            credentialFile.getPath(),
+            credentialFile.getPath(),
+            new String[] {TEST_URI},
+            "https://custom.github.com/",
             TEST_URI,
             TEST_URI);
     // when
@@ -93,22 +125,40 @@ public class GitHubOAuthAuthenticatorProviderTest {
   @DataProvider(name = "noopConfig")
   public Object[][] noopConfig() {
     return new Object[][] {
-      {null, null, null, null, null},
-      {credentialFile.getPath(), emptyFile.getPath(), null, TEST_URI, null},
-      {emptyFile.getPath(), emptyFile.getPath(), null, null, TEST_URI},
-      {null, emptyFile.getPath(), null, TEST_URI, TEST_URI},
-      {null, credentialFile.getPath(), new String[] {}, null, null},
-      {emptyFile.getPath(), null, new String[] {}, "", ""},
-      {credentialFile.getPath(), null, new String[] {}, "", null},
-      {null, emptyFile.getPath(), new String[] {}, null, ""},
-      {credentialFile.getPath(), null, new String[] {}, TEST_URI, null},
-      {null, emptyFile.getPath(), new String[] {}, TEST_URI, TEST_URI},
-      {emptyFile.getPath(), null, new String[] {TEST_URI}, null, null},
-      {credentialFile.getPath(), null, new String[] {TEST_URI}, "", ""},
-      {credentialFile.getPath(), credentialFile.getPath(), new String[] {TEST_URI}, null, TEST_URI},
-      {credentialFile.getPath(), emptyFile.getPath(), new String[] {TEST_URI}, TEST_URI, null},
-      {credentialFile.getPath(), credentialFile.getPath(), new String[] {TEST_URI}, TEST_URI, ""},
-      {emptyFile.getPath(), emptyFile.getPath(), new String[] {TEST_URI}, "", TEST_URI}
+      {null, null, null, null, null, null},
+      {null, null, null, "", null, null},
+      {null, null, null, TEST_URI, null, null},
+      {credentialFile.getPath(), emptyFile.getPath(), null, null, TEST_URI, null},
+      {emptyFile.getPath(), emptyFile.getPath(), null, null, null, TEST_URI},
+      {null, emptyFile.getPath(), null, null, TEST_URI, TEST_URI},
+      {null, credentialFile.getPath(), new String[] {}, null, null, null},
+      {emptyFile.getPath(), null, new String[] {}, null, "", ""},
+      {credentialFile.getPath(), null, new String[] {}, null, "", null},
+      {null, emptyFile.getPath(), new String[] {}, null, null, ""},
+      {credentialFile.getPath(), null, new String[] {}, null, TEST_URI, null},
+      {null, emptyFile.getPath(), new String[] {}, null, TEST_URI, TEST_URI},
+      {emptyFile.getPath(), null, new String[] {TEST_URI}, null, null, null},
+      {credentialFile.getPath(), null, new String[] {TEST_URI}, null, "", ""},
+      {
+        credentialFile.getPath(),
+        credentialFile.getPath(),
+        new String[] {TEST_URI},
+        null,
+        null,
+        TEST_URI
+      },
+      {
+        credentialFile.getPath(), emptyFile.getPath(), new String[] {TEST_URI}, null, TEST_URI, null
+      },
+      {
+        credentialFile.getPath(),
+        credentialFile.getPath(),
+        new String[] {TEST_URI},
+        null,
+        TEST_URI,
+        ""
+      },
+      {emptyFile.getPath(), emptyFile.getPath(), new String[] {TEST_URI}, null, "", TEST_URI}
     };
   }
 }

--- a/wsmaster/che-core-api-factory-github/pom.xml
+++ b/wsmaster/che-core-api-factory-github/pom.xml
@@ -88,6 +88,10 @@
         </dependency>
         <dependency>
             <groupId>org.eclipse.che.core</groupId>
+            <artifactId>che-core-commons-annotations</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.che.core</groupId>
             <artifactId>che-core-commons-lang</artifactId>
         </dependency>
         <dependency>

--- a/wsmaster/che-core-api-factory-github/src/main/java/org/eclipse/che/api/factory/server/github/GithubPersonalAccessTokenFetcher.java
+++ b/wsmaster/che-core-api-factory-github/src/main/java/org/eclipse/che/api/factory/server/github/GithubPersonalAccessTokenFetcher.java
@@ -34,6 +34,7 @@ import org.eclipse.che.api.factory.server.scm.exception.ScmCommunicationExceptio
 import org.eclipse.che.api.factory.server.scm.exception.ScmItemNotFoundException;
 import org.eclipse.che.api.factory.server.scm.exception.ScmUnauthorizedException;
 import org.eclipse.che.api.factory.server.scm.exception.UnknownScmProviderException;
+import org.eclipse.che.commons.annotation.Nullable;
 import org.eclipse.che.commons.lang.NameGenerator;
 import org.eclipse.che.commons.subject.Subject;
 import org.eclipse.che.security.oauth.OAuthAPI;
@@ -117,8 +118,11 @@ public class GithubPersonalAccessTokenFetcher implements PersonalAccessTokenFetc
           .build();
 
   @Inject
-  public GithubPersonalAccessTokenFetcher(@Named("che.api") String apiEndpoint, OAuthAPI oAuthAPI) {
-    this(apiEndpoint, oAuthAPI, new GithubApiClient());
+  public GithubPersonalAccessTokenFetcher(
+      @Named("che.api") String apiEndpoint,
+      @Nullable @Named("che.integration.github.oauth_endpoint") String oauthEndpoint,
+      OAuthAPI oAuthAPI) {
+    this(apiEndpoint, oAuthAPI, new GithubApiClient(oauthEndpoint));
   }
 
   /**
@@ -161,7 +165,7 @@ public class GithubPersonalAccessTokenFetcher implements PersonalAccessTokenFetc
       if (valid.isEmpty()) {
         throw new ScmCommunicationException(
             "Unable to verify if current token is a valid GitHub token.  Token's scm-url needs to be '"
-                + GithubApiClient.GITHUB_SERVER
+                + GithubApiClient.GITHUB_SAAS_ENDPOINT
                 + "' and was '"
                 + token.getScmProviderUrl()
                 + "'");

--- a/wsmaster/che-core-api-factory-github/src/main/java/org/eclipse/che/api/factory/server/github/GithubUrl.java
+++ b/wsmaster/che-core-api-factory-github/src/main/java/org/eclipse/che/api/factory/server/github/GithubUrl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012-2021 Red Hat, Inc.
+ * Copyright (c) 2012-2022 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/
@@ -12,8 +12,8 @@
 package org.eclipse.che.api.factory.server.github;
 
 import static com.google.common.base.MoreObjects.firstNonNull;
+import static com.google.common.base.Strings.isNullOrEmpty;
 
-import com.google.common.base.Strings;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
@@ -46,6 +46,8 @@ public class GithubUrl implements RemoteFactoryUrl {
 
   /** Subfolder if any */
   private String subfolder;
+
+  private String serverUrl;
 
   /** Devfile filenames list */
   private final List<String> devfileFilenames = new ArrayList<>();
@@ -110,7 +112,7 @@ public class GithubUrl implements RemoteFactoryUrl {
   }
 
   protected GithubUrl withBranch(String branch) {
-    if (!Strings.isNullOrEmpty(branch)) {
+    if (!isNullOrEmpty(branch)) {
       this.branch = branch;
     }
     return this;
@@ -133,6 +135,11 @@ public class GithubUrl implements RemoteFactoryUrl {
    */
   protected GithubUrl withSubfolder(String subfolder) {
     this.subfolder = subfolder;
+    return this;
+  }
+
+  public GithubUrl withServerUrl(String serverUrl) {
+    this.serverUrl = serverUrl;
     return this;
   }
 
@@ -167,7 +174,7 @@ public class GithubUrl implements RemoteFactoryUrl {
    */
   public String rawFileLocation(String fileName) {
     return new StringJoiner("/")
-        .add("https://raw.githubusercontent.com")
+        .add(isNullOrEmpty(serverUrl) ? "https://raw.githubusercontent.com" : serverUrl + "/raw")
         .add(username)
         .add(repository)
         .add(firstNonNull(branch, "HEAD"))
@@ -177,7 +184,7 @@ public class GithubUrl implements RemoteFactoryUrl {
 
   @Override
   public String getHostName() {
-    return HOSTNAME;
+    return isNullOrEmpty(serverUrl) ? HOSTNAME : serverUrl;
   }
 
   /**
@@ -186,6 +193,11 @@ public class GithubUrl implements RemoteFactoryUrl {
    * @return location of the repository.
    */
   protected String repositoryLocation() {
-    return HOSTNAME + "/" + this.username + "/" + this.repository + ".git";
+    return (isNullOrEmpty(serverUrl) ? HOSTNAME : serverUrl)
+        + "/"
+        + this.username
+        + "/"
+        + this.repository
+        + ".git";
   }
 }

--- a/wsmaster/che-core-api-factory-github/src/main/java/org/eclipse/che/api/factory/server/github/GithubUserDataFetcher.java
+++ b/wsmaster/che-core-api-factory-github/src/main/java/org/eclipse/che/api/factory/server/github/GithubUserDataFetcher.java
@@ -29,6 +29,7 @@ import org.eclipse.che.api.factory.server.scm.exception.ScmBadRequestException;
 import org.eclipse.che.api.factory.server.scm.exception.ScmCommunicationException;
 import org.eclipse.che.api.factory.server.scm.exception.ScmItemNotFoundException;
 import org.eclipse.che.api.factory.server.scm.exception.ScmUnauthorizedException;
+import org.eclipse.che.commons.annotation.Nullable;
 import org.eclipse.che.commons.env.EnvironmentContext;
 import org.eclipse.che.commons.subject.Subject;
 import org.eclipse.che.security.oauth.OAuthAPI;
@@ -49,8 +50,11 @@ public class GithubUserDataFetcher implements GitUserDataFetcher {
       ImmutableSet.of("repo", "user:email", "read:user");
 
   @Inject
-  public GithubUserDataFetcher(@Named("che.api") String apiEndpoint, OAuthAPI oAuthAPI) {
-    this(apiEndpoint, oAuthAPI, new GithubApiClient());
+  public GithubUserDataFetcher(
+      @Named("che.api") String apiEndpoint,
+      @Nullable @Named("che.integration.github.oauth_endpoint") String oauthEndpoint,
+      OAuthAPI oAuthAPI) {
+    this(apiEndpoint, oAuthAPI, new GithubApiClient(oauthEndpoint));
   }
 
   /** Constructor used for testing only. */

--- a/wsmaster/che-core-api-factory-github/src/test/java/org/eclipse/che/api/factory/server/github/GithubApiClientTest.java
+++ b/wsmaster/che-core-api-factory-github/src/test/java/org/eclipse/che/api/factory/server/github/GithubApiClientTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012-2021 Red Hat, Inc.
+ * Copyright (c) 2012-2022 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/
@@ -58,7 +58,7 @@ public class GithubApiClientTest {
   @Test
   public void testGetUser() throws Exception {
     stubFor(
-        get(urlEqualTo("/user"))
+        get(urlEqualTo("/api/v3/user"))
             .withHeader(HttpHeaders.AUTHORIZATION, equalTo("token token1"))
             .willReturn(
                 aResponse()
@@ -81,7 +81,7 @@ public class GithubApiClientTest {
   @Test
   public void testGetTokenScopes() throws Exception {
     stubFor(
-        get(urlEqualTo("/user"))
+        get(urlEqualTo("/api/v3/user"))
             .withHeader(HttpHeaders.AUTHORIZATION, equalTo("token token1"))
             .willReturn(
                 aResponse()
@@ -99,7 +99,7 @@ public class GithubApiClientTest {
   @Test
   public void testGetTokenScopesWithNoScopeHeader() throws Exception {
     stubFor(
-        get(urlEqualTo("/user"))
+        get(urlEqualTo("/api/v3/user"))
             .withHeader(HttpHeaders.AUTHORIZATION, equalTo("token token1"))
             .willReturn(
                 aResponse()
@@ -119,7 +119,7 @@ public class GithubApiClientTest {
   @Test
   public void testGetTokenScopesWithNoScope() throws Exception {
     stubFor(
-        get(urlEqualTo("/user"))
+        get(urlEqualTo("/api/v3/user"))
             .withHeader(HttpHeaders.AUTHORIZATION, equalTo("token token1"))
             .willReturn(
                 aResponse()
@@ -144,6 +144,6 @@ public class GithubApiClientTest {
 
   @Test
   public void shouldReturnTrueWhenConnectedToGithub() {
-    assertTrue(client.isConnected("https://github.com"));
+    assertTrue(client.isConnected(wireMockServer.url("/")));
   }
 }

--- a/wsmaster/che-core-api-factory-github/src/test/java/org/eclipse/che/api/factory/server/github/GithubFactoryParametersResolverTest.java
+++ b/wsmaster/che-core-api-factory-github/src/test/java/org/eclipse/che/api/factory/server/github/GithubFactoryParametersResolverTest.java
@@ -21,7 +21,6 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.ArgumentMatchers.anyMap;
 import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -102,8 +101,7 @@ public class GithubFactoryParametersResolverTest {
   @BeforeMethod
   protected void init() {
     githubUrlParser =
-        new GithubURLParser(
-            personalAccessTokenManager, devfileFilenamesProvider, mock(GithubApiClient.class));
+        new GithubURLParser(personalAccessTokenManager, devfileFilenamesProvider, null);
     assertNotNull(this.githubUrlParser);
     githubFactoryParametersResolver =
         new GithubFactoryParametersResolver(

--- a/wsmaster/che-core-api-factory-github/src/test/java/org/eclipse/che/api/factory/server/github/GithubGitUserDataFetcherTest.java
+++ b/wsmaster/che-core-api-factory-github/src/test/java/org/eclipse/che/api/factory/server/github/GithubGitUserDataFetcherTest.java
@@ -59,7 +59,7 @@ public class GithubGitUserDataFetcherTest {
         new GithubUserDataFetcher(
             "http://che.api", oAuthAPI, new GithubApiClient(wireMockServer.url("/")));
     stubFor(
-        get(urlEqualTo("/user"))
+        get(urlEqualTo("/api/v3/user"))
             .withHeader(HttpHeaders.AUTHORIZATION, equalTo("token " + githubOauthToken))
             .willReturn(
                 aResponse()

--- a/wsmaster/che-core-api-factory-github/src/test/java/org/eclipse/che/api/factory/server/github/GithubPersonalAccessTokenFetcherTest.java
+++ b/wsmaster/che-core-api-factory-github/src/test/java/org/eclipse/che/api/factory/server/github/GithubPersonalAccessTokenFetcherTest.java
@@ -143,7 +143,7 @@ public class GithubPersonalAccessTokenFetcherTest {
     when(oAuthAPI.getToken(anyString())).thenReturn(oAuthToken);
 
     stubFor(
-        get(urlEqualTo("/user"))
+        get(urlEqualTo("/api/v3/user"))
             .withHeader(HttpHeaders.AUTHORIZATION, equalTo("token " + githubOauthToken))
             .willReturn(
                 aResponse()
@@ -151,7 +151,7 @@ public class GithubPersonalAccessTokenFetcherTest {
                     .withHeader(GithubApiClient.GITHUB_OAUTH_SCOPES_HEADER, "")
                     .withBodyFile("github/rest/user/response.json")));
 
-    githubPATFetcher.fetchPersonalAccessToken(subject, GithubApiClient.GITHUB_SERVER);
+    githubPATFetcher.fetchPersonalAccessToken(subject, wireMockServer.url("/"));
   }
 
   @Test(
@@ -161,7 +161,7 @@ public class GithubPersonalAccessTokenFetcherTest {
     Subject subject = new SubjectImpl("Username", "id1", "token", false);
     when(oAuthAPI.getToken(anyString())).thenThrow(UnauthorizedException.class);
 
-    githubPATFetcher.fetchPersonalAccessToken(subject, GithubApiClient.GITHUB_SERVER);
+    githubPATFetcher.fetchPersonalAccessToken(subject, wireMockServer.url("/"));
   }
 
   @Test
@@ -171,7 +171,7 @@ public class GithubPersonalAccessTokenFetcherTest {
     when(oAuthAPI.getToken(anyString())).thenReturn(oAuthToken);
 
     stubFor(
-        get(urlEqualTo("/user"))
+        get(urlEqualTo("/api/v3/user"))
             .withHeader(HttpHeaders.AUTHORIZATION, equalTo("token " + githubOauthToken))
             .willReturn(
                 aResponse()
@@ -182,14 +182,14 @@ public class GithubPersonalAccessTokenFetcherTest {
                     .withBodyFile("github/rest/user/response.json")));
 
     PersonalAccessToken token =
-        githubPATFetcher.fetchPersonalAccessToken(subject, GithubApiClient.GITHUB_SERVER);
+        githubPATFetcher.fetchPersonalAccessToken(subject, wireMockServer.url("/"));
     assertNotNull(token);
   }
 
   @Test
   public void shouldValidatePersonalToken() throws Exception {
     stubFor(
-        get(urlEqualTo("/user"))
+        get(urlEqualTo("/api/v3/user"))
             .withHeader(HttpHeaders.AUTHORIZATION, equalTo("token " + githubOauthToken))
             .willReturn(
                 aResponse()
@@ -201,7 +201,7 @@ public class GithubPersonalAccessTokenFetcherTest {
 
     PersonalAccessToken token =
         new PersonalAccessToken(
-            "https://github.com",
+            wireMockServer.url("/"),
             "cheUser",
             "username",
             "123456789",
@@ -215,7 +215,7 @@ public class GithubPersonalAccessTokenFetcherTest {
   @Test
   public void shouldValidateOauthToken() throws Exception {
     stubFor(
-        get(urlEqualTo("/user"))
+        get(urlEqualTo("/api/v3/user"))
             .withHeader(HttpHeaders.AUTHORIZATION, equalTo("token " + githubOauthToken))
             .willReturn(
                 aResponse()
@@ -227,7 +227,7 @@ public class GithubPersonalAccessTokenFetcherTest {
 
     PersonalAccessToken token =
         new PersonalAccessToken(
-            "https://github.com",
+            wireMockServer.url("/"),
             "cheUser",
             "username",
             "123456789",
@@ -240,11 +240,11 @@ public class GithubPersonalAccessTokenFetcherTest {
 
   @Test
   public void shouldNotValidateExpiredOauthToken() throws Exception {
-    stubFor(get(urlEqualTo("/user")).willReturn(aResponse().withStatus(HTTP_FORBIDDEN)));
+    stubFor(get(urlEqualTo("/api/v3/user")).willReturn(aResponse().withStatus(HTTP_FORBIDDEN)));
 
     PersonalAccessToken token =
         new PersonalAccessToken(
-            "https://github.com",
+            wireMockServer.url("/"),
             "cheUser",
             "username",
             "123456789",

--- a/wsmaster/che-core-api-factory-github/src/test/java/org/eclipse/che/api/factory/server/github/GithubScmFileResolverTest.java
+++ b/wsmaster/che-core-api-factory-github/src/test/java/org/eclipse/che/api/factory/server/github/GithubScmFileResolverTest.java
@@ -13,7 +13,6 @@ package org.eclipse.che.api.factory.server.github;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
-import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 import static org.testng.Assert.*;
 
@@ -45,8 +44,7 @@ public class GithubScmFileResolverTest {
   @BeforeMethod
   protected void init() {
     githubURLParser =
-        new GithubURLParser(
-            personalAccessTokenManager, devfileFilenamesProvider, mock(GithubApiClient.class));
+        new GithubURLParser(personalAccessTokenManager, devfileFilenamesProvider, null);
     assertNotNull(this.githubURLParser);
     githubScmFileResolver =
         new GithubScmFileResolver(
@@ -65,7 +63,7 @@ public class GithubScmFileResolverTest {
   @Test
   public void checkValidAcceptUrl() {
     // should be accepted
-    assertTrue(githubScmFileResolver.accept("http://github.com/test/repo.git"));
+    assertTrue(githubScmFileResolver.accept("https://github.com/test/repo.git"));
   }
 
   @Test
@@ -77,7 +75,8 @@ public class GithubScmFileResolverTest {
     when(personalAccessTokenManager.fetchAndSave(any(), anyString()))
         .thenReturn(personalAccessToken);
 
-    String content = githubScmFileResolver.fileContent("http://github.com/test/repo.git", filename);
+    String content =
+        githubScmFileResolver.fileContent("https://github.com/test/repo.git", filename);
 
     assertEquals(content, rawContent);
   }


### PR DESCRIPTION
Signed-off-by: Igor Vinokur <ivinokur@redhat.com>

<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests
-->

### What does this PR do?
Currently the GitHub OAuth provider is hardcoded to `https://github.com` endpoint. In order to support Github Enterprise Server, the endpoint of the GitHub OAuth provider is configurable by the oauth secret.

### Screenshot/screencast of this PR
<!-- Please include a screenshot or a screencast explaining what is doing this PR -->


### What issues does this PR fix or reference?
<!-- Please include any related issue from eclipse che repository (or from another issue tracker).
     Include link to other pull requests like documentation PR from [the docs repo](https://github.com/eclipse/che-docs)
-->
https://github.com/eclipse/che/issues/21485

### How to test this PR?
<!-- Please explain for example :
  - The test platform (openshift, kubernetes, minikube, CodeReady Container, docker-desktop, etc)
  - Installation method: chectl / che-operator
  - steps to reproduce
 -->
1. Deploy Che from the custom `che-server` image built from the PR source: `quay.io/ivinokur/che-server:next`.
2. Apply the GitHub OAuth secret:
```YAML
kind: Secret
apiVersion: v1
metadata:
  name: github-oauth-config
  labels:
    app.kubernetes.io/component: oauth-scm-configuration
    app.kubernetes.io/part-of: che.eclipse.org
  annotations:
    che.eclipse.org/oauth-scm-server: github
    che.eclipse.org/scm-server-endpoint: 'http://37.139.177.199/'
data:
  id: YTFmOTcyYWM4ZGM4ZTRlNjJjN2I=
  secret: N2E3OGYwZjIxMmFkOGZlMGEyYjVlZGQzZDlhOTg0NmQxOGVhMDYwYg==
type: Opaque
```
The secret refers to the GitHub Enterprise Server instace, launched in my local virtualbox environment, and exposed to `http://37.139.177.199`, [see](https://www.eclipse.org/che/docs/stable/administration-guide/configuring-oauth-2-for-github/#applying-the-github-oauth-app-secret_che) for more details.
3. Ping me to start the GitHub instance :) or use your own application, but configure the endpoint in the secret.
4. Start a factory from `http://37.139.177.199/test/test.git` or your own repo.
### PR Checklist

[As the author of this Pull Request I made sure that:](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#pull-request-template-and-its-checklist)

- [ ] [The Eclipse Contributor Agreement is valid](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-eclipse-contributor-agreement-is-valid)
- [ ] [Code produced is complete](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-produced-is-complete)
- [ ] [Code builds without errors](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-builds-without-errors)
- [ ] [Tests are covering the bugfix](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#tests-are-covering-the-bugfix)
- [ ] [The repository devfile is up to date and works](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-repository-devfile-is-up-to-date-and-works)
- [ ] [Sections `What issues does this PR fix or reference` and `How to test this PR` completed](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#sections-what-issues-does-this-pr-fix-or-reference-and-how-to-test-this-pr-completed)
- [ ] [Relevant user documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [Relevant contributing documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [CI/CD changes implemented, documented and communicated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#cicd-changes-implemented-documented-and-communicated)

### Reviewers

Reviewers, please comment how you tested the PR when approving it.
