### PR TITLE
chore: Rework the bitbucket raw file location url

### DIFF
--- a/wsmaster/che-core-api-factory-bitbucket/src/main/java/org/eclipse/che/api/factory/server/bitbucket/BitbucketAuthorizingFileContentProvider.java
+++ b/wsmaster/che-core-api-factory-bitbucket/src/main/java/org/eclipse/che/api/factory/server/bitbucket/BitbucketAuthorizingFileContentProvider.java
@@ -36,10 +36,9 @@ class BitbucketAuthorizingFileContentProvider extends AuthorizingFileContentProv
   protected boolean isPublicRepository(BitbucketUrl remoteFactoryUrl) {
     try {
       urlFetcher.fetch(
-          BitbucketApiClient.BITBUCKET_API_SERVER
-              + "repos"
+          remoteFactoryUrl.getHostName()
               + '/'
-              + remoteFactoryUrl.getUsername()
+              + remoteFactoryUrl.getWorkspaceId()
               + '/'
               + remoteFactoryUrl.getRepository());
       return true;

--- a/wsmaster/che-core-api-factory-bitbucket/src/main/java/org/eclipse/che/api/factory/server/bitbucket/BitbucketUrl.java
+++ b/wsmaster/che-core-api-factory-bitbucket/src/main/java/org/eclipse/che/api/factory/server/bitbucket/BitbucketUrl.java
@@ -133,10 +133,10 @@ public class BitbucketUrl implements RemoteFactoryUrl {
 
   public String rawFileLocation(String fileName) {
     return new StringJoiner("/")
-        .add("https://api.bitbucket.org/2.0/repositories")
+        .add("https://bitbucket.org")
         .add(workspaceId)
         .add(repository)
-        .add("src")
+        .add("raw")
         .add(firstNonNull(branch, "HEAD"))
         .add(fileName)
         .toString();

--- a/wsmaster/che-core-api-factory-bitbucket/src/test/java/org/eclipse/che/api/factory/server/bitbucket/BitbucketAuthorizingFileContentProviderTest.java
+++ b/wsmaster/che-core-api-factory-bitbucket/src/test/java/org/eclipse/che/api/factory/server/bitbucket/BitbucketAuthorizingFileContentProviderTest.java
@@ -44,8 +44,7 @@ public class BitbucketAuthorizingFileContentProviderTest {
     fileContentProvider.fetchContent("devfile.yaml");
     verify(urlFetcher)
         .fetch(
-            eq("https://api.bitbucket.org/2.0/repositories/eclipse/che/src/HEAD/devfile.yaml"),
-            eq("Bearer my-token"));
+            eq("https://bitbucket.org/eclipse/che/raw/HEAD/devfile.yaml"), eq("Bearer my-token"));
   }
 
   @Test
@@ -65,11 +64,11 @@ public class BitbucketAuthorizingFileContentProviderTest {
   @Test(expectedExceptions = FileNotFoundException.class)
   public void shouldThrowNotFoundForPublicRepos() throws Exception {
     URLFetcher urlFetcher = Mockito.mock(URLFetcher.class);
-    String url = "https://api.bitbucket.org/2.0/repositories/foo/bar/devfile.yaml";
+    String url = "https://bitbucket.org/foo/bar/raw/HEAD/devfile.yaml";
     when(personalAccessTokenManager.getAndStore(anyString()))
         .thenThrow(UnknownScmProviderException.class);
     when(urlFetcher.fetch(eq(url))).thenThrow(FileNotFoundException.class);
-    when(urlFetcher.fetch(eq("https://api.bitbucket.org/2.0/repos/eclipse/che"))).thenReturn("OK");
+    when(urlFetcher.fetch(eq("https://bitbucket.org/eclipse/che"))).thenReturn("OK");
     BitbucketUrl bitbucketUrl =
         new BitbucketUrl().withUsername("eclipse").withWorkspaceId("eclipse").withRepository("che");
     FileContentProvider fileContentProvider =

--- a/wsmaster/che-core-api-factory-bitbucket/src/test/java/org/eclipse/che/api/factory/server/bitbucket/BitbucketFactoryParametersResolverTest.java
+++ b/wsmaster/che-core-api-factory-bitbucket/src/test/java/org/eclipse/che/api/factory/server/bitbucket/BitbucketFactoryParametersResolverTest.java
@@ -183,7 +183,7 @@ public class BitbucketFactoryParametersResolverTest {
     verify(urlFactoryBuilder, never()).buildDefaultDevfile(eq("che"));
     assertEquals(
         factoryUrlArgumentCaptor.getValue().devfileFileLocations().iterator().next().location(),
-        "https://api.bitbucket.org/2.0/repositories/eclipse/che/src/HEAD/devfile.yaml");
+        "https://bitbucket.org/eclipse/che/raw/HEAD/devfile.yaml");
   }
 
   @Test

--- a/wsmaster/che-core-api-factory-bitbucket/src/test/java/org/eclipse/che/api/factory/server/bitbucket/BitbucketUrlTest.java
+++ b/wsmaster/che-core-api-factory-bitbucket/src/test/java/org/eclipse/che/api/factory/server/bitbucket/BitbucketUrlTest.java
@@ -58,12 +58,9 @@ public class BitbucketUrlTest {
     assertEquals(bitbucketUrl.devfileFileLocations().size(), 2);
     Iterator<DevfileLocation> iterator = bitbucketUrl.devfileFileLocations().iterator();
     assertEquals(
-        iterator.next().location(),
-        "https://api.bitbucket.org/2.0/repositories/eclipse/che/src/HEAD/devfile.yaml");
+        iterator.next().location(), "https://bitbucket.org/eclipse/che/raw/HEAD/devfile.yaml");
 
-    assertEquals(
-        iterator.next().location(),
-        "https://api.bitbucket.org/2.0/repositories/eclipse/che/src/HEAD/foo.bar");
+    assertEquals(iterator.next().location(), "https://bitbucket.org/eclipse/che/raw/HEAD/foo.bar");
   }
 
   /** Check the original repository */


### PR DESCRIPTION
Signed-off-by: Igor Vinokur <ivinokur@redhat.com>

<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests
-->

### What does this PR do?
Rework the `rawFileLocation()` function to return a file url, which is available for public, without an authentication. This allows to use a factory from a public bitbucket repo without the bitbucket OAuth configuration.

### Screenshot/screencast of this PR
<!-- Please include a screenshot or a screencast explaining what is doing this PR -->


### What issues does this PR fix or reference?
<!-- Please include any related issue from eclipse che repository (or from another issue tracker).
     Include link to other pull requests like documentation PR from [the docs repo](https://github.com/eclipse/che-docs)
-->
https://issues.redhat.com/browse/CRW-3359

### How to test this PR?
<!-- Please explain for example :
  - The test platform (openshift, kubernetes, minikube, CodeReady Container, docker-desktop, etc)
  - Installation method: chectl / che-operator
  - steps to reproduce
 -->


### PR Checklist

[As the author of this Pull Request I made sure that:](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#pull-request-template-and-its-checklist)

- [ ] [The Eclipse Contributor Agreement is valid](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-eclipse-contributor-agreement-is-valid)
- [ ] [Code produced is complete](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-produced-is-complete)
- [ ] [Code builds without errors](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-builds-without-errors)
- [ ] [Tests are covering the bugfix](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#tests-are-covering-the-bugfix)
- [ ] [The repository devfile is up to date and works](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-repository-devfile-is-up-to-date-and-works)
- [ ] [Sections `What issues does this PR fix or reference` and `How to test this PR` completed](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#sections-what-issues-does-this-pr-fix-or-reference-and-how-to-test-this-pr-completed)
- [ ] [Relevant user documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [Relevant contributing documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [CI/CD changes implemented, documented and communicated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#cicd-changes-implemented-documented-and-communicated)

### Reviewers

Reviewers, please comment how you tested the PR when approving it.
