### PR TITLE
fix: Fix gitlab url validation

### DIFF
--- a/infrastructures/infrastructure-factory/src/main/java/org/eclipse/che/api/factory/server/scm/kubernetes/KubernetesPersonalAccessTokenManager.java
+++ b/infrastructures/infrastructure-factory/src/main/java/org/eclipse/che/api/factory/server/scm/kubernetes/KubernetesPersonalAccessTokenManager.java
@@ -185,15 +185,16 @@ public class KubernetesPersonalAccessTokenManager implements PersonalAccessToken
           UnknownScmProviderException, UnsatisfiedScmPreconditionException,
           ScmUnauthorizedException {
     Subject subject = EnvironmentContext.getCurrent().getSubject();
-    Optional<PersonalAccessToken> token = get(subject, scmServerUrl);
-    if (token.isPresent()) {
-      return token.get();
+    Optional<PersonalAccessToken> tokenOptional = get(subject, scmServerUrl);
+    PersonalAccessToken personalAccessToken;
+    if (tokenOptional.isPresent()) {
+      personalAccessToken = tokenOptional.get();
     } else {
       // try to authenticate for the given URL
-      PersonalAccessToken personalAccessToken = fetchAndSave(subject, scmServerUrl);
-      gitCredentialManager.createOrReplace(personalAccessToken);
-      return personalAccessToken;
+      personalAccessToken = fetchAndSave(subject, scmServerUrl);
     }
+    gitCredentialManager.createOrReplace(personalAccessToken);
+    return personalAccessToken;
   }
 
   private String getFirstNamespace()

--- a/wsmaster/che-core-api-factory-gitlab/src/test/java/org/eclipse/che/api/factory/server/gitlab/GitlabUrlParserTest.java
+++ b/wsmaster/che-core-api-factory-gitlab/src/test/java/org/eclipse/che/api/factory/server/gitlab/GitlabUrlParserTest.java
@@ -60,14 +60,6 @@ public class GitlabUrlParserTest {
     assertEquals(gitlabUrl.getSubfolder(), subfolder);
   }
 
-  @Test(
-      expectedExceptions = IllegalArgumentException.class,
-      expectedExceptionsMessageRegExp =
-          "The given url https://github.com/org/repo is not a valid Gitlab server URL. Check either URL or server configuration.")
-  public void shouldThrowExceptionWhenURLDintMatchAnyConfiguredServer() {
-    gitlabUrlParser.parse("https://github.com/org/repo");
-  }
-
   @DataProvider(name = "UrlsProvider")
   public Object[][] urls() {
     return new Object[][] {


### PR DESCRIPTION
Signed-off-by: Igor Vinokur <ivinokur@redhat.com>

<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests
-->

### What does this PR do?
* Check if a user namespace PAT secret is present, even if the given URL doesn't match the predefined patterns:
https://github.com/eclipse-che/che-server/blob/f69dc4d9ea8c88a4f8b9c792c52de45c5036671b/wsmaster/che-core-api-factory-gitlab/src/main/java/org/eclipse/che/api/factory/server/gitlab/GitlabUrlParser.java#L95-L98
* Fix the `getPatternMatcherByUrl()` function as `gitlabUrlPatterns.isEmpty()` condition is impossible.
* Fix the git credentials secret initialisation when a PAT secret is already present:
https://github.com/eclipse-che/che-server/blob/f69dc4d9ea8c88a4f8b9c792c52de45c5036671b/infrastructures/infrastructure-factory/src/main/java/org/eclipse/che/api/factory/server/scm/kubernetes/KubernetesPersonalAccessTokenManager.java#L189-L197

### Screenshot/screencast of this PR
<!-- Please include a screenshot or a screencast explaining what is doing this PR -->


### What issues does this PR fix or reference?
<!-- Please include any related issue from eclipse che repository (or from another issue tracker).
     Include link to other pull requests like documentation PR from [the docs repo](https://github.com/eclipse/che-docs)
-->
https://issues.redhat.com/browse/CRW-3431

### How to test this PR?
<!-- Please explain for example :
  - The test platform (openshift, kubernetes, minikube, CodeReady Container, docker-desktop, etc)
  - Installation method: chectl / che-operator
  - steps to reproduce
 -->
* Create a PAT secret in the user namespace: https://www.eclipse.org/che/docs/stable/end-user-guide/using-git-credentials/#using-a-git-provider-access-token
* Start a workspace from a private gitlab repo.
See: workspace starts and the project is cloned.

### PR Checklist

[As the author of this Pull Request I made sure that:](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#pull-request-template-and-its-checklist)

- [ ] [The Eclipse Contributor Agreement is valid](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-eclipse-contributor-agreement-is-valid)
- [ ] [Code produced is complete](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-produced-is-complete)
- [ ] [Code builds without errors](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-builds-without-errors)
- [ ] [Tests are covering the bugfix](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#tests-are-covering-the-bugfix)
- [ ] [The repository devfile is up to date and works](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-repository-devfile-is-up-to-date-and-works)
- [ ] [Sections `What issues does this PR fix or reference` and `How to test this PR` completed](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#sections-what-issues-does-this-pr-fix-or-reference-and-how-to-test-this-pr-completed)
- [ ] [Relevant user documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [Relevant contributing documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [CI/CD changes implemented, documented and communicated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#cicd-changes-implemented-documented-and-communicated)

### Reviewers

Reviewers, please comment how you tested the PR when approving it.
