### PR TITLE
fix: Override bitbucket content provider to use API request

### DIFF
--- a/wsmaster/che-core-api-factory-bitbucket/src/main/java/org/eclipse/che/api/factory/server/bitbucket/BitbucketApiClient.java
+++ b/wsmaster/che-core-api-factory-bitbucket/src/main/java/org/eclipse/che/api/factory/server/bitbucket/BitbucketApiClient.java
@@ -115,6 +115,26 @@ public class BitbucketApiClient {
         });
   }
 
+  public String getFileContent(
+      String workspace, String repository, String source, String path, String authenticationToken)
+      throws ScmItemNotFoundException, ScmCommunicationException, ScmBadRequestException {
+    final URI uri =
+        apiServerUrl.resolve(
+            String.format("repositories/%s/%s/src/%s/%s", workspace, repository, source, path));
+    HttpRequest request = buildBitbucketApiRequest(uri, authenticationToken);
+    LOG.trace("executeRequest={}", request);
+    return executeRequest(
+        httpClient,
+        request,
+        response -> {
+          try {
+            return CharStreams.toString(new InputStreamReader(response.body(), Charsets.UTF_8));
+          } catch (IOException e) {
+            throw new UncheckedIOException(e);
+          }
+        });
+  }
+
   /**
    * Returns email of the user, associated with the provided OAuth access token.
    *

--- a/wsmaster/che-core-api-factory-bitbucket/src/main/java/org/eclipse/che/api/factory/server/bitbucket/BitbucketAuthorizingFileContentProvider.java
+++ b/wsmaster/che-core-api-factory-bitbucket/src/main/java/org/eclipse/che/api/factory/server/bitbucket/BitbucketAuthorizingFileContentProvider.java
@@ -11,25 +11,67 @@
  */
 package org.eclipse.che.api.factory.server.bitbucket;
 
+import java.io.FileNotFoundException;
 import java.io.IOException;
 import org.eclipse.che.api.factory.server.scm.AuthorizingFileContentProvider;
+import org.eclipse.che.api.factory.server.scm.PersonalAccessToken;
 import org.eclipse.che.api.factory.server.scm.PersonalAccessTokenManager;
+import org.eclipse.che.api.factory.server.scm.exception.ScmBadRequestException;
+import org.eclipse.che.api.factory.server.scm.exception.ScmCommunicationException;
+import org.eclipse.che.api.factory.server.scm.exception.ScmConfigurationPersistenceException;
+import org.eclipse.che.api.factory.server.scm.exception.ScmItemNotFoundException;
+import org.eclipse.che.api.factory.server.scm.exception.ScmUnauthorizedException;
+import org.eclipse.che.api.factory.server.scm.exception.UnknownScmProviderException;
+import org.eclipse.che.api.factory.server.scm.exception.UnsatisfiedScmPreconditionException;
 import org.eclipse.che.api.workspace.server.devfile.URLFetcher;
+import org.eclipse.che.api.workspace.server.devfile.exception.DevfileException;
 
 /** Bitbucket specific authorizing file content provider. */
 class BitbucketAuthorizingFileContentProvider extends AuthorizingFileContentProvider<BitbucketUrl> {
 
+  private final BitbucketApiClient apiClient;
+
   BitbucketAuthorizingFileContentProvider(
       BitbucketUrl bitbucketUrl,
       URLFetcher urlFetcher,
-      PersonalAccessTokenManager personalAccessTokenManager) {
+      PersonalAccessTokenManager personalAccessTokenManager,
+      BitbucketApiClient apiClient) {
     super(bitbucketUrl, urlFetcher, personalAccessTokenManager);
+    this.apiClient = apiClient;
   }
 
   /** Formats OAuth token as HTTP Authorization header. */
   @Override
   protected String formatAuthorization(String token) {
     return "Bearer " + token;
+  }
+
+  @Override
+  public String fetchContent(String fileURL) throws IOException, DevfileException {
+    final String requestURL = formatUrl(fileURL);
+    try {
+      // try to authenticate for the given URL
+      PersonalAccessToken token =
+          personalAccessTokenManager.getAndStore(remoteFactoryUrl.getHostName());
+      String[] split = requestURL.split("/");
+      return apiClient.getFileContent(
+          split[3],
+          split[4],
+          split[6],
+          fileURL.substring(fileURL.indexOf(split[6]) + split[6].length() + 1),
+          token.getToken());
+    } catch (UnknownScmProviderException e) {
+      return fetchContent(requestURL, e);
+    } catch (ScmCommunicationException e) {
+      return fetchContent(fileURL, e);
+    } catch (ScmUnauthorizedException
+        | ScmConfigurationPersistenceException
+        | UnsatisfiedScmPreconditionException
+        | ScmBadRequestException e) {
+      throw new DevfileException(e.getMessage(), e);
+    } catch (ScmItemNotFoundException e) {
+      throw new FileNotFoundException(e.getMessage());
+    }
   }
 
   @Override

--- a/wsmaster/che-core-api-factory-bitbucket/src/main/java/org/eclipse/che/api/factory/server/bitbucket/BitbucketAuthorizingFileContentProvider.java
+++ b/wsmaster/che-core-api-factory-bitbucket/src/main/java/org/eclipse/che/api/factory/server/bitbucket/BitbucketAuthorizingFileContentProvider.java
@@ -61,9 +61,9 @@ class BitbucketAuthorizingFileContentProvider extends AuthorizingFileContentProv
           fileURL.substring(fileURL.indexOf(split[6]) + split[6].length() + 1),
           token.getToken());
     } catch (UnknownScmProviderException e) {
-      return fetchContent(requestURL, e);
+      return fetchContentWithoutToken(requestURL, e);
     } catch (ScmCommunicationException e) {
-      return fetchContent(fileURL, e);
+      return toIOException(fileURL, e);
     } catch (ScmUnauthorizedException
         | ScmConfigurationPersistenceException
         | UnsatisfiedScmPreconditionException

--- a/wsmaster/che-core-api-factory-bitbucket/src/main/java/org/eclipse/che/api/factory/server/bitbucket/BitbucketFactoryParametersResolver.java
+++ b/wsmaster/che-core-api-factory-bitbucket/src/main/java/org/eclipse/che/api/factory/server/bitbucket/BitbucketFactoryParametersResolver.java
@@ -51,6 +51,8 @@ public class BitbucketFactoryParametersResolver extends DefaultFactoryParameterR
   /** Personal Access Token manager used when fetching protected content. */
   private final PersonalAccessTokenManager personalAccessTokenManager;
 
+  private final BitbucketApiClient bitbucketApiClient;
+
   @Inject
   public BitbucketFactoryParametersResolver(
       BitbucketURLParser bitbucketURLParser,
@@ -58,12 +60,14 @@ public class BitbucketFactoryParametersResolver extends DefaultFactoryParameterR
       BitbucketSourceStorageBuilder bitbucketSourceStorageBuilder,
       URLFactoryBuilder urlFactoryBuilder,
       ProjectConfigDtoMerger projectConfigDtoMerger,
-      PersonalAccessTokenManager personalAccessTokenManager) {
+      PersonalAccessTokenManager personalAccessTokenManager,
+      BitbucketApiClient bitbucketApiClient) {
     super(urlFactoryBuilder, urlFetcher);
     this.bitbucketURLParser = bitbucketURLParser;
     this.bitbucketSourceStorageBuilder = bitbucketSourceStorageBuilder;
     this.projectConfigDtoMerger = projectConfigDtoMerger;
     this.personalAccessTokenManager = personalAccessTokenManager;
+    this.bitbucketApiClient = bitbucketApiClient;
   }
 
   /**
@@ -98,7 +102,7 @@ public class BitbucketFactoryParametersResolver extends DefaultFactoryParameterR
         .createFactoryFromDevfile(
             bitbucketUrl,
             new BitbucketAuthorizingFileContentProvider(
-                bitbucketUrl, urlFetcher, personalAccessTokenManager),
+                bitbucketUrl, urlFetcher, personalAccessTokenManager, bitbucketApiClient),
             extractOverrideParams(factoryParameters),
             false)
         .orElseGet(() -> newDto(FactoryDto.class).withV(CURRENT_VERSION).withSource("repo"))

--- a/wsmaster/che-core-api-factory-bitbucket/src/main/java/org/eclipse/che/api/factory/server/bitbucket/BitbucketScmFileResolver.java
+++ b/wsmaster/che-core-api-factory-bitbucket/src/main/java/org/eclipse/che/api/factory/server/bitbucket/BitbucketScmFileResolver.java
@@ -29,15 +29,18 @@ public class BitbucketScmFileResolver implements ScmFileResolver {
   private final BitbucketURLParser bitbucketUrlParser;
   private final URLFetcher urlFetcher;
   private final PersonalAccessTokenManager personalAccessTokenManager;
+  private final BitbucketApiClient bitbucketApiClient;
 
   @Inject
   public BitbucketScmFileResolver(
       BitbucketURLParser bitbucketUrlParser,
       URLFetcher urlFetcher,
-      PersonalAccessTokenManager personalAccessTokenManager) {
+      PersonalAccessTokenManager personalAccessTokenManager,
+      BitbucketApiClient bitbucketApiClient) {
     this.bitbucketUrlParser = bitbucketUrlParser;
     this.urlFetcher = urlFetcher;
     this.personalAccessTokenManager = personalAccessTokenManager;
+    this.bitbucketApiClient = bitbucketApiClient;
   }
 
   @Override
@@ -52,7 +55,7 @@ public class BitbucketScmFileResolver implements ScmFileResolver {
     final BitbucketUrl bitbucketUrl = bitbucketUrlParser.parse(repository);
     try {
       return new BitbucketAuthorizingFileContentProvider(
-              bitbucketUrl, urlFetcher, personalAccessTokenManager)
+              bitbucketUrl, urlFetcher, personalAccessTokenManager, bitbucketApiClient)
           .fetchContent(bitbucketUrl.rawFileLocation(filePath));
     } catch (IOException e) {
       throw new NotFoundException(e.getMessage());

--- a/wsmaster/che-core-api-factory-bitbucket/src/test/java/org/eclipse/che/api/factory/server/bitbucket/BitbucketFactoryParametersResolverTest.java
+++ b/wsmaster/che-core-api-factory-bitbucket/src/test/java/org/eclipse/che/api/factory/server/bitbucket/BitbucketFactoryParametersResolverTest.java
@@ -79,6 +79,7 @@ public class BitbucketFactoryParametersResolverTest {
   @Mock private URLFactoryBuilder urlFactoryBuilder;
 
   @Mock private PersonalAccessTokenManager personalAccessTokenManager;
+  @Mock private BitbucketApiClient bitbucketApiClient;
 
   /**
    * Capturing the location parameter when calling {@link
@@ -100,7 +101,8 @@ public class BitbucketFactoryParametersResolverTest {
             bitbucketSourceStorageBuilder,
             urlFactoryBuilder,
             projectConfigDtoMerger,
-            personalAccessTokenManager);
+            personalAccessTokenManager,
+            bitbucketApiClient);
     assertNotNull(this.bitbucketFactoryParametersResolver);
   }
 

--- a/wsmaster/che-core-api-factory-bitbucket/src/test/java/org/eclipse/che/api/factory/server/bitbucket/BitbucketScmFileResolverTest.java
+++ b/wsmaster/che-core-api-factory-bitbucket/src/test/java/org/eclipse/che/api/factory/server/bitbucket/BitbucketScmFileResolverTest.java
@@ -12,6 +12,7 @@
 package org.eclipse.che.api.factory.server.bitbucket;
 
 import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.when;
 import static org.testng.AssertJUnit.assertEquals;
 import static org.testng.AssertJUnit.assertFalse;
@@ -37,6 +38,7 @@ public class BitbucketScmFileResolverTest {
 
   @Mock private DevfileFilenamesProvider devfileFilenamesProvider;
   @Mock private PersonalAccessTokenManager personalAccessTokenManager;
+  @Mock private BitbucketApiClient bitbucketApiClient;
 
   private BitbucketScmFileResolver bitbucketScmFileResolver;
 
@@ -45,7 +47,8 @@ public class BitbucketScmFileResolverTest {
     bitbucketURLParser = new BitbucketURLParser(devfileFilenamesProvider);
     assertNotNull(this.bitbucketURLParser);
     bitbucketScmFileResolver =
-        new BitbucketScmFileResolver(bitbucketURLParser, urlFetcher, personalAccessTokenManager);
+        new BitbucketScmFileResolver(
+            bitbucketURLParser, urlFetcher, personalAccessTokenManager, bitbucketApiClient);
     assertNotNull(this.bitbucketScmFileResolver);
   }
 
@@ -67,7 +70,9 @@ public class BitbucketScmFileResolverTest {
   public void shouldReturnContentFromUrlFetcher() throws Exception {
     final String rawContent = "raw_content";
     final String filename = "devfile.yaml";
-    when(urlFetcher.fetch(anyString(), anyString())).thenReturn(rawContent);
+    when(bitbucketApiClient.getFileContent(
+            eq("test"), eq("repo"), eq("HEAD"), eq("devfile.yaml"), eq("my-token")))
+        .thenReturn(rawContent);
     var personalAccessToken = new PersonalAccessToken("foo", "che", "my-token");
     when(personalAccessTokenManager.getAndStore(anyString())).thenReturn(personalAccessToken);
 

--- a/wsmaster/che-core-api-factory/src/main/java/org/eclipse/che/api/factory/server/scm/AuthorizingFileContentProvider.java
+++ b/wsmaster/che-core-api-factory/src/main/java/org/eclipse/che/api/factory/server/scm/AuthorizingFileContentProvider.java
@@ -105,7 +105,7 @@ public class AuthorizingFileContentProvider<T extends RemoteFactoryUrl>
     }
   }
 
-  protected String fetchContent(String fileURL, ScmCommunicationException e) throws IOException {
+  protected String toIOException(String fileURL, ScmCommunicationException e) throws IOException {
     throw new IOException(
         String.format(
             "Failed to fetch a content from URL %s. Make sure the URL"

--- a/wsmaster/che-core-api-factory/src/main/java/org/eclipse/che/api/factory/server/scm/AuthorizingFileContentProvider.java
+++ b/wsmaster/che-core-api-factory/src/main/java/org/eclipse/che/api/factory/server/scm/AuthorizingFileContentProvider.java
@@ -80,7 +80,7 @@ public class AuthorizingFileContentProvider<T extends RemoteFactoryUrl>
     }
   }
 
-  protected String fetchContent(String requestURL, UnknownScmProviderException e)
+  protected String fetchContentWithoutToken(String requestURL, UnknownScmProviderException e)
       throws DevfileException, IOException {
     // we don't have any provider matching this SCM provider
     // so try without secrets being configured

--- a/wsmaster/che-core-api-factory/src/main/java/org/eclipse/che/api/factory/server/scm/AuthorizingFileContentProvider.java
+++ b/wsmaster/che-core-api-factory/src/main/java/org/eclipse/che/api/factory/server/scm/AuthorizingFileContentProvider.java
@@ -70,9 +70,9 @@ public class AuthorizingFileContentProvider<T extends RemoteFactoryUrl>
         return urlFetcher.fetch(requestURL, formatAuthorization(token.getToken()));
       }
     } catch (UnknownScmProviderException e) {
-      return fetchContent(requestURL, e);
+      return fetchContentWithoutToken(requestURL, e);
     } catch (ScmCommunicationException e) {
-      return fetchContent(fileURL, e);
+      return toIOException(fileURL, e);
     } catch (ScmUnauthorizedException
         | ScmConfigurationPersistenceException
         | UnsatisfiedScmPreconditionException e) {

--- a/wsmaster/che-core-api-factory/src/main/java/org/eclipse/che/api/factory/server/scm/AuthorizingFileContentProvider.java
+++ b/wsmaster/che-core-api-factory/src/main/java/org/eclipse/che/api/factory/server/scm/AuthorizingFileContentProvider.java
@@ -70,44 +70,53 @@ public class AuthorizingFileContentProvider<T extends RemoteFactoryUrl>
         return urlFetcher.fetch(requestURL, formatAuthorization(token.getToken()));
       }
     } catch (UnknownScmProviderException e) {
-      // we don't have any provider matching this SCM provider
-      // so try without secrets being configured
-      try {
-        return urlFetcher.fetch(requestURL);
-      } catch (IOException exception) {
-        if (exception instanceof SSLException) {
-          ScmCommunicationException cause =
-              new ScmCommunicationException(
-                  String.format(
-                      "Failed to fetch a content from URL %s due to TLS key misconfiguration. Please refer to the docs about how to correctly import it. ",
-                      requestURL));
-          throw new DevfileException(exception.getMessage(), cause);
-        } else if (exception instanceof FileNotFoundException) {
-          if (isPublicRepository(remoteFactoryUrl)) {
-            // for public repo-s return 404 as-is
-            throw exception;
-          }
-        }
-        throw new DevfileException(
-            String.format("%s: %s", e.getMessage(), exception.getMessage()), exception);
-      }
+      return fetchContent(requestURL, e);
     } catch (ScmCommunicationException e) {
-      throw new IOException(
-          String.format(
-              "Failed to fetch a content from URL %s. Make sure the URL"
-                  + " is correct. For private repository, make sure authentication is configured."
-                  + " Additionally, if you're using "
-                  + " relative form, make sure the referenced file are actually stored"
-                  + " relative to the devfile on the same host,"
-                  + " or try to specify URL in absolute form. The current attempt to authenticate"
-                  + " request, failed with the following error message: %s",
-              fileURL, e.getMessage()),
-          e);
+      return fetchContent(fileURL, e);
     } catch (ScmUnauthorizedException
         | ScmConfigurationPersistenceException
         | UnsatisfiedScmPreconditionException e) {
       throw new DevfileException(e.getMessage(), e);
     }
+  }
+
+  protected String fetchContent(String requestURL, UnknownScmProviderException e)
+      throws DevfileException, IOException {
+    // we don't have any provider matching this SCM provider
+    // so try without secrets being configured
+    try {
+      return urlFetcher.fetch(requestURL);
+    } catch (IOException exception) {
+      if (exception instanceof SSLException) {
+        ScmCommunicationException cause =
+            new ScmCommunicationException(
+                String.format(
+                    "Failed to fetch a content from URL %s due to TLS key misconfiguration. Please refer to the docs about how to correctly import it. ",
+                    requestURL));
+        throw new DevfileException(exception.getMessage(), cause);
+      } else if (exception instanceof FileNotFoundException) {
+        if (isPublicRepository(remoteFactoryUrl)) {
+          // for public repo-s return 404 as-is
+          throw exception;
+        }
+      }
+      throw new DevfileException(
+          String.format("%s: %s", e.getMessage(), exception.getMessage()), exception);
+    }
+  }
+
+  protected String fetchContent(String fileURL, ScmCommunicationException e) throws IOException {
+    throw new IOException(
+        String.format(
+            "Failed to fetch a content from URL %s. Make sure the URL"
+                + " is correct. For private repository, make sure authentication is configured."
+                + " Additionally, if you're using "
+                + " relative form, make sure the referenced file are actually stored"
+                + " relative to the devfile on the same host,"
+                + " or try to specify URL in absolute form. The current attempt to authenticate"
+                + " request, failed with the following error message: %s",
+            fileURL, e.getMessage()),
+        e);
   }
 
   protected boolean isPublicRepository(T remoteFactoryUrl) {


### PR DESCRIPTION
Signed-off-by: Igor Vinokur <ivinokur@redhat.com>

<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests
-->

### What does this PR do?
bitbucket.org doesn't allow to fetch raw file content from private repositories using oAuth token any more. Override the common fetch content flow specifically for bitbucket. 

### Screenshot/screencast of this PR
<!-- Please include a screenshot or a screencast explaining what is doing this PR -->


### What issues does this PR fix or reference?
<!-- Please include any related issue from eclipse che repository (or from another issue tracker).
     Include link to other pull requests like documentation PR from [the docs repo](https://github.com/eclipse/che-docs)
-->
https://issues.redhat.com/browse/CRW-3584

### How to test this PR?
<!-- Please explain for example :
  - The test platform (openshift, kubernetes, minikube, CodeReady Container, docker-desktop, etc)
  - Installation method: chectl / che-operator
  - steps to reproduce
 -->
1. Deploy che with the `quay.io/ivinokur/che-server:next`
2. Start a workspace from a private bitbucket.org repository
See: the workspace successfully starts.
### PR Checklist

[As the author of this Pull Request I made sure that:](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#pull-request-template-and-its-checklist)

- [ ] [The Eclipse Contributor Agreement is valid](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-eclipse-contributor-agreement-is-valid)
- [ ] [Code produced is complete](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-produced-is-complete)
- [ ] [Code builds without errors](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-builds-without-errors)
- [ ] [Tests are covering the bugfix](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#tests-are-covering-the-bugfix)
- [ ] [The repository devfile is up to date and works](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-repository-devfile-is-up-to-date-and-works)
- [ ] [Sections `What issues does this PR fix or reference` and `How to test this PR` completed](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#sections-what-issues-does-this-pr-fix-or-reference-and-how-to-test-this-pr-completed)
- [ ] [Relevant user documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [Relevant contributing documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [CI/CD changes implemented, documented and communicated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#cicd-changes-implemented-documented-and-communicated)

### Reviewers

Reviewers, please comment how you tested the PR when approving it.
