### PR TITLE
Avoid caching when getting a raw file from raw.githubusercontent.com

### DIFF
--- a/wsmaster/che-core-api-factory-github/src/main/java/org/eclipse/che/api/factory/server/github/GithubApiClient.java
+++ b/wsmaster/che-core-api-factory-github/src/main/java/org/eclipse/che/api/factory/server/github/GithubApiClient.java
@@ -29,6 +29,7 @@ import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.io.UncheckedIOException;
 import java.net.URI;
+import java.net.URISyntaxException;
 import java.net.http.HttpClient;
 import java.net.http.HttpRequest;
 import java.net.http.HttpResponse;
@@ -52,6 +53,10 @@ public class GithubApiClient {
   /** GitHub endpoint URL. */
   public static final String GITHUB_SAAS_ENDPOINT = "https://github.com";
 
+  public static final String GITHUB_SAAS_ENDPOINT_API = "https://api.github.com";
+
+  public static final String GITHUB_SAAS_ENDPOINT_RAW = "https://raw.githubusercontent.com";
+
   /** GitHub HTTP header containing OAuth scopes. */
   public static final String GITHUB_OAUTH_SCOPES_HEADER = "X-OAuth-Scopes";
 
@@ -68,7 +73,7 @@ public class GithubApiClient {
     this.apiServerUrl =
         URI.create(
             isNullOrEmpty(trimmedServerUrl) || trimmedServerUrl.equals(GITHUB_SAAS_ENDPOINT)
-                ? "https://api.github.com/"
+                ? GITHUB_SAAS_ENDPOINT_API + "/"
                 : trimmedServerUrl + "/api/v3/");
     this.scmServerUrl =
         URI.create(isNullOrEmpty(trimmedServerUrl) ? GITHUB_SAAS_ENDPOINT : trimmedServerUrl);
@@ -113,6 +118,16 @@ public class GithubApiClient {
         });
   }
 
+  /**
+   * Fetches and returns a pull request.
+   *
+   * @param id pull request ID
+   * @param username user name
+   * @param repoName repository name
+   * @param authenticationToken oauth access token, can be NULL as the GitHub can handle some
+   *     requests without authentication
+   * @return pull request
+   */
   public GithubPullRequest getPullRequest(
       String id, String username, String repoName, String authenticationToken)
       throws ScmItemNotFoundException, ScmCommunicationException, ScmBadRequestException {
@@ -126,6 +141,47 @@ public class GithubApiClient {
         response -> {
           try {
             return OBJECT_MAPPER.readValue(response.body(), GithubPullRequest.class);
+          } catch (IOException e) {
+            throw new UncheckedIOException(e);
+          }
+        });
+  }
+
+  /**
+   * Returns the latest commit of the branch.
+   *
+   * <p>GitHub REST API documentation: https://docs.github.com/en/rest/commits/commits
+   *
+   * @param user user or organization name
+   * @param repository repository name
+   * @param branch required branch
+   * @param authenticationToken OAuth access token, can be NULL as the GitHub can handle some
+   *     requests without authentication
+   * @return the latest commit of the branch
+   */
+  public GithubCommit getLatestCommit(
+      String user, String repository, String branch, @Nullable String authenticationToken)
+      throws ScmBadRequestException, ScmItemNotFoundException, ScmCommunicationException,
+          URISyntaxException {
+
+    final URI uri = apiServerUrl.resolve(String.format("./repos/%s/%s/commits", user, repository));
+
+    final URI requestURI =
+        new URI(
+            uri.getScheme(),
+            uri.getAuthority(),
+            uri.getPath(),
+            String.format("sha=%s&page=1&per_page=1", branch),
+            null);
+    HttpRequest request = buildGithubApiRequest(requestURI, authenticationToken);
+    LOG.trace("executeRequest={}", request);
+
+    return executeRequest(
+        httpClient,
+        request,
+        response -> {
+          try {
+            return OBJECT_MAPPER.readValue(response.body(), GithubCommit[].class)[0];
           } catch (IOException e) {
             throw new UncheckedIOException(e);
           }
@@ -162,15 +218,30 @@ public class GithubApiClient {
         });
   }
 
-  private HttpRequest buildGithubApiRequest(URI uri, String authenticationToken) {
-    return HttpRequest.newBuilder(uri)
-        .headers(
-            "Authorization",
-            "token " + authenticationToken,
-            "Accept",
-            "application/vnd.github.v3+json")
-        .timeout(DEFAULT_HTTP_TIMEOUT)
-        .build();
+  /**
+   * Builds and returns HttpRequest to acces the GitHub API.
+   *
+   * @param uri request uri
+   * @param authenticationToken authentication token, can be NULL as the GitHub can handle some
+   *     requests without authentication
+   * @return HttpRequest object
+   */
+  private HttpRequest buildGithubApiRequest(URI uri, @Nullable String authenticationToken) {
+    if (isNullOrEmpty(authenticationToken)) {
+      return HttpRequest.newBuilder(uri)
+          .headers("Accept", "application/vnd.github.v3+json")
+          .timeout(DEFAULT_HTTP_TIMEOUT)
+          .build();
+    } else {
+      return HttpRequest.newBuilder(uri)
+          .headers(
+              "Authorization",
+              "token " + authenticationToken,
+              "Accept",
+              "application/vnd.github.v3+json")
+          .timeout(DEFAULT_HTTP_TIMEOUT)
+          .build();
+    }
   }
 
   private <T> T executeRequest(

--- a/wsmaster/che-core-api-factory-github/src/main/java/org/eclipse/che/api/factory/server/github/GithubCommit.java
+++ b/wsmaster/che-core-api-factory-github/src/main/java/org/eclipse/che/api/factory/server/github/GithubCommit.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright (c) 2012-2022 Red Hat, Inc.
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+
+package org.eclipse.che.api.factory.server.github;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class GithubCommit {
+
+  private String sha;
+
+  private String url;
+
+  public String getSha() {
+    return sha;
+  }
+
+  public void setSha(String sha) {
+    this.sha = sha;
+  }
+
+  public GithubCommit withSha(String sha) {
+    this.sha = sha;
+    return this;
+  }
+
+  public String getUrl() {
+    return url;
+  }
+
+  public void setUrl(String url) {
+    this.url = url;
+  }
+
+  public GithubCommit withUrl(String url) {
+    this.url = url;
+    return this;
+  }
+}

--- a/wsmaster/che-core-api-factory-github/src/main/java/org/eclipse/che/api/factory/server/github/GithubFactoryParametersResolver.java
+++ b/wsmaster/che-core-api-factory-github/src/main/java/org/eclipse/che/api/factory/server/github/GithubFactoryParametersResolver.java
@@ -19,6 +19,7 @@ import static org.eclipse.che.security.oauth1.OAuthAuthenticationService.ERROR_Q
 import jakarta.validation.constraints.NotNull;
 import java.util.Map;
 import javax.inject.Inject;
+import javax.inject.Named;
 import javax.inject.Singleton;
 import org.eclipse.che.api.core.ApiException;
 import org.eclipse.che.api.core.BadRequestException;
@@ -35,6 +36,7 @@ import org.eclipse.che.api.factory.shared.dto.ScmInfoDto;
 import org.eclipse.che.api.workspace.server.devfile.URLFetcher;
 import org.eclipse.che.api.workspace.shared.dto.ProjectConfigDto;
 import org.eclipse.che.api.workspace.shared.dto.devfile.ProjectDto;
+import org.eclipse.che.commons.annotation.Nullable;
 
 /**
  * Provides Factory Parameters resolver for github repositories.
@@ -57,6 +59,23 @@ public class GithubFactoryParametersResolver extends DefaultFactoryParameterReso
 
   @Inject
   public GithubFactoryParametersResolver(
+      GithubURLParser githubUrlParser,
+      URLFetcher urlFetcher,
+      GithubSourceStorageBuilder githubSourceStorageBuilder,
+      URLFactoryBuilder urlFactoryBuilder,
+      ProjectConfigDtoMerger projectConfigDtoMerger,
+      PersonalAccessTokenManager personalAccessTokenManager,
+      @Nullable @Named("che.integration.github.oauth_endpoint") String oauthEndpoint) {
+    this(
+        githubUrlParser,
+        urlFetcher,
+        githubSourceStorageBuilder,
+        urlFactoryBuilder,
+        projectConfigDtoMerger,
+        personalAccessTokenManager);
+  }
+
+  GithubFactoryParametersResolver(
       GithubURLParser githubUrlParser,
       URLFetcher urlFetcher,
       GithubSourceStorageBuilder githubSourceStorageBuilder,

--- a/wsmaster/che-core-api-factory-github/src/main/java/org/eclipse/che/api/factory/server/github/GithubPullRequest.java
+++ b/wsmaster/che-core-api-factory-github/src/main/java/org/eclipse/che/api/factory/server/github/GithubPullRequest.java
@@ -24,6 +24,11 @@ class GithubRepo {
   public void setName(String name) {
     this.name = name;
   }
+
+  public GithubRepo withName(String name) {
+    this.name = name;
+    return this;
+  }
 }
 
 @JsonIgnoreProperties(ignoreUnknown = true)
@@ -40,6 +45,11 @@ class GithubHead {
     this.ref = ref;
   }
 
+  public GithubHead withRef(String ref) {
+    this.ref = ref;
+    return this;
+  }
+
   public GithubUser getUser() {
     return user;
   }
@@ -48,12 +58,22 @@ class GithubHead {
     this.user = user;
   }
 
+  public GithubHead withUser(GithubUser user) {
+    this.user = user;
+    return this;
+  }
+
   public GithubRepo getRepo() {
     return repo;
   }
 
   public void setRepo(GithubRepo repo) {
     this.repo = repo;
+  }
+
+  public GithubHead withRepo(GithubRepo repo) {
+    this.repo = repo;
+    return this;
   }
 }
 
@@ -70,11 +90,21 @@ public class GithubPullRequest {
     this.state = state;
   }
 
+  public GithubPullRequest withState(String state) {
+    this.state = state;
+    return this;
+  }
+
   public GithubHead getHead() {
     return head;
   }
 
   public void setHead(GithubHead head) {
     this.head = head;
+  }
+
+  public GithubPullRequest withHead(GithubHead head) {
+    this.head = head;
+    return this;
   }
 }

--- a/wsmaster/che-core-api-factory-github/src/main/java/org/eclipse/che/api/factory/server/github/GithubURLParser.java
+++ b/wsmaster/che-core-api-factory-github/src/main/java/org/eclipse/che/api/factory/server/github/GithubURLParser.java
@@ -11,6 +11,7 @@
  */
 package org.eclipse.che.api.factory.server.github;
 
+import static com.google.common.base.MoreObjects.firstNonNull;
 import static com.google.common.base.Strings.isNullOrEmpty;
 import static java.lang.String.format;
 import static java.util.regex.Pattern.compile;
@@ -19,6 +20,7 @@ import static org.eclipse.che.api.factory.server.github.GithubApiClient.GITHUB_S
 import static org.eclipse.che.commons.lang.StringUtils.trimEnd;
 
 import jakarta.validation.constraints.NotNull;
+import java.net.URISyntaxException;
 import java.util.Optional;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -89,14 +91,16 @@ public class GithubURLParser {
     this.devfileFilenamesProvider = devfileFilenamesProvider;
     this.apiClient = githubApiClient;
     this.oauthEndpoint = oauthEndpoint;
+    this.disableSubdomainIsolation = disableSubdomainIsolation;
+
     String endpoint =
         isNullOrEmpty(oauthEndpoint) ? GITHUB_SAAS_ENDPOINT : trimEnd(oauthEndpoint, '/');
+
     this.githubPattern =
         compile(
             format(
                 "^%s/(?<repoUser>[^/]++)/(?<repoName>[^/]++)((/)|(?:/tree/(?<branchName>[^/]++)(?:/(?<subFolder>.*))?)|(/pull/(?<pullRequestId>[^/]++)))?$",
                 endpoint));
-    this.disableSubdomainIsolation = disableSubdomainIsolation;
   }
 
   public boolean isValid(@NotNull String url) {
@@ -130,48 +134,36 @@ public class GithubURLParser {
     if (repoName.matches("^[\\w-][\\w.-]*?\\.git$")) {
       repoName = repoName.substring(0, repoName.length() - 4);
     }
+
     String branchName = matcher.group("branchName");
 
     String pullRequestId = matcher.group("pullRequestId");
+
     if (pullRequestId != null) {
-      try {
-        String githubEndpoint =
-            isNullOrEmpty(oauthEndpoint) ? GITHUB_SAAS_ENDPOINT : trimEnd(oauthEndpoint, '/');
-        Subject subject = EnvironmentContext.getCurrent().getSubject();
-        PersonalAccessToken personalAccessToken = null;
-        Optional<PersonalAccessToken> tokenOptional = tokenManager.get(subject, githubEndpoint);
-        if (tokenOptional.isPresent()) {
-          personalAccessToken = tokenOptional.get();
-        } else if (authenticationRequired) {
-          personalAccessToken = tokenManager.fetchAndSave(subject, githubEndpoint);
+      GithubPullRequest pullRequest =
+          this.getPullRequest(pullRequestId, repoUser, repoName, authenticationRequired);
+      if (pullRequest != null) {
+        String state = pullRequest.getState();
+        if (!"open".equalsIgnoreCase(state)) {
+          throw new IllegalArgumentException(
+              format(
+                  "The given Pull Request url %s is not Opened, (found %s), thus it can't be opened as branch may have been removed.",
+                  url, state));
         }
-        if (personalAccessToken != null) {
-          GithubPullRequest pullRequest =
-              this.apiClient.getPullRequest(
-                  pullRequestId, repoUser, repoName, personalAccessToken.getToken());
-          String prState = pullRequest.getState();
-          if (!"open".equalsIgnoreCase(prState)) {
-            throw new IllegalArgumentException(
-                format(
-                    "The given Pull Request url %s is not Opened, (found %s), thus it can't be opened as branch may have been removed.",
-                    url, prState));
-          }
-          GithubHead pullRequestHead = pullRequest.getHead();
-          repoUser = pullRequestHead.getUser().getLogin();
-          repoName = pullRequestHead.getRepo().getName();
-          branchName = pullRequestHead.getRef();
-        }
-      } catch (ScmUnauthorizedException e) {
-        throw toApiException(e);
-      } catch (ScmCommunicationException
-          | UnsatisfiedScmPreconditionException
-          | ScmConfigurationPersistenceException e) {
-        LOG.error("Failed to authenticate to GitHub", e);
-      } catch (ScmItemNotFoundException | ScmBadRequestException e) {
-        LOG.error("Failed retrieve GitHub Pull Request", e);
-      } catch (UnknownScmProviderException e) {
-        LOG.warn(e.getMessage());
+
+        GithubHead pullRequestHead = pullRequest.getHead();
+        repoUser = pullRequestHead.getUser().getLogin();
+        repoName = pullRequestHead.getRepo().getName();
+        branchName = pullRequestHead.getRef();
       }
+    }
+
+    String latestCommit = null;
+    GithubCommit commit =
+        this.getLatestCommit(
+            repoUser, repoName, firstNonNull(branchName, "HEAD"), authenticationRequired);
+    if (commit != null) {
+      latestCommit = commit.getSha();
     }
 
     return new GithubUrl()
@@ -180,7 +172,102 @@ public class GithubURLParser {
         .withServerUrl(serverUrl)
         .withDisableSubdomainIsolation(disableSubdomainIsolation)
         .withBranch(branchName)
+        .withLatestCommit(latestCommit)
         .withSubfolder(matcher.group("subFolder"))
         .withDevfileFilenames(devfileFilenamesProvider.getConfiguredDevfileFilenames());
+  }
+
+  private GithubPullRequest getPullRequest(
+      String pullRequestId, String repoUser, String repoName, boolean authenticationRequired)
+      throws ApiException {
+    try {
+      // prepare token
+      String githubEndpoint =
+          isNullOrEmpty(oauthEndpoint) ? GITHUB_SAAS_ENDPOINT : trimEnd(oauthEndpoint, '/');
+      Subject subject = EnvironmentContext.getCurrent().getSubject();
+      PersonalAccessToken personalAccessToken = null;
+      Optional<PersonalAccessToken> token = tokenManager.get(subject, githubEndpoint);
+      if (token.isPresent()) {
+        personalAccessToken = token.get();
+      } else if (authenticationRequired) {
+        personalAccessToken = tokenManager.fetchAndSave(subject, githubEndpoint);
+      }
+
+      // get pull request
+      return this.apiClient.getPullRequest(
+          pullRequestId,
+          repoUser,
+          repoName,
+          personalAccessToken != null ? personalAccessToken.getToken() : null);
+    } catch (UnknownScmProviderException e) {
+
+      // get pull request without authentication
+      try {
+        return this.apiClient.getPullRequest(pullRequestId, repoUser, repoName, null);
+      } catch (ScmItemNotFoundException
+          | ScmCommunicationException
+          | ScmBadRequestException exception) {
+        LOG.error("Failed to authenticate to GitHub", e);
+      }
+
+    } catch (ScmUnauthorizedException e) {
+      throw toApiException(e);
+    } catch (ScmCommunicationException
+        | UnsatisfiedScmPreconditionException
+        | ScmConfigurationPersistenceException e) {
+      LOG.error("Failed to authenticate to GitHub", e);
+    } catch (ScmItemNotFoundException | ScmBadRequestException e) {
+      LOG.error("Failed retrieve GitHub Pull Request", e);
+    }
+
+    return null;
+  }
+
+  private GithubCommit getLatestCommit(
+      String repoUser, String repoName, String branchName, boolean authenticationRequired)
+      throws ApiException {
+    try {
+      // prepare token
+      String githubEndpoint =
+          isNullOrEmpty(oauthEndpoint) ? GITHUB_SAAS_ENDPOINT : trimEnd(oauthEndpoint, '/');
+      Subject subject = EnvironmentContext.getCurrent().getSubject();
+      PersonalAccessToken personalAccessToken = null;
+      Optional<PersonalAccessToken> token = tokenManager.get(subject, githubEndpoint);
+      if (token.isPresent()) {
+        personalAccessToken = token.get();
+      } else if (authenticationRequired) {
+        personalAccessToken = tokenManager.fetchAndSave(subject, githubEndpoint);
+      }
+
+      // get latest commit
+      return this.apiClient.getLatestCommit(
+          repoUser,
+          repoName,
+          branchName,
+          personalAccessToken != null ? personalAccessToken.getToken() : null);
+    } catch (UnknownScmProviderException e) {
+
+      // get latest commit without authentication
+      try {
+        return this.apiClient.getLatestCommit(repoUser, repoName, branchName, null);
+      } catch (ScmItemNotFoundException
+          | ScmCommunicationException
+          | ScmBadRequestException
+          | URISyntaxException exception) {
+        LOG.error("Failed to authenticate to GitHub", e);
+      }
+
+    } catch (ScmUnauthorizedException e) {
+      throw toApiException(e);
+    } catch (ScmCommunicationException
+        | UnsatisfiedScmPreconditionException
+        | ScmConfigurationPersistenceException e) {
+      LOG.error("Failed to authenticate to GitHub", e);
+    } catch (ScmItemNotFoundException | ScmBadRequestException | URISyntaxException e) {
+      LOG.error("Failed to retrieve the latest commit", e);
+      e.printStackTrace();
+    }
+
+    return null;
   }
 }

--- a/wsmaster/che-core-api-factory-github/src/main/java/org/eclipse/che/api/factory/server/github/GithubUrl.java
+++ b/wsmaster/che-core-api-factory-github/src/main/java/org/eclipse/che/api/factory/server/github/GithubUrl.java
@@ -11,7 +11,6 @@
  */
 package org.eclipse.che.api.factory.server.github;
 
-import static com.google.common.base.MoreObjects.firstNonNull;
 import static com.google.common.base.Strings.isNullOrEmpty;
 
 import java.util.ArrayList;
@@ -43,6 +42,9 @@ public class GithubUrl implements RemoteFactoryUrl {
 
   /** Branch name */
   private String branch;
+
+  /** SHA of the latest commit in the current branch */
+  private String latestCommit;
 
   /** Subfolder if any */
   private String subfolder;
@@ -121,6 +123,27 @@ public class GithubUrl implements RemoteFactoryUrl {
   }
 
   /**
+   * Retuna SHA of the latest commimt
+   *
+   * @return latest commit SHA
+   */
+  public String getLatestCommit() {
+    return this.latestCommit;
+  }
+
+  /**
+   * Sets SHA of the latest commit
+   *
+   * @param latestCommit latest commit SHA
+   */
+  protected GithubUrl withLatestCommit(String latestCommit) {
+    if (!isNullOrEmpty(latestCommit)) {
+      this.latestCommit = latestCommit;
+    }
+    return this;
+  }
+
+  /**
    * Gets subfolder of this github url
    *
    * @return the subfolder part
@@ -180,6 +203,8 @@ public class GithubUrl implements RemoteFactoryUrl {
    * @return location of specified file in a repository
    */
   public String rawFileLocation(String fileName) {
+    String branchName = latestCommit != null ? latestCommit : branch != null ? branch : "HEAD";
+
     return new StringJoiner("/")
         .add(
             isNullOrEmpty(serverUrl)
@@ -191,7 +216,7 @@ public class GithubUrl implements RemoteFactoryUrl {
                         + serverUrl.substring(serverUrl.indexOf("://") + 3))
         .add(username)
         .add(repository)
-        .add(firstNonNull(branch, "HEAD"))
+        .add(branchName)
         .add(fileName)
         .toString();
   }

--- a/wsmaster/che-core-api-factory-github/src/main/java/org/eclipse/che/api/factory/server/github/GithubUser.java
+++ b/wsmaster/che-core-api-factory-github/src/main/java/org/eclipse/che/api/factory/server/github/GithubUser.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012-2021 Red Hat, Inc.
+ * Copyright (c) 2012-2022 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/
@@ -30,12 +30,22 @@ public class GithubUser {
     this.id = id;
   }
 
+  public GithubUser withId(long id) {
+    this.id = id;
+    return this;
+  }
+
   public String getLogin() {
     return login;
   }
 
   public void setLogin(String login) {
     this.login = login;
+  }
+
+  public GithubUser withLogin(String login) {
+    this.login = login;
+    return this;
   }
 
   public String getEmail() {
@@ -46,12 +56,22 @@ public class GithubUser {
     this.email = email;
   }
 
+  public GithubUser withEmail(String email) {
+    this.email = email;
+    return this;
+  }
+
   public String getName() {
     return name;
   }
 
   public void setName(String name) {
     this.name = name;
+  }
+
+  public GithubUser withName(String name) {
+    this.name = name;
+    return this;
   }
 
   @Override

--- a/wsmaster/che-core-api-factory-github/src/test/java/org/eclipse/che/api/factory/server/github/GithubApiClientTest.java
+++ b/wsmaster/che-core-api-factory-github/src/test/java/org/eclipse/che/api/factory/server/github/GithubApiClientTest.java
@@ -269,4 +269,21 @@ public class GithubApiClientTest {
     // when
     client.getUser("token");
   }
+
+  @Test
+  public void testGetLatestCommit() throws Exception {
+    stubFor(
+        get(urlEqualTo("/api/v3/repos/eclipse-che/che-server/commits?sha=HEAD&page=1&per_page=1"))
+            .withHeader(HttpHeaders.AUTHORIZATION, equalTo("token token1"))
+            .willReturn(
+                aResponse()
+                    .withHeader("Content-Type", "application/json; charset=utf-8")
+                    .withBody("[{\"sha\": \"test_sha\", \"url\": \"http://commit.url\" }]")));
+
+    GithubCommit commit = client.getLatestCommit("eclipse-che", "che-server", "HEAD", "token1");
+
+    assertNotNull(commit, "GitHub API should return the latest commit");
+    assertEquals(commit.getSha(), "test_sha");
+    assertEquals(commit.getUrl(), "http://commit.url");
+  }
 }

--- a/wsmaster/che-core-api-factory-github/src/test/java/org/eclipse/che/api/factory/server/github/GithubAuthorizingFileContentProviderTest.java
+++ b/wsmaster/che-core-api-factory-github/src/test/java/org/eclipse/che/api/factory/server/github/GithubAuthorizingFileContentProviderTest.java
@@ -12,6 +12,7 @@
 package org.eclipse.che.api.factory.server.github;
 
 import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -23,7 +24,7 @@ import org.eclipse.che.api.factory.server.scm.exception.UnknownScmProviderExcept
 import org.eclipse.che.api.workspace.server.devfile.FileContentProvider;
 import org.eclipse.che.api.workspace.server.devfile.URLFetcher;
 import org.eclipse.che.api.workspace.server.devfile.exception.DevfileException;
-import org.mockito.Mock;
+import org.mockito.Mockito;
 import org.mockito.testng.MockitoTestNGListener;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Listeners;
@@ -32,56 +33,109 @@ import org.testng.annotations.Test;
 @Listeners(MockitoTestNGListener.class)
 public class GithubAuthorizingFileContentProviderTest {
 
-  @Mock private PersonalAccessTokenManager personalAccessTokenManager;
-  @Mock private URLFetcher urlFetcher;
-  private static final String URL = "https://raw.githubusercontent.com/foo/bar/devfile.yaml";
-  GithubUrl githubUrl;
-  FileContentProvider fileContentProvider;
+  private PersonalAccessTokenManager personalAccessTokenManager;
 
   @BeforeMethod
-  public void setup() {
-    githubUrl = new GithubUrl().withUsername("eclipse").withRepository("che");
-    fileContentProvider =
-        new GithubAuthorizingFileContentProvider(githubUrl, urlFetcher, personalAccessTokenManager);
+  void start() {
+    personalAccessTokenManager = mock(PersonalAccessTokenManager.class);
   }
 
   @Test
   public void shouldExpandRelativePaths() throws Exception {
-    var personalAccessToken = new PersonalAccessToken("foo", "che", "my-token");
-    when(personalAccessTokenManager.getAndStore(anyString())).thenReturn(personalAccessToken);
+    URLFetcher urlFetcher = mock(URLFetcher.class);
+
+    GithubUrl githubUrl =
+        new GithubUrl()
+            .withUsername("eclipse")
+            .withRepository("che")
+            .withBranch("main")
+            .withLatestCommit("d74923ebf968454cf13251f17df69dcd87d3b932");
+
+    FileContentProvider fileContentProvider =
+        new GithubAuthorizingFileContentProvider(githubUrl, urlFetcher, personalAccessTokenManager);
+
+    when(personalAccessTokenManager.getAndStore(anyString()))
+        .thenReturn(new PersonalAccessToken("foo", "che", "my-token"));
+
     fileContentProvider.fetchContent("devfile.yaml");
+
     verify(urlFetcher)
         .fetch(
-            eq("https://raw.githubusercontent.com/eclipse/che/HEAD/devfile.yaml"),
+            eq(
+                "https://raw.githubusercontent.com/eclipse/che/d74923ebf968454cf13251f17df69dcd87d3b932/devfile.yaml"),
             eq("token my-token"));
   }
 
   @Test
   public void shouldPreserveAbsolutePaths() throws Exception {
-    String url = "https://raw.githubusercontent.com/foo/bar/devfile.yaml";
-    var personalAccessToken = new PersonalAccessToken(url, "che", "my-token");
-    when(personalAccessTokenManager.getAndStore(anyString())).thenReturn(personalAccessToken);
-    fileContentProvider.fetchContent(url);
-    verify(urlFetcher).fetch(eq(url), eq("token my-token"));
+    String raw_url = "https://raw.githubusercontent.com/foo/bar/branch-name/devfile.yaml";
+
+    GithubUrl githubUrl =
+        new GithubUrl()
+            .withUsername("eclipse")
+            .withRepository("che")
+            .withBranch("main")
+            .withLatestCommit("9ac2f42ed62944d164f189afd57f14a2793a7e4b");
+
+    URLFetcher urlFetcher = mock(URLFetcher.class);
+    FileContentProvider fileContentProvider =
+        new GithubAuthorizingFileContentProvider(githubUrl, urlFetcher, personalAccessTokenManager);
+
+    when(personalAccessTokenManager.getAndStore(anyString()))
+        .thenReturn(new PersonalAccessToken(raw_url, "che", "my-token"));
+
+    fileContentProvider.fetchContent(raw_url);
+    verify(urlFetcher).fetch(eq(raw_url), eq("token my-token"));
   }
 
   @Test(expectedExceptions = FileNotFoundException.class)
   public void shouldThrowNotFoundForPublicRepos() throws Exception {
+    String url = "https://raw.githubusercontent.com/foo/bar/branch-name/devfile.yaml";
+
+    GithubUrl githubUrl = new GithubUrl().withUsername("eclipse").withRepository("che");
+
+    URLFetcher urlFetcher = Mockito.mock(URLFetcher.class);
+    FileContentProvider fileContentProvider =
+        new GithubAuthorizingFileContentProvider(githubUrl, urlFetcher, personalAccessTokenManager);
+
     when(personalAccessTokenManager.getAndStore(anyString()))
         .thenThrow(UnknownScmProviderException.class);
-    when(urlFetcher.fetch(eq(URL))).thenThrow(FileNotFoundException.class);
-    when(urlFetcher.fetch(eq("https://github.com/eclipse/che"))).thenReturn("OK");
-    fileContentProvider.fetchContent(URL);
+
+    when(urlFetcher.fetch(eq(url))).thenThrow(FileNotFoundException.class);
+
+    fileContentProvider.fetchContent(url);
   }
 
   @Test(expectedExceptions = DevfileException.class)
   public void shouldThrowDevfileException() throws Exception {
-    // given
+    String url = "https://raw.githubusercontent.com/foo/bar/branch-name/devfile.yaml";
+    GithubUrl githubUrl = new GithubUrl().withUsername("eclipse").withRepository("che");
+
+    URLFetcher urlFetcher = Mockito.mock(URLFetcher.class);
+    FileContentProvider fileContentProvider =
+        new GithubAuthorizingFileContentProvider(githubUrl, urlFetcher, personalAccessTokenManager);
+
     when(personalAccessTokenManager.getAndStore(anyString()))
         .thenThrow(UnknownScmProviderException.class);
-    when(urlFetcher.fetch(eq(URL))).thenThrow(FileNotFoundException.class);
+    when(urlFetcher.fetch(eq(url))).thenThrow(FileNotFoundException.class);
     when(urlFetcher.fetch(eq("https://github.com/eclipse/che"))).thenThrow(IOException.class);
-    // when
-    fileContentProvider.fetchContent(URL);
+
+    fileContentProvider.fetchContent(url);
+  }
+
+  @Test
+  public void shouldNotAskGitHubAPIForDifferentDomain() throws Exception {
+    String raw_url = "https://ghserver.com/foo/bar/branch-name/devfile.yaml";
+
+    URLFetcher urlFetcher = Mockito.mock(URLFetcher.class);
+    GithubUrl githubUrl = new GithubUrl().withUsername("eclipse").withRepository("che");
+    FileContentProvider fileContentProvider =
+        new GithubAuthorizingFileContentProvider(githubUrl, urlFetcher, personalAccessTokenManager);
+    var personalAccessToken = new PersonalAccessToken(raw_url, "che", "my-token");
+    when(personalAccessTokenManager.getAndStore(anyString())).thenReturn(personalAccessToken);
+
+    fileContentProvider.fetchContent(raw_url);
+
+    verify(urlFetcher).fetch(eq(raw_url), eq("token my-token"));
   }
 }

--- a/wsmaster/che-core-api-factory-github/src/test/java/org/eclipse/che/api/factory/server/github/GithubFactoryParametersResolverTest.java
+++ b/wsmaster/che-core-api-factory-github/src/test/java/org/eclipse/che/api/factory/server/github/GithubFactoryParametersResolverTest.java
@@ -20,7 +20,9 @@ import static org.eclipse.che.security.oauth1.OAuthAuthenticationService.ERROR_Q
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.ArgumentMatchers.anyMap;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -72,6 +74,8 @@ public class GithubFactoryParametersResolverTest {
   /** Parser which will allow to check validity of URLs and create objects. */
   private GithubURLParser githubUrlParser;
 
+  private GithubApiClient githubApiClient;
+
   /** Converter allowing to convert github URL to other objects. */
   @Spy
   private GithubSourceStorageBuilder githubSourceStorageBuilder = new GithubSourceStorageBuilder();
@@ -80,7 +84,7 @@ public class GithubFactoryParametersResolverTest {
   @Mock private ProjectConfigDtoMerger projectConfigDtoMerger;
 
   /** Parser which will allow to check validity of URLs and create objects. */
-  @Mock private URLFactoryBuilder urlFactoryBuilder;
+  private URLFactoryBuilder urlFactoryBuilder;
 
   @Mock private PersonalAccessTokenManager personalAccessTokenManager;
 
@@ -95,10 +99,14 @@ public class GithubFactoryParametersResolverTest {
   private GithubFactoryParametersResolver githubFactoryParametersResolver;
 
   @BeforeMethod
-  protected void init() {
+  protected void init() throws Exception {
+    this.githubApiClient = mock(GithubApiClient.class);
+    this.urlFactoryBuilder = mock(URLFactoryBuilder.class);
+
     githubUrlParser =
-        new GithubURLParser(personalAccessTokenManager, devfileFilenamesProvider, null, false);
-    assertNotNull(this.githubUrlParser);
+        new GithubURLParser(
+            personalAccessTokenManager, devfileFilenamesProvider, githubApiClient, null, false);
+
     githubFactoryParametersResolver =
         new GithubFactoryParametersResolver(
             githubUrlParser,
@@ -150,6 +158,10 @@ public class GithubFactoryParametersResolverTest {
     when(urlFactoryBuilder.createFactoryFromDevfile(
             any(RemoteFactoryUrl.class), any(), anyMap(), anyBoolean()))
         .thenReturn(Optional.empty());
+
+    when(githubApiClient.getLatestCommit(anyString(), anyString(), anyString(), any()))
+        .thenReturn(new GithubCommit().withSha("test-sha"));
+
     Map<String, String> params = ImmutableMap.of(URL_PARAMETER_NAME, githubUrl);
     // when
     FactoryDto factory = (FactoryDto) githubFactoryParametersResolver.createFactory(params);
@@ -166,6 +178,10 @@ public class GithubFactoryParametersResolverTest {
     // given
     when(urlFactoryBuilder.buildDefaultDevfile(any()))
         .thenReturn(generateDevfileFactory().getDevfile());
+
+    when(githubApiClient.getLatestCommit(anyString(), anyString(), anyString(), any()))
+        .thenReturn(new GithubCommit().withSha("test-sha"));
+
     // when
     Map<String, String> params =
         ImmutableMap.of(
@@ -185,6 +201,10 @@ public class GithubFactoryParametersResolverTest {
     // given
     when(urlFactoryBuilder.buildDefaultDevfile(any()))
         .thenReturn(generateDevfileFactory().getDevfile());
+
+    when(githubApiClient.getLatestCommit(anyString(), anyString(), anyString(), any()))
+        .thenReturn(new GithubCommit().withSha("test-sha"));
+
     // when
     githubFactoryParametersResolver.createFactory(
         ImmutableMap.of(URL_PARAMETER_NAME, "https://github.com/eclipse/che"));
@@ -208,6 +228,9 @@ public class GithubFactoryParametersResolverTest {
             any(RemoteFactoryUrl.class), any(), anyMap(), anyBoolean()))
         .thenReturn(Optional.of(computedFactory));
 
+    when(githubApiClient.getLatestCommit(anyString(), anyString(), anyString(), any()))
+        .thenReturn(new GithubCommit().withSha("13bbd0d4605a6ed3350f7b15eb02c4d4e6f8df6e"));
+
     Map<String, String> params = ImmutableMap.of(URL_PARAMETER_NAME, githubUrl);
     // when
     FactoryDto factory = (FactoryDto) githubFactoryParametersResolver.createFactory(params);
@@ -222,7 +245,7 @@ public class GithubFactoryParametersResolverTest {
     verify(urlFactoryBuilder, never()).buildDefaultDevfile(eq("che"));
     assertEquals(
         factoryUrlArgumentCaptor.getValue().devfileFileLocations().iterator().next().location(),
-        "https://raw.githubusercontent.com/eclipse/che/HEAD/devfile.yaml");
+        "https://raw.githubusercontent.com/eclipse/che/13bbd0d4605a6ed3350f7b15eb02c4d4e6f8df6e/devfile.yaml");
   }
 
   @Test
@@ -235,6 +258,9 @@ public class GithubFactoryParametersResolverTest {
     when(urlFactoryBuilder.createFactoryFromDevfile(
             any(RemoteFactoryUrl.class), any(), anyMap(), anyBoolean()))
         .thenReturn(Optional.of(computedFactory));
+
+    when(githubApiClient.getLatestCommit(anyString(), anyString(), anyString(), any()))
+        .thenReturn(new GithubCommit().withSha("test-sha"));
 
     Map<String, String> params = ImmutableMap.of(URL_PARAMETER_NAME, githubUrl);
     // when
@@ -264,6 +290,9 @@ public class GithubFactoryParametersResolverTest {
             any(RemoteFactoryUrl.class), any(), anyMap(), anyBoolean()))
         .thenReturn(Optional.of(computedFactory));
 
+    when(githubApiClient.getLatestCommit(anyString(), anyString(), anyString(), any()))
+        .thenReturn(new GithubCommit().withSha("test-sha"));
+
     Map<String, String> params = ImmutableMap.of(URL_PARAMETER_NAME, githubUrl);
     // when
     FactoryDto factory = (FactoryDto) githubFactoryParametersResolver.createFactory(params);
@@ -283,6 +312,9 @@ public class GithubFactoryParametersResolverTest {
     when(urlFactoryBuilder.createFactoryFromDevfile(
             any(RemoteFactoryUrl.class), any(), anyMap(), anyBoolean()))
         .thenReturn(Optional.of(computedFactory));
+
+    when(githubApiClient.getLatestCommit(anyString(), anyString(), anyString(), any()))
+        .thenReturn(new GithubCommit().withSha("test-sha"));
 
     Map<String, String> params = ImmutableMap.of(URL_PARAMETER_NAME, githubUrl);
     // when

--- a/wsmaster/che-core-api-factory-github/src/test/java/org/eclipse/che/api/factory/server/github/GithubUrlTest.java
+++ b/wsmaster/che-core-api-factory-github/src/test/java/org/eclipse/che/api/factory/server/github/GithubUrlTest.java
@@ -11,21 +11,17 @@
  */
 package org.eclipse.che.api.factory.server.github;
 
-import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 import static org.testng.Assert.assertEquals;
-import static org.testng.Assert.assertNotNull;
 
 import java.util.Arrays;
 import java.util.Iterator;
-import org.eclipse.che.api.core.ApiException;
 import org.eclipse.che.api.factory.server.scm.PersonalAccessTokenManager;
 import org.eclipse.che.api.factory.server.urlfactory.DevfileFilenamesProvider;
 import org.eclipse.che.api.factory.server.urlfactory.RemoteFactoryUrl.DevfileLocation;
 import org.mockito.Mock;
 import org.mockito.testng.MockitoTestNGListener;
-import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Listeners;
 import org.testng.annotations.Test;
 
@@ -37,30 +33,26 @@ import org.testng.annotations.Test;
 @Listeners(MockitoTestNGListener.class)
 public class GithubUrlTest {
 
-  @Mock private DevfileFilenamesProvider devfileFilenamesProvider;
-
-  /** Instance of the url created */
-  private GithubUrl githubUrl;
-
-  /** Setup objects/ */
-  @BeforeMethod
-  protected void init() throws ApiException {
-    /** Parser used to create the url. */
-    GithubURLParser githubUrlParser =
-        new GithubURLParser(
-            mock(PersonalAccessTokenManager.class), devfileFilenamesProvider, null, false);
-    when(devfileFilenamesProvider.getConfiguredDevfileFilenames())
-        .thenReturn(Arrays.asList("devfile.yaml", "foo.bar"));
-    githubUrl = githubUrlParser.parse("https://github.com/eclipse/che");
-    assertNotNull(githubUrl);
-  }
+  @Mock private GithubApiClient githubApiClient;
 
   /** Check when there is devfile in the repository */
   @Test
-  public void checkDevfileLocation() {
-    lenient()
-        .when(devfileFilenamesProvider.getConfiguredDevfileFilenames())
+  public void checkDevfileLocation() throws Exception {
+    DevfileFilenamesProvider devfileFilenamesProvider = mock(DevfileFilenamesProvider.class);
+
+    /** Parser used to create the url. */
+    GithubURLParser githubUrlParser =
+        new GithubURLParser(
+            mock(PersonalAccessTokenManager.class),
+            devfileFilenamesProvider,
+            githubApiClient,
+            null,
+            false);
+
+    when(devfileFilenamesProvider.getConfiguredDevfileFilenames())
         .thenReturn(Arrays.asList("devfile.yaml", "foo.bar"));
+
+    GithubUrl githubUrl = githubUrlParser.parse("https://github.com/eclipse/che");
 
     assertEquals(githubUrl.devfileFileLocations().size(), 2);
     Iterator<DevfileLocation> iterator = githubUrl.devfileFileLocations().iterator();
@@ -74,7 +66,62 @@ public class GithubUrlTest {
 
   /** Check the original repository */
   @Test
-  public void checkRepositoryLocation() {
+  public void checkRepositoryLocation() throws Exception {
+    DevfileFilenamesProvider devfileFilenamesProvider = mock(DevfileFilenamesProvider.class);
+
+    /** Parser used to create the url. */
+    GithubURLParser githubUrlParser =
+        new GithubURLParser(
+            mock(PersonalAccessTokenManager.class),
+            devfileFilenamesProvider,
+            githubApiClient,
+            null,
+            false);
+
+    when(devfileFilenamesProvider.getConfiguredDevfileFilenames())
+        .thenReturn(Arrays.asList("devfile.yaml", "foo.bar"));
+
+    GithubUrl githubUrl = githubUrlParser.parse("https://github.com/eclipse/che");
+
     assertEquals(githubUrl.repositoryLocation(), "https://github.com/eclipse/che.git");
+  }
+
+  @Test
+  public void testRawFileLocationWithDefaultBranchName() {
+    String file = ".che/che-theia-plugins.yaml";
+
+    GithubUrl url = new GithubUrl().withUsername("eclipse").withRepository("che");
+
+    assertEquals(
+        url.rawFileLocation(file),
+        "https://raw.githubusercontent.com/eclipse/che/HEAD/.che/che-theia-plugins.yaml");
+  }
+
+  @Test
+  public void testRawFileLocationWithCustomBranchName() {
+    String file = ".che/che-theia-plugins.yaml";
+
+    GithubUrl url =
+        new GithubUrl().withUsername("eclipse").withRepository("che").withBranch("main");
+
+    assertEquals(
+        url.rawFileLocation(file),
+        "https://raw.githubusercontent.com/eclipse/che/main/.che/che-theia-plugins.yaml");
+  }
+
+  @Test
+  public void testRawFileLocationForCommit() {
+    String file = ".che/che-theia-plugins.yaml";
+
+    GithubUrl url =
+        new GithubUrl()
+            .withUsername("eclipse")
+            .withRepository("che")
+            .withBranch("main")
+            .withLatestCommit("c24fd44e0f7296be2e49a380fb8abe2fe4db9100");
+
+    assertEquals(
+        url.rawFileLocation(file),
+        "https://raw.githubusercontent.com/eclipse/che/c24fd44e0f7296be2e49a380fb8abe2fe4db9100/.che/che-theia-plugins.yaml");
   }
 }

--- a/wsmaster/che-core-api-factory/src/main/java/org/eclipse/che/api/factory/server/scm/AuthorizingFileContentProvider.java
+++ b/wsmaster/che-core-api-factory/src/main/java/org/eclipse/che/api/factory/server/scm/AuthorizingFileContentProvider.java
@@ -33,8 +33,8 @@ import org.eclipse.che.api.workspace.server.devfile.exception.DevfileException;
 public class AuthorizingFileContentProvider<T extends RemoteFactoryUrl>
     implements FileContentProvider {
 
-  private final T remoteFactoryUrl;
-  private final PersonalAccessTokenManager personalAccessTokenManager;
+  protected final T remoteFactoryUrl;
+  protected final PersonalAccessTokenManager personalAccessTokenManager;
   protected final URLFetcher urlFetcher;
 
   public AuthorizingFileContentProvider(
@@ -57,7 +57,7 @@ public class AuthorizingFileContentProvider<T extends RemoteFactoryUrl>
     return fetchContent(fileURL, true);
   }
 
-  private String fetchContent(String fileURL, boolean skipAuthentication)
+  protected String fetchContent(String fileURL, boolean skipAuthentication)
       throws IOException, DevfileException {
     final String requestURL = formatUrl(fileURL);
     try {


### PR DESCRIPTION
Signed-off-by: Vitaliy Gulyy <vgulyy@redhat.com>

<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests
-->

### What does this PR do?

At the moment it's difficult to test the flow on custom git servers, so the functionality is temporary enabled only for github.com.

To prevent caching of raw file content, when addressing the file via https://raw.githubusercontent.com it needs to use SHA of the last commit instead of the branch name.
It gives us the unique URI on each file change.

E.g., use
```
https://raw.githubusercontent.com/vitaliy-guliy/web-nodejs-sample/ce7b7ab0aa069e0bda52eac761e2d763ae78bd71/devfile.yaml
``` 
instead of
```
https://raw.githubusercontent.com/vitaliy-guliy/web-nodejs-sample/devfilev2/devfile.yaml
```

---
When client asks the content of `devfile.yaml` in `devfilev2` branch, che-server

- gets the last commit for `devfilev2` branch using GitHub rest API
```
https://api.github.com/repos/che-samples/web-nodejs-sample/commits?sha=devfilev2&page=1&per_page=1
```

- forms new URI to the raw file, where the branch name is replaced on the commit SHA
```
https://raw.githubusercontent.com/vitaliy-guliy/web-nodejs-sample/ce7b7ab0aa069e0bda52eac761e2d763ae78bd71/devfile.yaml
```

### Screenshot/screencast of this PR
<!-- Please include a screenshot or a screencast explaining what is doing this PR -->


### What issues does this PR fix or reference?
<!-- Please include any related issue from eclipse che repository (or from another issue tracker).
     Include link to other pull requests like documentation PR from [the docs repo](https://github.com/eclipse/che-docs)
-->
https://github.com/eclipse/che/issues/21184

### How to test this PR?
<!-- Please explain for example :
  - The test platform (openshift, kubernetes, minikube, CodeReady Container, docker-desktop, etc)
  - Installation method: chectl / che-operator
  - steps to reproduce
 -->
 
1. Deploy Che with
```
chectl server:deploy -p=minikube -i=quay.io/vgulyy/che-server:test-fetching-git-files
```
2. Create a workspace from git repository
3. Change the devfile, push changes
4. Within a minute, delete workspace and create a new one using the same factory link
5. Check if the changes have been applied

### PR Checklist

[As the author of this Pull Request I made sure that:](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#pull-request-template-and-its-checklist)

- [ ] [The Eclipse Contributor Agreement is valid](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-eclipse-contributor-agreement-is-valid)
- [x] [Code produced is complete](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-produced-is-complete)
- [x] [Code builds without errors](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-builds-without-errors)
- [x] [Tests are covering the bugfix](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#tests-are-covering-the-bugfix)
- [x] [The repository devfile is up to date and works](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-repository-devfile-is-up-to-date-and-works)
- [x] [Sections `What issues does this PR fix or reference` and `How to test this PR` completed](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#sections-what-issues-does-this-pr-fix-or-reference-and-how-to-test-this-pr-completed)
- [ ] [Relevant user documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [Relevant contributing documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [CI/CD changes implemented, documented and communicated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#cicd-changes-implemented-documented-and-communicated)

### Reviewers

Reviewers, please comment how you tested the PR when approving it.
