### PR TITLE
Retry factory authentication when user rejects git service oauth

### DIFF
--- a/wsmaster/che-core-api-factory-bitbucket-server/src/main/java/org/eclipse/che/api/factory/server/bitbucket/BitbucketServerAuthorizingFactoryParametersResolver.java
+++ b/wsmaster/che-core-api-factory-bitbucket-server/src/main/java/org/eclipse/che/api/factory/server/bitbucket/BitbucketServerAuthorizingFactoryParametersResolver.java
@@ -14,6 +14,7 @@ package org.eclipse.che.api.factory.server.bitbucket;
 import static org.eclipse.che.api.factory.shared.Constants.CURRENT_VERSION;
 import static org.eclipse.che.api.factory.shared.Constants.URL_PARAMETER_NAME;
 import static org.eclipse.che.dto.server.DtoFactory.newDto;
+import static org.eclipse.che.security.oauth1.OAuthAuthenticationService.ERROR_QUERY_NAME;
 
 import jakarta.validation.constraints.NotNull;
 import java.util.Map;
@@ -91,13 +92,16 @@ public class BitbucketServerAuthorizingFactoryParametersResolver
         new BitbucketServerAuthorizingFileContentProvider(
             bitbucketServerUrl, urlFetcher, personalAccessTokenManager);
 
+    boolean skipAuthentication =
+        factoryParameters.get(ERROR_QUERY_NAME) != null
+            && factoryParameters.get(ERROR_QUERY_NAME).equals("access_denied");
     // create factory from the following location if location exists, else create default factory
     return urlFactoryBuilder
         .createFactoryFromDevfile(
             bitbucketServerUrl,
             fileContentProvider,
             extractOverrideParams(factoryParameters),
-            false)
+            skipAuthentication)
         .orElseGet(() -> newDto(FactoryDto.class).withV(CURRENT_VERSION).withSource("repo"))
         .acceptVisitor(new BitbucketFactoryVisitor(bitbucketServerUrl));
   }

--- a/wsmaster/che-core-api-factory-bitbucket-server/src/test/java/org/eclipse/che/api/factory/server/bitbucket/BitbucketServerAuthorizingFactoryParametersResolverTest.java
+++ b/wsmaster/che-core-api-factory-bitbucket-server/src/test/java/org/eclipse/che/api/factory/server/bitbucket/BitbucketServerAuthorizingFactoryParametersResolverTest.java
@@ -16,6 +16,7 @@ import static org.eclipse.che.api.factory.shared.Constants.CURRENT_VERSION;
 import static org.eclipse.che.api.factory.shared.Constants.URL_PARAMETER_NAME;
 import static org.eclipse.che.api.workspace.server.devfile.Constants.CURRENT_API_VERSION;
 import static org.eclipse.che.dto.server.DtoFactory.newDto;
+import static org.eclipse.che.security.oauth1.OAuthAuthenticationService.ERROR_QUERY_NAME;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.ArgumentMatchers.anyMap;
@@ -32,6 +33,7 @@ import static org.testng.Assert.assertTrue;
 import com.google.common.collect.ImmutableMap;
 import java.util.Map;
 import java.util.Optional;
+import org.eclipse.che.api.core.ApiException;
 import org.eclipse.che.api.core.model.factory.ScmInfo;
 import org.eclipse.che.api.factory.server.scm.PersonalAccessTokenManager;
 import org.eclipse.che.api.factory.server.urlfactory.DevfileFilenamesProvider;
@@ -181,5 +183,27 @@ public class BitbucketServerAuthorizingFactoryParametersResolverTest {
         .withV(CURRENT_VERSION)
         .withSource("repo")
         .withDevfile(Map.of("schemaVersion", "2.0.0"));
+  }
+
+  @Test
+  public void shouldCreateFactoryWithoutAuthentication() throws ApiException {
+    // given
+    String bitbucketServerUrl = "http://bitbucket.2mcl.com/scm/~user/repo.git";
+    Map<String, String> params =
+        ImmutableMap.of(URL_PARAMETER_NAME, bitbucketServerUrl, ERROR_QUERY_NAME, "access_denied");
+    when(urlFactoryBuilder.createFactoryFromDevfile(
+            any(RemoteFactoryUrl.class), any(), anyMap(), anyBoolean()))
+        .thenReturn(Optional.of(generateDevfileFactory()));
+
+    // when
+    bitbucketServerFactoryParametersResolver.createFactory(params);
+
+    // then
+    verify(urlFactoryBuilder)
+        .createFactoryFromDevfile(
+            any(BitbucketServerUrl.class),
+            any(BitbucketServerAuthorizingFileContentProvider.class),
+            anyMap(),
+            eq(true));
   }
 }

--- a/wsmaster/che-core-api-factory-bitbucket-server/src/test/java/org/eclipse/che/api/factory/server/bitbucket/BitbucketServerScmFileResolverTest.java
+++ b/wsmaster/che-core-api-factory-bitbucket-server/src/test/java/org/eclipse/che/api/factory/server/bitbucket/BitbucketServerScmFileResolverTest.java
@@ -14,11 +14,13 @@ package org.eclipse.che.api.factory.server.bitbucket;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.testng.Assert.*;
 
 import org.eclipse.che.api.factory.server.scm.PersonalAccessToken;
 import org.eclipse.che.api.factory.server.scm.PersonalAccessTokenManager;
+import org.eclipse.che.api.factory.server.scm.exception.ScmUnauthorizedException;
 import org.eclipse.che.api.factory.server.urlfactory.DevfileFilenamesProvider;
 import org.eclipse.che.api.workspace.server.devfile.URLFetcher;
 import org.mockito.Mock;
@@ -79,5 +81,18 @@ public class BitbucketServerScmFileResolverTest {
         serverScmFileResolver.fileContent("https://foo.bar/scm/test/repo.git", filename);
 
     assertEquals(content, rawContent);
+  }
+
+  @Test
+  public void shouldFetchContentWithoutAuthentication() throws Exception {
+    // given
+    when(personalAccessTokenManager.getAndStore(anyString()))
+        .thenThrow(new ScmUnauthorizedException("message", "bitbucket-server", "v1", "url"));
+
+    // when
+    serverScmFileResolver.fileContent("https://foo.bar/scm/~username/repo.git", "devfile.yaml");
+
+    // then
+    verify(urlFetcher).fetch(anyString());
   }
 }

--- a/wsmaster/che-core-api-factory-bitbucket/src/main/java/org/eclipse/che/api/factory/server/bitbucket/BitbucketAuthorizingFileContentProvider.java
+++ b/wsmaster/che-core-api-factory-bitbucket/src/main/java/org/eclipse/che/api/factory/server/bitbucket/BitbucketAuthorizingFileContentProvider.java
@@ -58,7 +58,7 @@ class BitbucketAuthorizingFileContentProvider extends AuthorizingFileContentProv
           split[3],
           split[4],
           split[6],
-          fileURL.substring(fileURL.indexOf(split[6]) + split[6].length() + 1),
+          requestURL.substring(requestURL.indexOf(split[6]) + split[6].length() + 1),
           token.getToken());
     } catch (UnknownScmProviderException e) {
       return fetchContentWithoutToken(requestURL, e);

--- a/wsmaster/che-core-api-factory-bitbucket/src/main/java/org/eclipse/che/api/factory/server/bitbucket/BitbucketFactoryParametersResolver.java
+++ b/wsmaster/che-core-api-factory-bitbucket/src/main/java/org/eclipse/che/api/factory/server/bitbucket/BitbucketFactoryParametersResolver.java
@@ -14,6 +14,7 @@ package org.eclipse.che.api.factory.server.bitbucket;
 import static org.eclipse.che.api.factory.shared.Constants.CURRENT_VERSION;
 import static org.eclipse.che.api.factory.shared.Constants.URL_PARAMETER_NAME;
 import static org.eclipse.che.dto.server.DtoFactory.newDto;
+import static org.eclipse.che.security.oauth1.OAuthAuthenticationService.ERROR_QUERY_NAME;
 
 import jakarta.validation.constraints.NotNull;
 import java.util.Map;
@@ -96,7 +97,9 @@ public class BitbucketFactoryParametersResolver extends DefaultFactoryParameterR
     // no need to check null value of url parameter as accept() method has performed the check
     final BitbucketUrl bitbucketUrl =
         bitbucketURLParser.parse(factoryParameters.get(URL_PARAMETER_NAME));
-
+    boolean skipAuthentication =
+        factoryParameters.get(ERROR_QUERY_NAME) != null
+            && factoryParameters.get(ERROR_QUERY_NAME).equals("access_denied");
     // create factory from the following location if location exists, else create default factory
     return urlFactoryBuilder
         .createFactoryFromDevfile(
@@ -104,7 +107,7 @@ public class BitbucketFactoryParametersResolver extends DefaultFactoryParameterR
             new BitbucketAuthorizingFileContentProvider(
                 bitbucketUrl, urlFetcher, personalAccessTokenManager, bitbucketApiClient),
             extractOverrideParams(factoryParameters),
-            false)
+            skipAuthentication)
         .orElseGet(() -> newDto(FactoryDto.class).withV(CURRENT_VERSION).withSource("repo"))
         .acceptVisitor(new BitbucketFactoryVisitor(bitbucketUrl));
   }

--- a/wsmaster/che-core-api-factory-bitbucket/src/test/java/org/eclipse/che/api/factory/server/bitbucket/BitbucketFactoryParametersResolverTest.java
+++ b/wsmaster/che-core-api-factory-bitbucket/src/test/java/org/eclipse/che/api/factory/server/bitbucket/BitbucketFactoryParametersResolverTest.java
@@ -16,6 +16,7 @@ import static org.eclipse.che.api.factory.shared.Constants.CURRENT_VERSION;
 import static org.eclipse.che.api.factory.shared.Constants.URL_PARAMETER_NAME;
 import static org.eclipse.che.api.workspace.server.devfile.Constants.CURRENT_API_VERSION;
 import static org.eclipse.che.dto.server.DtoFactory.newDto;
+import static org.eclipse.che.security.oauth1.OAuthAuthenticationService.ERROR_QUERY_NAME;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.ArgumentMatchers.anyMap;
@@ -33,6 +34,7 @@ import com.google.common.collect.ImmutableMap;
 import java.util.Collections;
 import java.util.Map;
 import java.util.Optional;
+import org.eclipse.che.api.core.ApiException;
 import org.eclipse.che.api.core.model.factory.ScmInfo;
 import org.eclipse.che.api.factory.server.scm.PersonalAccessTokenManager;
 import org.eclipse.che.api.factory.server.urlfactory.DevfileFilenamesProvider;
@@ -274,5 +276,27 @@ public class BitbucketFactoryParametersResolverTest {
         .withV(CURRENT_VERSION)
         .withSource("repo")
         .withDevfile(Map.of("schemaVersion", "2.0.0"));
+  }
+
+  @Test
+  public void shouldCreateFactoryWithoutAuthentication() throws ApiException {
+    // given
+    String bitbucketUrl = "https://bitbucket.org/user/repo.git";
+    Map<String, String> params =
+        ImmutableMap.of(URL_PARAMETER_NAME, bitbucketUrl, ERROR_QUERY_NAME, "access_denied");
+    when(urlFactoryBuilder.createFactoryFromDevfile(
+            any(RemoteFactoryUrl.class), any(), anyMap(), anyBoolean()))
+        .thenReturn(Optional.of(generateDevfileFactory()));
+
+    // when
+    bitbucketFactoryParametersResolver.createFactory(params);
+
+    // then
+    verify(urlFactoryBuilder)
+        .createFactoryFromDevfile(
+            any(BitbucketUrl.class),
+            any(BitbucketAuthorizingFileContentProvider.class),
+            anyMap(),
+            eq(true));
   }
 }

--- a/wsmaster/che-core-api-factory-bitbucket/src/test/java/org/eclipse/che/api/factory/server/bitbucket/BitbucketScmFileResolverTest.java
+++ b/wsmaster/che-core-api-factory-bitbucket/src/test/java/org/eclipse/che/api/factory/server/bitbucket/BitbucketScmFileResolverTest.java
@@ -13,6 +13,7 @@ package org.eclipse.che.api.factory.server.bitbucket;
 
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.testng.AssertJUnit.assertEquals;
 import static org.testng.AssertJUnit.assertFalse;
@@ -21,6 +22,7 @@ import static org.testng.AssertJUnit.assertTrue;
 
 import org.eclipse.che.api.factory.server.scm.PersonalAccessToken;
 import org.eclipse.che.api.factory.server.scm.PersonalAccessTokenManager;
+import org.eclipse.che.api.factory.server.scm.exception.ScmUnauthorizedException;
 import org.eclipse.che.api.factory.server.urlfactory.DevfileFilenamesProvider;
 import org.eclipse.che.api.workspace.server.devfile.URLFetcher;
 import org.mockito.Mock;
@@ -80,5 +82,18 @@ public class BitbucketScmFileResolverTest {
         bitbucketScmFileResolver.fileContent("http://bitbucket.org/test/repo.git", filename);
 
     assertEquals(content, rawContent);
+  }
+
+  @Test
+  public void shouldFetchContentWithoutAuthentication() throws Exception {
+    // given
+    when(personalAccessTokenManager.getAndStore(anyString()))
+        .thenThrow(new ScmUnauthorizedException("message", "bitbucket", "v1", "url"));
+
+    // when
+    bitbucketScmFileResolver.fileContent("https://bitbucket.org/username/repo.git", "devfile.yaml");
+
+    // then
+    verify(urlFetcher).fetch(anyString());
   }
 }

--- a/wsmaster/che-core-api-factory-github/src/main/java/org/eclipse/che/api/factory/server/github/GithubURLParser.java
+++ b/wsmaster/che-core-api-factory-github/src/main/java/org/eclipse/che/api/factory/server/github/GithubURLParser.java
@@ -245,8 +245,7 @@ public class GithubURLParser {
           repoName,
           branchName,
           personalAccessToken != null ? personalAccessToken.getToken() : null);
-    } catch (UnknownScmProviderException e) {
-
+    } catch (UnknownScmProviderException | ScmUnauthorizedException e) {
       // get latest commit without authentication
       try {
         return this.apiClient.getLatestCommit(repoUser, repoName, branchName, null);
@@ -256,9 +255,6 @@ public class GithubURLParser {
           | URISyntaxException exception) {
         LOG.error("Failed to authenticate to GitHub", e);
       }
-
-    } catch (ScmUnauthorizedException e) {
-      throw toApiException(e);
     } catch (ScmCommunicationException
         | UnsatisfiedScmPreconditionException
         | ScmConfigurationPersistenceException e) {

--- a/wsmaster/che-core-api-factory-github/src/test/java/org/eclipse/che/api/factory/server/github/GithubFactoryParametersResolverTest.java
+++ b/wsmaster/che-core-api-factory-github/src/test/java/org/eclipse/che/api/factory/server/github/GithubFactoryParametersResolverTest.java
@@ -36,6 +36,7 @@ import com.google.common.collect.ImmutableMap;
 import java.util.Collections;
 import java.util.Map;
 import java.util.Optional;
+import org.eclipse.che.api.core.ApiException;
 import org.eclipse.che.api.core.model.factory.ScmInfo;
 import org.eclipse.che.api.factory.server.scm.PersonalAccessTokenManager;
 import org.eclipse.che.api.factory.server.urlfactory.DevfileFilenamesProvider;
@@ -326,6 +327,28 @@ public class GithubFactoryParametersResolverTest {
     assertEquals(scmInfo.getScmProviderName(), "github");
     assertEquals(scmInfo.getRepositoryUrl(), "https://github.com/eclipse/che.git");
     assertEquals(scmInfo.getBranch(), "foobar");
+  }
+
+  @Test
+  public void shouldCreateFactoryWithoutAuthentication() throws ApiException {
+    // given
+    String githubUrl = "https://github.com/user/repo.git";
+    Map<String, String> params =
+        ImmutableMap.of(URL_PARAMETER_NAME, githubUrl, ERROR_QUERY_NAME, "access_denied");
+    when(urlFactoryBuilder.createFactoryFromDevfile(
+            any(RemoteFactoryUrl.class), any(), anyMap(), anyBoolean()))
+        .thenReturn(Optional.of(generateDevfileFactory()));
+
+    // when
+    githubFactoryParametersResolver.createFactory(params);
+
+    // then
+    verify(urlFactoryBuilder)
+        .createFactoryFromDevfile(
+            any(GithubUrl.class),
+            any(GithubAuthorizingFileContentProvider.class),
+            anyMap(),
+            eq(true));
   }
 
   private FactoryDto generateDevfileFactory() {

--- a/wsmaster/che-core-api-factory-github/src/test/java/org/eclipse/che/api/factory/server/github/GithubScmFileResolverTest.java
+++ b/wsmaster/che-core-api-factory-github/src/test/java/org/eclipse/che/api/factory/server/github/GithubScmFileResolverTest.java
@@ -15,11 +15,13 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.testng.Assert.*;
 
 import org.eclipse.che.api.factory.server.scm.PersonalAccessToken;
 import org.eclipse.che.api.factory.server.scm.PersonalAccessTokenManager;
+import org.eclipse.che.api.factory.server.scm.exception.ScmUnauthorizedException;
 import org.eclipse.che.api.factory.server.urlfactory.DevfileFilenamesProvider;
 import org.eclipse.che.api.workspace.server.devfile.URLFetcher;
 import org.mockito.Mock;
@@ -96,5 +98,18 @@ public class GithubScmFileResolverTest {
         githubScmFileResolver.fileContent("https://github.com/organization/samples.git", filename);
 
     assertEquals(content, rawContent);
+  }
+
+  @Test
+  public void shouldReturnContentWithoutAuthentication() throws Exception {
+    // given
+    when(personalAccessTokenManager.getAndStore(anyString()))
+        .thenThrow(new ScmUnauthorizedException("message", "github", "v1", "url"));
+
+    // when
+    githubScmFileResolver.fileContent("https://github.com/username/repo.git", "devfile.yaml");
+
+    // then
+    verify(urlFetcher).fetch(anyString());
   }
 }

--- a/wsmaster/che-core-api-factory-gitlab/src/test/java/org/eclipse/che/api/factory/server/gitlab/GitlabScmFileResolverTest.java
+++ b/wsmaster/che-core-api-factory-gitlab/src/test/java/org/eclipse/che/api/factory/server/gitlab/GitlabScmFileResolverTest.java
@@ -15,11 +15,13 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.testng.Assert.*;
 
 import org.eclipse.che.api.factory.server.scm.PersonalAccessToken;
 import org.eclipse.che.api.factory.server.scm.PersonalAccessTokenManager;
+import org.eclipse.che.api.factory.server.scm.exception.ScmUnauthorizedException;
 import org.eclipse.che.api.factory.server.urlfactory.DevfileFilenamesProvider;
 import org.eclipse.che.api.workspace.server.devfile.URLFetcher;
 import org.mockito.Mock;
@@ -79,5 +81,18 @@ public class GitlabScmFileResolverTest {
         gitlabScmFileResolver.fileContent("http://gitlab.2mcl.com/test/proj/repo.git", filename);
 
     assertEquals(content, rawContent);
+  }
+
+  @Test
+  public void shouldFetchContentWithoutAuthentication() throws Exception {
+    // given
+    when(personalAccessTokenManager.getAndStore(anyString()))
+        .thenThrow(new ScmUnauthorizedException("message", "gitlab", "v1", "url"));
+
+    // when
+    gitlabScmFileResolver.fileContent("https://gitlab.com/username/repo.git", "devfile.yaml");
+
+    // then
+    verify(urlFetcher).fetch(anyString());
   }
 }


### PR DESCRIPTION
Signed-off-by: Igor Vinokur <ivinokur@redhat.com>

<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests
-->

### What does this PR do?
Currently when user rejects the oauth page for GitHub factory, Che tries to continue the factory flow without authentication (possible only for public repo). Apply the logic for the others git authentication providers.

### Screenshot/screencast of this PR
<!-- Please include a screenshot or a screencast explaining what is doing this PR -->


### What issues does this PR fix or reference?
<!-- Please include any related issue from eclipse che repository (or from another issue tracker).
     Include link to other pull requests like documentation PR from [the docs repo](https://github.com/eclipse/che-docs)
-->
https://issues.redhat.com/browse/CRW-3594

### How to test this PR?
<!-- Please explain for example :
  - The test platform (openshift, kubernetes, minikube, CodeReady Container, docker-desktop, etc)
  - Installation method: chectl / che-operator
  - steps to reproduce
 -->
1. Deploy Che with `quay.io/ivinokur/che-server:next` as che-server image.
2. Start a factory from GitLab / GitLab server / Bitbucket / Bitbucket Server public repo.
3. Reject the authentication request.
See: workspace starts.

### PR Checklist

[As the author of this Pull Request I made sure that:](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#pull-request-template-and-its-checklist)

- [x] [The Eclipse Contributor Agreement is valid](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-eclipse-contributor-agreement-is-valid)
- [x] [Code produced is complete](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-produced-is-complete)
- [ ] [Code builds without errors](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-builds-without-errors)
- [x] [Tests are covering the bugfix](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#tests-are-covering-the-bugfix)
- [ ] [The repository devfile is up to date and works](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-repository-devfile-is-up-to-date-and-works)
- [x] [Sections `What issues does this PR fix or reference` and `How to test this PR` completed](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#sections-what-issues-does-this-pr-fix-or-reference-and-how-to-test-this-pr-completed)
- [ ] [Relevant user documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [Relevant contributing documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [CI/CD changes implemented, documented and communicated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#cicd-changes-implemented-documented-and-communicated)

### Reviewers

Reviewers, please comment how you tested the PR when approving it.
