### PR TITLE
feat: Delegate only needed roles to user in his namespace

### DIFF
--- a/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/namespace/KubernetesNamespace.java
+++ b/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/namespace/KubernetesNamespace.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012-2021 Red Hat, Inc.
+ * Copyright (c) 2012-2022 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/
@@ -153,10 +153,10 @@ public class KubernetesNamespace {
         throw new InfrastructureException(
             format("Creating the namespace '%s' is not allowed, yet it was not found.", name));
       }
-      namespace = create(name, client);
+      create(name, client);
     }
-    label(namespace, labels);
-    annotate(namespace, annotations);
+    label(client.namespaces().withName(name).get(), labels);
+    annotate(client.namespaces().withName(name).get(), annotations);
   }
 
   /**

--- a/infrastructures/openshift/pom.xml
+++ b/infrastructures/openshift/pom.xml
@@ -52,6 +52,10 @@
         </dependency>
         <dependency>
             <groupId>io.fabric8</groupId>
+            <artifactId>kubernetes-model-rbac</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.fabric8</groupId>
             <artifactId>openshift-client</artifactId>
         </dependency>
         <dependency>

--- a/infrastructures/openshift/src/main/java/org/eclipse/che/workspace/infrastructure/openshift/OpenShiftInfraModule.java
+++ b/infrastructures/openshift/src/main/java/org/eclipse/che/workspace/infrastructure/openshift/OpenShiftInfraModule.java
@@ -49,7 +49,14 @@ import org.eclipse.che.workspace.infrastructure.kubernetes.devfile.KubernetesDev
 import org.eclipse.che.workspace.infrastructure.kubernetes.environment.KubernetesEnvironment;
 import org.eclipse.che.workspace.infrastructure.kubernetes.environment.KubernetesEnvironmentFactory;
 import org.eclipse.che.workspace.infrastructure.kubernetes.namespace.KubernetesNamespaceFactory;
-import org.eclipse.che.workspace.infrastructure.kubernetes.namespace.configurator.*;
+import org.eclipse.che.workspace.infrastructure.kubernetes.namespace.configurator.CredentialsSecretConfigurator;
+import org.eclipse.che.workspace.infrastructure.kubernetes.namespace.configurator.GitconfigUserDataConfigurator;
+import org.eclipse.che.workspace.infrastructure.kubernetes.namespace.configurator.NamespaceConfigurator;
+import org.eclipse.che.workspace.infrastructure.kubernetes.namespace.configurator.PreferencesConfigMapConfigurator;
+import org.eclipse.che.workspace.infrastructure.kubernetes.namespace.configurator.SshKeysConfigurator;
+import org.eclipse.che.workspace.infrastructure.kubernetes.namespace.configurator.UserPermissionConfigurator;
+import org.eclipse.che.workspace.infrastructure.kubernetes.namespace.configurator.UserPreferencesConfigurator;
+import org.eclipse.che.workspace.infrastructure.kubernetes.namespace.configurator.UserProfileConfigurator;
 import org.eclipse.che.workspace.infrastructure.kubernetes.provision.GatewayTlsProvisioner;
 import org.eclipse.che.workspace.infrastructure.kubernetes.provision.KubernetesCheApiExternalEnvVarProvider;
 import org.eclipse.che.workspace.infrastructure.kubernetes.provision.KubernetesCheApiInternalEnvVarProvider;

--- a/infrastructures/openshift/src/main/java/org/eclipse/che/workspace/infrastructure/openshift/OpenShiftInfraModule.java
+++ b/infrastructures/openshift/src/main/java/org/eclipse/che/workspace/infrastructure/openshift/OpenShiftInfraModule.java
@@ -49,13 +49,7 @@ import org.eclipse.che.workspace.infrastructure.kubernetes.devfile.KubernetesDev
 import org.eclipse.che.workspace.infrastructure.kubernetes.environment.KubernetesEnvironment;
 import org.eclipse.che.workspace.infrastructure.kubernetes.environment.KubernetesEnvironmentFactory;
 import org.eclipse.che.workspace.infrastructure.kubernetes.namespace.KubernetesNamespaceFactory;
-import org.eclipse.che.workspace.infrastructure.kubernetes.namespace.configurator.CredentialsSecretConfigurator;
-import org.eclipse.che.workspace.infrastructure.kubernetes.namespace.configurator.GitconfigUserDataConfigurator;
-import org.eclipse.che.workspace.infrastructure.kubernetes.namespace.configurator.NamespaceConfigurator;
-import org.eclipse.che.workspace.infrastructure.kubernetes.namespace.configurator.PreferencesConfigMapConfigurator;
-import org.eclipse.che.workspace.infrastructure.kubernetes.namespace.configurator.SshKeysConfigurator;
-import org.eclipse.che.workspace.infrastructure.kubernetes.namespace.configurator.UserPreferencesConfigurator;
-import org.eclipse.che.workspace.infrastructure.kubernetes.namespace.configurator.UserProfileConfigurator;
+import org.eclipse.che.workspace.infrastructure.kubernetes.namespace.configurator.*;
 import org.eclipse.che.workspace.infrastructure.kubernetes.provision.GatewayTlsProvisioner;
 import org.eclipse.che.workspace.infrastructure.kubernetes.provision.KubernetesCheApiExternalEnvVarProvider;
 import org.eclipse.che.workspace.infrastructure.kubernetes.provision.KubernetesCheApiInternalEnvVarProvider;
@@ -107,6 +101,7 @@ public class OpenShiftInfraModule extends AbstractModule {
 
     Multibinder<NamespaceConfigurator> namespaceConfigurators =
         Multibinder.newSetBinder(binder(), NamespaceConfigurator.class);
+    namespaceConfigurators.addBinding().to(UserPermissionConfigurator.class);
     namespaceConfigurators.addBinding().to(UserProfileConfigurator.class);
     namespaceConfigurators.addBinding().to(UserPreferencesConfigurator.class);
     namespaceConfigurators.addBinding().to(CredentialsSecretConfigurator.class);

--- a/infrastructures/openshift/src/test/java/org/eclipse/che/workspace/infrastructure/openshift/project/OpenShiftProjectTest.java
+++ b/infrastructures/openshift/src/test/java/org/eclipse/che/workspace/infrastructure/openshift/project/OpenShiftProjectTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012-2021 Red Hat, Inc.
+ * Copyright (c) 2012-2022 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/
@@ -26,7 +26,6 @@ import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertNotNull;
 import static org.testng.Assert.assertTrue;
 
-import com.google.common.collect.ImmutableList;
 import io.fabric8.kubernetes.api.model.Namespace;
 import io.fabric8.kubernetes.api.model.NamespaceBuilder;
 import io.fabric8.kubernetes.api.model.ServiceAccount;
@@ -42,7 +41,6 @@ import io.fabric8.openshift.api.model.ProjectRequest;
 import io.fabric8.openshift.api.model.ProjectRequestFluent.MetadataNested;
 import io.fabric8.openshift.api.model.RoleBinding;
 import io.fabric8.openshift.api.model.RoleBindingList;
-import io.fabric8.openshift.api.model.UserBuilder;
 import io.fabric8.openshift.client.OpenShiftClient;
 import io.fabric8.openshift.client.dsl.ProjectOperation;
 import io.fabric8.openshift.client.dsl.ProjectRequestOperation;
@@ -112,6 +110,9 @@ public class OpenShiftProjectTest {
     lenient().when(clientFactory.createOC(anyString())).thenReturn(openShiftClient);
 
     lenient().when(cheServerOpenshiftClientFactory.createOC()).thenReturn(openShiftCheServerClient);
+    lenient()
+        .when(cheServerOpenshiftClientFactory.createOC(anyString()))
+        .thenReturn(openShiftCheServerClient);
 
     lenient().when(openShiftClient.adapt(OpenShiftClient.class)).thenReturn(openShiftClient);
 
@@ -202,13 +203,6 @@ public class OpenShiftProjectTest {
     when(namespaceOperation.withName(anyString())).thenReturn(serviceAccountResource);
     when(serviceAccountResource.get()).thenReturn(mock(ServiceAccount.class));
     doReturn(projectRequestOperation).when(openShiftCheServerClient).projectrequests();
-    // doReturn(metadataNested).when(metadataNested).withName(anyString());
-    when(openShiftCheServerClient.roleBindings()).thenReturn(mixedRoleBindingOperation);
-    lenient()
-        .when(mixedRoleBindingOperation.inNamespace(anyString()))
-        .thenReturn(nonNamespaceRoleBindingOperation);
-    when(openShiftClient.currentUser())
-        .thenReturn(new UserBuilder().withNewMetadata().withName("user").endMetadata().build());
     // when
     openShiftProject.prepare(true, true, Map.of(), Map.of());
 
@@ -218,46 +212,6 @@ public class OpenShiftProjectTest {
     Assert.assertEquals(captor.getValue().getMetadata().getName(), PROJECT_NAME);
     verifyNoMoreInteractions(openShiftCheServerClient);
     verifyNoMoreInteractions(kubernetesClient);
-    ArgumentCaptor<RoleBinding> roleBindingArgumentCaptor =
-        ArgumentCaptor.forClass(RoleBinding.class);
-    verify(nonNamespaceRoleBindingOperation).createOrReplace(roleBindingArgumentCaptor.capture());
-    assertNotNull(roleBindingArgumentCaptor.getValue());
-  }
-
-  @Test(dependsOnMethods = "testOpenShiftProjectPreparingWhenProjectDoesNotExistWithCheServerSA")
-  public void testOpenShiftProjectPreparingRoleBindingWhenProjectDoesNotExistWithCheServerSA()
-      throws Exception {
-    // given
-    prepareNamespaceGet(PROJECT_NAME);
-
-    Resource resource = prepareProjectResource(PROJECT_NAME);
-    doThrow(new KubernetesClientException("error", 403, null)).when(resource).get();
-    final MixedOperation mixedOperation = mock(MixedOperation.class);
-    final NonNamespaceOperation namespaceOperation = mock(NonNamespaceOperation.class);
-    doReturn(mixedOperation).when(openShiftCheServerClient).serviceAccounts();
-    when(mixedOperation.inNamespace(anyString())).thenReturn(namespaceOperation);
-    when(namespaceOperation.withName(anyString())).thenReturn(serviceAccountResource);
-    when(serviceAccountResource.get()).thenReturn(mock(ServiceAccount.class));
-    doReturn(projectRequestOperation).when(openShiftCheServerClient).projectrequests();
-    // doReturn(metadataNested).when(metadataNested).withName(anyString());
-    when(openShiftCheServerClient.roleBindings()).thenReturn(mixedRoleBindingOperation);
-    lenient()
-        .when(mixedRoleBindingOperation.inNamespace(anyString()))
-        .thenReturn(nonNamespaceRoleBindingOperation);
-    when(openShiftClient.currentUser())
-        .thenReturn(new UserBuilder().withNewMetadata().withName("jdoe").endMetadata().build());
-    // when
-    openShiftProject.prepare(true, true, Map.of(), Map.of());
-
-    // then
-    ArgumentCaptor<RoleBinding> roleBindingArgumentCaptor =
-        ArgumentCaptor.forClass(RoleBinding.class);
-    verify(nonNamespaceRoleBindingOperation).createOrReplace(roleBindingArgumentCaptor.capture());
-    RoleBinding roleBinding = roleBindingArgumentCaptor.getValue();
-    assertNotNull(roleBinding);
-    assertEquals(roleBinding.getMetadata().getName(), "admin");
-    assertEquals(roleBinding.getRoleRef().getName(), "admin");
-    assertEquals(roleBinding.getUserNames(), ImmutableList.of("jdoe"));
   }
 
   @Test(expectedExceptions = InfrastructureException.class)
@@ -596,13 +550,13 @@ public class OpenShiftProjectTest {
 
     ProjectOperation projectOperation = mock(ProjectOperation.class);
     doReturn(projectResource).when(projectOperation).withName(projectName);
-    doReturn(projectOperation).when(openShiftClient).projects();
+    doReturn(projectOperation).when(openShiftCheServerClient).projects();
 
     when(projectResource.get())
         .thenReturn(
             new ProjectBuilder().withNewMetadata().withName(projectName).endMetadata().build());
 
-    openShiftClient.projects().withName(projectName).get();
+    openShiftCheServerClient.projects().withName(projectName).get();
     return projectResource;
   }
 
@@ -611,7 +565,7 @@ public class OpenShiftProjectTest {
         new NamespaceBuilder().withNewMetadata().withName(namespaceName).endMetadata().build();
 
     NonNamespaceOperation nsOperation = mock(NonNamespaceOperation.class);
-    doReturn(nsOperation).when(openShiftClient).namespaces();
+    doReturn(nsOperation).when(openShiftCheServerClient).namespaces();
 
     Resource nsResource = mock(Resource.class);
     doReturn(nsResource).when(nsOperation).withName(namespaceName);


### PR DESCRIPTION
Signed-off-by: Anatolii Bazko <abazko@redhat.com>

<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests
-->

### What does this PR do?
feat: Delegate only needed roles to user in his namespace
related che-operator PR: https://github.com/eclipse-che/che-operator/pull/1532

### Screenshot/screencast of this PR
<!-- Please include a screenshot or a screencast explaining what is doing this PR -->
N/A

### What issues does this PR fix or reference?
<!-- Please include any related issue from eclipse che repository (or from another issue tracker).
     Include link to other pull requests like documentation PR from [the docs repo](https://github.com/eclipse/che-docs)
-->
https://github.com/eclipse/che/issues/21695

### How to test this PR?
<!-- Please explain for example :
  - The test platform (openshift, kubernetes, minikube, CodeReady Container, docker-desktop, etc)
  - Installation method: chectl / che-operator
  - steps to reproduce
 -->

1. Deploy Eclipse Che
`chectl server:deploy --platform=openshift --cheimage docker.io/abazko/che-server:21695  --che-operator-image=docker.io/abazko/operator:21695`
2. Log into Eclipse Che
3. Check `rolebindings` in a user namespace, it must contain only 2 rolebindings for the current user and it mustn't contain `admin` ClusterRoleBinding
```
oc get rolebindings -n <USER_NAMESPACE> -o custom-columns=NAME:metadata.name,ROLE:roleRef.name,SUBJECT:subjects\[0\].name  | grep <USERNAME>
NAME                                                 ROLE                                                 SUBJECT
eclipse-che-cheworkspaces-clusterrole                eclipse-che-cheworkspaces-clusterrole                <USERNAME>
eclipse-che-cheworkspaces-devworkspace-clusterrole   eclipse-che-cheworkspaces-devworkspace-clusterrole   <USERNAME>
...
```
4. Create and start a workspace

### PR Checklist

[As the author of this Pull Request I made sure that:](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#pull-request-template-and-its-checklist)

- [x] [The Eclipse Contributor Agreement is valid](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-eclipse-contributor-agreement-is-valid)
- [x] [Code produced is complete](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-produced-is-complete)
- [x] [Code builds without errors](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-builds-without-errors)
- [x] [Tests are covering the bugfix](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#tests-are-covering-the-bugfix)
- [ ] [The repository devfile is up to date and works](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-repository-devfile-is-up-to-date-and-works)
- [ ] [Sections `What issues does this PR fix or reference` and `How to test this PR` completed](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#sections-what-issues-does-this-pr-fix-or-reference-and-how-to-test-this-pr-completed)
- [ ] [Relevant user documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [Relevant contributing documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [CI/CD changes implemented, documented and communicated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#cicd-changes-implemented-documented-and-communicated)

### Reviewers

Reviewers, please comment how you tested the PR when approving it.
