### PR TITLE
fix: Allow to get files from git repository if file name starts with dot

### DIFF
--- a/wsmaster/che-core-api-factory-bitbucket-server/src/test/java/org/eclipse/che/api/factory/server/bitbucket/BitbucketServerAuthorizingFileContentProviderTest.java
+++ b/wsmaster/che-core-api-factory-bitbucket-server/src/test/java/org/eclipse/che/api/factory/server/bitbucket/BitbucketServerAuthorizingFileContentProviderTest.java
@@ -112,7 +112,6 @@ public class BitbucketServerAuthorizingFileContentProviderTest {
   public static Object[][] relativePathsProvider() {
     return new Object[][] {
       {"./file.txt", "https://foo.bar/rest/api/1.0/projects/proj/repos/repo/raw/file.txt", null},
-      {"../file.txt", "https://foo.bar/rest/api/1.0/projects/proj/repos/repo/raw/file.txt", null},
       {"/file.txt", "https://foo.bar/rest/api/1.0/projects/proj/repos/repo/raw/file.txt", null},
       {"file.txt", "https://foo.bar/rest/api/1.0/projects/proj/repos/repo/raw/file.txt", null},
       {

--- a/wsmaster/che-core-api-factory/src/main/java/org/eclipse/che/api/factory/server/scm/AuthorizingFileContentProvider.java
+++ b/wsmaster/che-core-api-factory/src/main/java/org/eclipse/che/api/factory/server/scm/AuthorizingFileContentProvider.java
@@ -139,14 +139,16 @@ public class AuthorizingFileContentProvider<T extends RemoteFactoryUrl>
     return false;
   }
 
-  private String formatUrl(String fileURL) throws DevfileException {
+  protected String formatUrl(String fileURL) throws DevfileException {
     String requestURL;
     try {
       if (new URI(fileURL).isAbsolute()) {
         requestURL = fileURL;
       } else {
-        // since files retrieved via REST, we cannot use path symbols like . ./ so cut them off
-        requestURL = remoteFactoryUrl.rawFileLocation(fileURL.replaceAll("^[/.]+", ""));
+        // since files retrieved via REST, we cannot use path like '.' or one that starts with './'
+        // so cut them off
+        requestURL =
+            remoteFactoryUrl.rawFileLocation(fileURL.replaceAll("^(?:\\.?\\/)|(?:\\.$)", ""));
       }
     } catch (URISyntaxException e) {
       throw new DevfileException(e.getMessage(), e);


### PR DESCRIPTION
Signed-off-by: Vitaliy Gulyy <vgulyy@redhat.com>

<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests
-->

### What does this PR do?
Fixes retrieving files from git repository when filename or directory name starts with dots.


### Screenshot/screencast of this PR
<!-- Please include a screenshot or a screencast explaining what is doing this PR -->

![Screenshot from 2022-09-07 18-01-29](https://user-images.githubusercontent.com/1655894/188923141-39ed7c01-ac0b-46d2-87af-0b42c54609a1.png)

![Screenshot from 2022-09-07 18-10-39](https://user-images.githubusercontent.com/1655894/188926460-caa22dda-d05f-4da4-9c52-f1aaf1027b92.png)

### What issues does this PR fix or reference?
<!-- Please include any related issue from eclipse che repository (or from another issue tracker).
     Include link to other pull requests like documentation PR from [the docs repo](https://github.com/eclipse/che-docs)
-->
Fixes https://github.com/eclipse/che/issues/21635, and potentially https://github.com/eclipse/che/issues/21639
Could solve  as well

### How to test this PR?
<!-- Please explain for example :
  - The test platform (openshift, kubernetes, minikube, CodeReady Container, docker-desktop, etc)
  - Installation method: chectl / che-operator
  - steps to reproduce
 -->
1. Deploy Che with
```
chectl server:deploy -p=minikube -i=quay.io/vgulyy/che-server:test-fetching-git-files
```

2. Create a workspace with a factory
https://github.com/che-samples/java-spring-petclinic/tree/devfilev2?che-editor=eclipse/che-theia/next

3. Open Plugins view, check for installed plugins. Open terminal in editor container, check for `.vsix` files existence in `/plugins/sidecars/tools` directory.


### PR Checklist

[As the author of this Pull Request I made sure that:](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#pull-request-template-and-its-checklist)

- [ ] [The Eclipse Contributor Agreement is valid](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-eclipse-contributor-agreement-is-valid)
- [x] [Code produced is complete](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-produced-is-complete)
- [x] [Code builds without errors](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-builds-without-errors)
- [x] [Tests are covering the bugfix](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#tests-are-covering-the-bugfix)
- [ ] [The repository devfile is up to date and works](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-repository-devfile-is-up-to-date-and-works)
- [ ] [Sections `What issues does this PR fix or reference` and `How to test this PR` completed](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#sections-what-issues-does-this-pr-fix-or-reference-and-how-to-test-this-pr-completed)
- [ ] [Relevant user documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [Relevant contributing documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [CI/CD changes implemented, documented and communicated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#cicd-changes-implemented-documented-and-communicated)

### Reviewers

Reviewers, please comment how you tested the PR when approving it.
