### PR TITLE
fix: Allign the GitHub raw file location Url with subdomain isolation option

### DIFF
--- a/assembly/assembly-wsmaster-war/src/main/webapp/WEB-INF/classes/che/che.properties
+++ b/assembly/assembly-wsmaster-war/src/main/webapp/WEB-INF/classes/che/che.properties
@@ -205,6 +205,9 @@ che.oauth.github.tokenuri= https://github.com/login/oauth/access_token
 # Prerequisite: OAuth 2 integration is configured on the GitHub server.
 che.integration.github.oauth_endpoint=NULL
 
+# GitHub server disable subdomain isolation flag.
+che.integration.github.disable_subdomain_isolation=false
+
 # GitHub OAuth redirect URIs.
 # Separate multiple values with comma, for example: URI,URI,URI.
 che.oauth.github.redirecturis= http://localhost:${CHE_PORT}/api/oauth/callback

--- a/wsmaster/che-core-api-factory-github/src/main/java/org/eclipse/che/api/factory/server/github/GithubURLParser.java
+++ b/wsmaster/che-core-api-factory-github/src/main/java/org/eclipse/che/api/factory/server/github/GithubURLParser.java
@@ -61,12 +61,21 @@ public class GithubURLParser {
    */
   private final Pattern githubPattern;
 
+  private final boolean disableSubdomainIsolation;
+
   @Inject
   public GithubURLParser(
       PersonalAccessTokenManager tokenManager,
       DevfileFilenamesProvider devfileFilenamesProvider,
-      @Nullable @Named("che.integration.github.oauth_endpoint") String oauthEndpoint) {
-    this(tokenManager, devfileFilenamesProvider, new GithubApiClient(oauthEndpoint), oauthEndpoint);
+      @Nullable @Named("che.integration.github.oauth_endpoint") String oauthEndpoint,
+      @Named("che.integration.github.disable_subdomain_isolation")
+          boolean disableSubdomainIsolation) {
+    this(
+        tokenManager,
+        devfileFilenamesProvider,
+        new GithubApiClient(oauthEndpoint),
+        oauthEndpoint,
+        disableSubdomainIsolation);
   }
 
   /** Constructor used for testing only. */
@@ -74,7 +83,8 @@ public class GithubURLParser {
       PersonalAccessTokenManager tokenManager,
       DevfileFilenamesProvider devfileFilenamesProvider,
       GithubApiClient githubApiClient,
-      String oauthEndpoint) {
+      String oauthEndpoint,
+      boolean disableSubdomainIsolation) {
     this.tokenManager = tokenManager;
     this.devfileFilenamesProvider = devfileFilenamesProvider;
     this.apiClient = githubApiClient;
@@ -86,6 +96,7 @@ public class GithubURLParser {
             format(
                 "^%s/(?<repoUser>[^/]++)/(?<repoName>[^/]++)((/)|(?:/tree/(?<branchName>[^/]++)(?:/(?<subFolder>.*))?)|(/pull/(?<pullRequestId>[^/]++)))?$",
                 endpoint));
+    this.disableSubdomainIsolation = disableSubdomainIsolation;
   }
 
   public boolean isValid(@NotNull String url) {
@@ -167,6 +178,7 @@ public class GithubURLParser {
         .withUsername(repoUser)
         .withRepository(repoName)
         .withServerUrl(serverUrl)
+        .withDisableSubdomainIsolation(disableSubdomainIsolation)
         .withBranch(branchName)
         .withSubfolder(matcher.group("subFolder"))
         .withDevfileFilenames(devfileFilenamesProvider.getConfiguredDevfileFilenames());

--- a/wsmaster/che-core-api-factory-github/src/main/java/org/eclipse/che/api/factory/server/github/GithubUrl.java
+++ b/wsmaster/che-core-api-factory-github/src/main/java/org/eclipse/che/api/factory/server/github/GithubUrl.java
@@ -49,6 +49,8 @@ public class GithubUrl implements RemoteFactoryUrl {
 
   private String serverUrl;
 
+  private boolean disableSubdomainIsolation;
+
   /** Devfile filenames list */
   private final List<String> devfileFilenames = new ArrayList<>();
 
@@ -143,6 +145,11 @@ public class GithubUrl implements RemoteFactoryUrl {
     return this;
   }
 
+  public GithubUrl withDisableSubdomainIsolation(boolean disableSubdomainIsolation) {
+    this.disableSubdomainIsolation = disableSubdomainIsolation;
+    return this;
+  }
+
   /**
    * Provides list of configured devfile filenames with locations
    *
@@ -174,7 +181,14 @@ public class GithubUrl implements RemoteFactoryUrl {
    */
   public String rawFileLocation(String fileName) {
     return new StringJoiner("/")
-        .add(isNullOrEmpty(serverUrl) ? "https://raw.githubusercontent.com" : serverUrl + "/raw")
+        .add(
+            isNullOrEmpty(serverUrl)
+                ? "https://raw.githubusercontent.com"
+                : disableSubdomainIsolation
+                    ? serverUrl + "/raw"
+                    : serverUrl.substring(0, serverUrl.indexOf("://") + 3)
+                        + "raw."
+                        + serverUrl.substring(serverUrl.indexOf("://") + 3))
         .add(username)
         .add(repository)
         .add(firstNonNull(branch, "HEAD"))

--- a/wsmaster/che-core-api-factory-github/src/test/java/org/eclipse/che/api/factory/server/github/GithubFactoryParametersResolverTest.java
+++ b/wsmaster/che-core-api-factory-github/src/test/java/org/eclipse/che/api/factory/server/github/GithubFactoryParametersResolverTest.java
@@ -97,7 +97,7 @@ public class GithubFactoryParametersResolverTest {
   @BeforeMethod
   protected void init() {
     githubUrlParser =
-        new GithubURLParser(personalAccessTokenManager, devfileFilenamesProvider, null);
+        new GithubURLParser(personalAccessTokenManager, devfileFilenamesProvider, null, false);
     assertNotNull(this.githubUrlParser);
     githubFactoryParametersResolver =
         new GithubFactoryParametersResolver(

--- a/wsmaster/che-core-api-factory-github/src/test/java/org/eclipse/che/api/factory/server/github/GithubScmFileResolverTest.java
+++ b/wsmaster/che-core-api-factory-github/src/test/java/org/eclipse/che/api/factory/server/github/GithubScmFileResolverTest.java
@@ -41,7 +41,7 @@ public class GithubScmFileResolverTest {
   @BeforeMethod
   protected void init() {
     githubURLParser =
-        new GithubURLParser(personalAccessTokenManager, devfileFilenamesProvider, null);
+        new GithubURLParser(personalAccessTokenManager, devfileFilenamesProvider, null, false);
     assertNotNull(this.githubURLParser);
     githubScmFileResolver =
         new GithubScmFileResolver(githubURLParser, urlFetcher, personalAccessTokenManager);

--- a/wsmaster/che-core-api-factory-github/src/test/java/org/eclipse/che/api/factory/server/github/GithubURLParserTest.java
+++ b/wsmaster/che-core-api-factory-github/src/test/java/org/eclipse/che/api/factory/server/github/GithubURLParserTest.java
@@ -26,8 +26,6 @@ import org.eclipse.che.api.factory.server.scm.PersonalAccessToken;
 import org.eclipse.che.api.factory.server.scm.PersonalAccessTokenManager;
 import org.eclipse.che.api.factory.server.urlfactory.DevfileFilenamesProvider;
 import org.eclipse.che.commons.subject.Subject;
-import org.mockito.InjectMocks;
-import org.mockito.Mock;
 import org.mockito.testng.MockitoTestNGListener;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Listeners;
@@ -41,18 +39,21 @@ import org.testng.annotations.Test;
 @Listeners(MockitoTestNGListener.class)
 public class GithubURLParserTest {
 
-  @Mock private DevfileFilenamesProvider devfileFilenamesProvider;
-
-  /** Instance of component that will be tested. */
-  @InjectMocks private GithubURLParser githubUrlParser;
-
-  @InjectMocks
-  private PersonalAccessTokenManager personalAccessTokenManager =
+  private final PersonalAccessTokenManager personalAccessTokenManager =
       mock(PersonalAccessTokenManager.class);
 
-  @InjectMocks private GithubApiClient githubApiClient = mock(GithubApiClient.class);
+  private final GithubApiClient githubApiClient = mock(GithubApiClient.class);
 
-  /** Check invalid url (not a github one) */
+  /** Instance of component that will be tested. */
+  private final GithubURLParser githubUrlParser =
+      new GithubURLParser(
+          personalAccessTokenManager,
+          mock(DevfileFilenamesProvider.class),
+          githubApiClient,
+          null,
+          false);
+
+  /** Check invalid url (not a GitHub one) */
   @Test(expectedExceptions = IllegalArgumentException.class)
   public void invalidUrl() throws ApiException {
     githubUrlParser.parse("http://www.eclipse.org");

--- a/wsmaster/che-core-api-factory-github/src/test/java/org/eclipse/che/api/factory/server/github/GithubUrlTest.java
+++ b/wsmaster/che-core-api-factory-github/src/test/java/org/eclipse/che/api/factory/server/github/GithubUrlTest.java
@@ -12,6 +12,7 @@
 package org.eclipse.che.api.factory.server.github;
 
 import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertNotNull;
@@ -19,9 +20,9 @@ import static org.testng.Assert.assertNotNull;
 import java.util.Arrays;
 import java.util.Iterator;
 import org.eclipse.che.api.core.ApiException;
+import org.eclipse.che.api.factory.server.scm.PersonalAccessTokenManager;
 import org.eclipse.che.api.factory.server.urlfactory.DevfileFilenamesProvider;
 import org.eclipse.che.api.factory.server.urlfactory.RemoteFactoryUrl.DevfileLocation;
-import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.testng.MockitoTestNGListener;
 import org.testng.annotations.BeforeMethod;
@@ -38,19 +39,20 @@ public class GithubUrlTest {
 
   @Mock private DevfileFilenamesProvider devfileFilenamesProvider;
 
-  /** Parser used to create the url. */
-  @InjectMocks private GithubURLParser githubUrlParser;
-
   /** Instance of the url created */
   private GithubUrl githubUrl;
 
   /** Setup objects/ */
   @BeforeMethod
   protected void init() throws ApiException {
+    /** Parser used to create the url. */
+    GithubURLParser githubUrlParser =
+        new GithubURLParser(
+            mock(PersonalAccessTokenManager.class), devfileFilenamesProvider, null, false);
     when(devfileFilenamesProvider.getConfiguredDevfileFilenames())
         .thenReturn(Arrays.asList("devfile.yaml", "foo.bar"));
-    this.githubUrl = this.githubUrlParser.parse("https://github.com/eclipse/che");
-    assertNotNull(this.githubUrl);
+    githubUrl = githubUrlParser.parse("https://github.com/eclipse/che");
+    assertNotNull(githubUrl);
   }
 
   /** Check when there is devfile in the repository */


### PR DESCRIPTION

<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests
-->

### What does this PR do?
Inject the `che.integration.github.disable_subdomain_isolation` env variable property to handle the [subdomain isolation](https://docs.github.com/en/enterprise-server@3.5/admin/configuration/configuring-network-settings/enabling-subdomain-isolation) GitHub option while returning the GitHub raw file location.

### Screenshot/screencast of this PR
<!-- Please include a screenshot or a screencast explaining what is doing this PR -->


### What issues does this PR fix or reference?
<!-- Please include any related issue from eclipse che repository (or from another issue tracker).
     Include link to other pull requests like documentation PR from [the docs repo](https://github.com/eclipse/che-docs)
-->
https://github.com/eclipse/che/issues/21724

### How to test this PR?
<!-- Please explain for example :
  - The test platform (openshift, kubernetes, minikube, CodeReady Container, docker-desktop, etc)
  - Installation method: chectl / che-operator
  - steps to reproduce
 -->
N/A

### PR Checklist

[As the author of this Pull Request I made sure that:](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#pull-request-template-and-its-checklist)

- [ ] [The Eclipse Contributor Agreement is valid](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-eclipse-contributor-agreement-is-valid)
- [ ] [Code produced is complete](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-produced-is-complete)
- [ ] [Code builds without errors](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-builds-without-errors)
- [ ] [Tests are covering the bugfix](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#tests-are-covering-the-bugfix)
- [ ] [The repository devfile is up to date and works](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-repository-devfile-is-up-to-date-and-works)
- [ ] [Sections `What issues does this PR fix or reference` and `How to test this PR` completed](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#sections-what-issues-does-this-pr-fix-or-reference-and-how-to-test-this-pr-completed)
- [ ] [Relevant user documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [Relevant contributing documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [CI/CD changes implemented, documented and communicated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#cicd-changes-implemented-documented-and-communicated)

### Reviewers

Reviewers, please comment how you tested the PR when approving it.
