### PR TITLE
fix: fix resolving Gitlab raw file location

### DIFF
--- a/wsmaster/che-core-api-factory-gitlab/src/main/java/org/eclipse/che/api/factory/server/gitlab/GitlabUrl.java
+++ b/wsmaster/che-core-api-factory-gitlab/src/main/java/org/eclipse/che/api/factory/server/gitlab/GitlabUrl.java
@@ -11,7 +11,6 @@
  */
 package org.eclipse.che.api.factory.server.gitlab;
 
-import static com.google.common.base.MoreObjects.firstNonNull;
 import static java.net.URLEncoder.encode;
 
 import com.google.common.base.Charsets;
@@ -200,14 +199,22 @@ public class GitlabUrl implements RemoteFactoryUrl {
    * @return location of specified file in a repository
    */
   public String rawFileLocation(String fileName) {
-    return new StringJoiner("/")
-        .add(hostName)
-        .add(username)
-        .add(project)
-        .add("-/raw")
-        .add(firstNonNull(branch, "HEAD"))
-        .add(fileName)
-        .toString();
+    String resultUrl =
+        new StringJoiner("/")
+            .add(hostName)
+            .add("api/v4/projects")
+            // use URL-encoded path to the project as a selector instead of id
+            .add(geProjectIdentifier())
+            .add("repository")
+            .add("files")
+            .add(encode(fileName, Charsets.UTF_8))
+            .add("raw")
+            .toString();
+    if (branch != null) {
+      resultUrl = resultUrl + "?ref=" + branch;
+    }
+
+    return resultUrl;
   }
 
   private String geProjectIdentifier() {

--- a/wsmaster/che-core-api-factory-gitlab/src/test/java/org/eclipse/che/api/factory/server/gitlab/GitlabAuthorizingFileContentProviderTest.java
+++ b/wsmaster/che-core-api-factory-gitlab/src/test/java/org/eclipse/che/api/factory/server/gitlab/GitlabAuthorizingFileContentProviderTest.java
@@ -43,7 +43,10 @@ public class GitlabAuthorizingFileContentProviderTest {
     when(personalAccessTokenManager.getAndStore(anyString())).thenReturn(personalAccessToken);
     fileContentProvider.fetchContent("devfile.yaml");
     verify(urlFetcher)
-        .fetch(eq("https://gitlab.net/eclipse/che/-/raw/HEAD/devfile.yaml"), eq("Bearer my-token"));
+        .fetch(
+            eq(
+                "https://gitlab.net/api/v4/projects/eclipse%2Fche/repository/files/devfile.yaml/raw"),
+            eq("Bearer my-token"));
   }
 
   @Test

--- a/wsmaster/che-core-api-factory-gitlab/src/test/java/org/eclipse/che/api/factory/server/gitlab/GitlabUrlTest.java
+++ b/wsmaster/che-core-api-factory-gitlab/src/test/java/org/eclipse/che/api/factory/server/gitlab/GitlabUrlTest.java
@@ -69,22 +69,25 @@ public class GitlabUrlTest {
   @DataProvider
   public static Object[][] urlsProvider() {
     return new Object[][] {
-      {"https://gitlab.net/eclipse/che.git", "https://gitlab.net/eclipse/che/-/raw/HEAD/%s"},
+      {
+        "https://gitlab.net/eclipse/che.git",
+        "https://gitlab.net/api/v4/projects/eclipse%%2Fche/repository/files/%s/raw"
+      },
       {
         "https://gitlab.net/eclipse/fooproj/che.git",
-        "https://gitlab.net/eclipse/fooproj/-/raw/HEAD/%s"
+        "https://gitlab.net/api/v4/projects/eclipse%%2Ffooproj%%2Fche/repository/files/%s/raw"
       },
       {
         "https://gitlab.net/eclipse/fooproj/-/tree/master/",
-        "https://gitlab.net/eclipse/fooproj/-/raw/master/%s"
+        "https://gitlab.net/api/v4/projects/eclipse%%2Ffooproj/repository/files/%s/raw?ref=master"
       },
       {
         "https://gitlab.net/eclipse/fooproj/che/-/tree/foobranch/",
-        "https://gitlab.net/eclipse/fooproj/-/raw/foobranch/%s"
+        "https://gitlab.net/api/v4/projects/eclipse%%2Ffooproj%%2Fche/repository/files/%s/raw?ref=foobranch"
       },
       {
         "https://gitlab.net/eclipse/fooproj/che/-/tree/foobranch/subfolder",
-        "https://gitlab.net/eclipse/fooproj/-/raw/foobranch/%s"
+        "https://gitlab.net/api/v4/projects/eclipse%%2Ffooproj%%2Fche/repository/files/%s/raw?ref=foobranch"
       },
     };
   }


### PR DESCRIPTION
Signed-off-by: Igor Vinokur <ivinokur@redhat.com>

<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests
-->

### What does this PR do?
Partially reverts https://github.com/eclipse-che/che-server/commit/5aa763aab38adeff1f415ae65fdd4e6efcdfced3 in order to fix the Gitlab OAuth flow.
The `rawFileUrl` method uses the API request now. If the request is passed without token it works for public repos, unlike the previous raw file request which fails for private projects, even with the Authorisation header.

### Screenshot/screencast of this PR
<!-- Please include a screenshot or a screencast explaining what is doing this PR -->


### What issues does this PR fix or reference?
<!-- Please include any related issue from eclipse che repository (or from another issue tracker).
     Include link to other pull requests like documentation PR from [the docs repo](https://github.com/eclipse/che-docs)
-->
https://issues.redhat.com/browse/CRW-3424

### How to test this PR?
<!-- Please explain for example :
  - The test platform (openshift, kubernetes, minikube, CodeReady Container, docker-desktop, etc)
  - Installation method: chectl / che-operator
  - steps to reproduce
 -->
* Try to create a workspace from a public gitlab repo without an OAuth config.
* Setup the Gitlab OAuth config and try to create a workspace from a private gitlab repo.

### PR Checklist

[As the author of this Pull Request I made sure that:](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#pull-request-template-and-its-checklist)

- [ ] [The Eclipse Contributor Agreement is valid](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-eclipse-contributor-agreement-is-valid)
- [ ] [Code produced is complete](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-produced-is-complete)
- [ ] [Code builds without errors](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-builds-without-errors)
- [ ] [Tests are covering the bugfix](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#tests-are-covering-the-bugfix)
- [ ] [The repository devfile is up to date and works](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-repository-devfile-is-up-to-date-and-works)
- [ ] [Sections `What issues does this PR fix or reference` and `How to test this PR` completed](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#sections-what-issues-does-this-pr-fix-or-reference-and-how-to-test-this-pr-completed)
- [ ] [Relevant user documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [Relevant contributing documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [CI/CD changes implemented, documented and communicated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#cicd-changes-implemented-documented-and-communicated)

### Reviewers

Reviewers, please comment how you tested the PR when approving it.
