### PR TITLE
Increase the maximum size of the request and response HTTP header to 32 KB

### DIFF
--- a/assembly/assembly-che-tomcat/src/assembly/conf/server.xml
+++ b/assembly/assembly-che-tomcat/src/assembly/conf/server.xml
@@ -69,6 +69,7 @@
       <Connector port="${port.http:-8080}" protocol="HTTP/1.1"
                  connectionTimeout="20000"
                  maxThreads="300"
+                 maxHttpHeaderSize="32768"
                  compression="on"
                  compressionMinSize="2048"
                  noCompressionUserAgents=".*MSIE 6.*"


### PR DESCRIPTION
### What does this PR do?
Tomcat allows to configure the maximum size of the request and response HTTP header. If not specified, this attribute is set to 8192 (8 KB). In order to avoid requests blocking by this limitation, tomcat configuration has been adjusted to set 32768 (32 KB).

We need it for Azure Active Directory case when auth token is quite big (more than 8KB).

More details on tomcat config: https://tomcat.apache.org/tomcat-8.0-doc/config/http.html

### Screenshot/screencast of this PR
<!-- Please include a screenshot or a screencast explaining what is doing this PR -->
Request HTTP header size is limited to 32 KB (not to 8 KB by default) after this change.
![image](https://user-images.githubusercontent.com/63723184/209093821-ef9cf303-560c-4011-abce-c88b0fa9695e.png)

### What issues does this PR fix or reference?
<!-- Please include any related issue from eclipse che repository (or from another issue tracker).
     Include link to other pull requests like documentation PR from [the docs repo](https://github.com/eclipse/che-docs)
-->
https://github.com/eclipse/che/issues/21898

### How to test this PR?

1. Deploy Che with `docker.io/karatkep/che-server:7.50-lh` as che-server image.
2. Call any che-server Open API, for example: GET /user. Please see screenshot above.




### PR Checklist

[As the author of this Pull Request I made sure that:](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#pull-request-template-and-its-checklist)

- [ ] [The Eclipse Contributor Agreement is valid](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-eclipse-contributor-agreement-is-valid)
- [ ] [Code produced is complete](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-produced-is-complete)
- [ ] [Code builds without errors](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-builds-without-errors)
- [ ] [Tests are covering the bugfix](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#tests-are-covering-the-bugfix)
- [ ] [The repository devfile is up to date and works](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-repository-devfile-is-up-to-date-and-works)
- [ ] [Sections `What issues does this PR fix or reference` and `How to test this PR` completed](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#sections-what-issues-does-this-pr-fix-or-reference-and-how-to-test-this-pr-completed)
- [ ] [Relevant user documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [Relevant contributing documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [CI/CD changes implemented, documented and communicated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#cicd-changes-implemented-documented-and-communicated)

### Reviewers

Reviewers, please comment how you tested the PR when approving it.
