### PR TITLE
Fix Delete oauth token API method

### DIFF
--- a/wsmaster/che-core-api-auth-bitbucket/src/main/java/org/eclipse/che/security/oauth/BitbucketOAuthAuthenticator.java
+++ b/wsmaster/che-core-api-auth-bitbucket/src/main/java/org/eclipse/che/security/oauth/BitbucketOAuthAuthenticator.java
@@ -63,6 +63,11 @@ public class BitbucketOAuthAuthenticator extends OAuthAuthenticator {
   }
 
   @Override
+  public String getEndpointUrl() {
+    return "https://bitbucket.org";
+  }
+
+  @Override
   protected <O> O getJson(String getUserUrl, String accessToken, Class<O> userClass)
       throws OAuthAuthenticationException {
     HttpURLConnection urlConnection = null;

--- a/wsmaster/che-core-api-auth-bitbucket/src/main/java/org/eclipse/che/security/oauth/BitbucketOAuthAuthenticatorProvider.java
+++ b/wsmaster/che-core-api-auth-bitbucket/src/main/java/org/eclipse/che/security/oauth/BitbucketOAuthAuthenticatorProvider.java
@@ -91,5 +91,10 @@ public class BitbucketOAuthAuthenticatorProvider implements Provider<OAuthAuthen
     public String getOAuthProvider() {
       return "Noop";
     }
+
+    @Override
+    public String getEndpointUrl() {
+      return "Noop";
+    }
   }
 }

--- a/wsmaster/che-core-api-auth-github/pom.xml
+++ b/wsmaster/che-core-api-auth-github/pom.xml
@@ -68,6 +68,11 @@
             <artifactId>slf4j-api</artifactId>
         </dependency>
         <dependency>
+            <groupId>com.github.tomakehurst</groupId>
+            <artifactId>wiremock-jre8-standalone</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>org.testng</groupId>
             <artifactId>testng</artifactId>
             <scope>test</scope>

--- a/wsmaster/che-core-api-auth-github/src/main/java/org/eclipse/che/security/oauth/GitHubOAuthAuthenticatorProvider.java
+++ b/wsmaster/che-core-api-auth-github/src/main/java/org/eclipse/che/security/oauth/GitHubOAuthAuthenticatorProvider.java
@@ -108,5 +108,10 @@ public class GitHubOAuthAuthenticatorProvider implements Provider<OAuthAuthentic
     public String getOAuthProvider() {
       return "Noop";
     }
+
+    @Override
+    public String getEndpointUrl() {
+      return "Noop";
+    }
   }
 }

--- a/wsmaster/che-core-api-auth-gitlab/src/main/java/org/eclipse/che/security/oauth/GitLabOAuthAuthenticator.java
+++ b/wsmaster/che-core-api-auth-gitlab/src/main/java/org/eclipse/che/security/oauth/GitLabOAuthAuthenticator.java
@@ -39,10 +39,12 @@ import org.eclipse.che.security.oauth.shared.User;
 public class GitLabOAuthAuthenticator extends OAuthAuthenticator {
   private final String gitlabUserEndpoint;
   private final String cheApiEndpoint;
+  private final String gitlabEndpoint;
 
   public GitLabOAuthAuthenticator(
       String clientId, String clientSecret, String gitlabEndpoint, String cheApiEndpoint)
       throws IOException {
+    this.gitlabEndpoint = gitlabEndpoint;
     String trimmedGitlabEndpoint = trimEnd(gitlabEndpoint, '/');
     this.gitlabUserEndpoint = trimmedGitlabEndpoint + "/api/v4/user";
     this.cheApiEndpoint = cheApiEndpoint;
@@ -115,5 +117,9 @@ public class GitLabOAuthAuthenticator extends OAuthAuthenticator {
       return null;
     }
     return token;
+  }
+
+  public String getEndpointUrl() {
+    return trimEnd(gitlabEndpoint, '/');
   }
 }

--- a/wsmaster/che-core-api-auth-gitlab/src/main/java/org/eclipse/che/security/oauth/GitLabOAuthAuthenticator.java
+++ b/wsmaster/che-core-api-auth-gitlab/src/main/java/org/eclipse/che/security/oauth/GitLabOAuthAuthenticator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012-2022 Red Hat, Inc.
+ * Copyright (c) 2012-2023 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/wsmaster/che-core-api-auth-gitlab/src/main/java/org/eclipse/che/security/oauth/GitLabOAuthAuthenticator.java
+++ b/wsmaster/che-core-api-auth-gitlab/src/main/java/org/eclipse/che/security/oauth/GitLabOAuthAuthenticator.java
@@ -44,7 +44,7 @@ public class GitLabOAuthAuthenticator extends OAuthAuthenticator {
   public GitLabOAuthAuthenticator(
       String clientId, String clientSecret, String gitlabEndpoint, String cheApiEndpoint)
       throws IOException {
-    this.gitlabEndpoint = gitlabEndpoint;
+    this.gitlabEndpoint = trimEnd(gitlabEndpoint, '/');
     String trimmedGitlabEndpoint = trimEnd(gitlabEndpoint, '/');
     this.gitlabUserEndpoint = trimmedGitlabEndpoint + "/api/v4/user";
     this.cheApiEndpoint = cheApiEndpoint;
@@ -120,6 +120,6 @@ public class GitLabOAuthAuthenticator extends OAuthAuthenticator {
   }
 
   public String getEndpointUrl() {
-    return trimEnd(gitlabEndpoint, '/');
+    return gitlabEndpoint;
   }
 }

--- a/wsmaster/che-core-api-auth-gitlab/src/main/java/org/eclipse/che/security/oauth/GitLabOAuthAuthenticatorProvider.java
+++ b/wsmaster/che-core-api-auth-gitlab/src/main/java/org/eclipse/che/security/oauth/GitLabOAuthAuthenticatorProvider.java
@@ -79,5 +79,10 @@ public class GitLabOAuthAuthenticatorProvider implements Provider<OAuthAuthentic
     public String getOAuthProvider() {
       return "Noop";
     }
+
+    @Override
+    public String getEndpointUrl() {
+      return "Noop";
+    }
   }
 }

--- a/wsmaster/che-core-api-auth-openshift/pom.xml
+++ b/wsmaster/che-core-api-auth-openshift/pom.xml
@@ -51,5 +51,9 @@
             <groupId>org.eclipse.che.core</groupId>
             <artifactId>che-core-commons-annotations</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.eclipse.che.core</groupId>
+            <artifactId>che-core-commons-lang</artifactId>
+        </dependency>
     </dependencies>
 </project>

--- a/wsmaster/che-core-api-auth-openshift/src/main/java/org/eclipse/che/security/oauth/OpenShiftOAuthAuthenticator.java
+++ b/wsmaster/che-core-api-auth-openshift/src/main/java/org/eclipse/che/security/oauth/OpenShiftOAuthAuthenticator.java
@@ -32,7 +32,7 @@ import org.eclipse.che.security.oauth.shared.User;
  */
 @Singleton
 public class OpenShiftOAuthAuthenticator extends OAuthAuthenticator {
-  @Nullable private final String oauthEndpoint;
+  private final String oauthEndpoint;
   private final String verifyTokenUrl;
 
   @Inject
@@ -43,7 +43,7 @@ public class OpenShiftOAuthAuthenticator extends OAuthAuthenticator {
       @Nullable @Named("che.oauth.openshift.verify_token_url") String verifyTokenUrl,
       @Named("che.api") String apiEndpoint)
       throws IOException {
-    this.oauthEndpoint = oauthEndpoint;
+    this.oauthEndpoint = isNullOrEmpty(oauthEndpoint) ? "" : trimEnd(oauthEndpoint, '/');
     this.verifyTokenUrl = verifyTokenUrl;
     String[] redirectUrl = {apiEndpoint + "/oauth/callback"};
     if (!isNullOrEmpty(clientId) && !isNullOrEmpty(clientSecret) && !isNullOrEmpty(oauthEndpoint)) {
@@ -97,6 +97,6 @@ public class OpenShiftOAuthAuthenticator extends OAuthAuthenticator {
 
   @Override
   public String getEndpointUrl() {
-    return isNullOrEmpty(oauthEndpoint) ? "" : trimEnd(oauthEndpoint, '/');
+    return oauthEndpoint;
   }
 }

--- a/wsmaster/che-core-api-auth-openshift/src/main/java/org/eclipse/che/security/oauth/OpenShiftOAuthAuthenticator.java
+++ b/wsmaster/che-core-api-auth-openshift/src/main/java/org/eclipse/che/security/oauth/OpenShiftOAuthAuthenticator.java
@@ -12,6 +12,7 @@
 package org.eclipse.che.security.oauth;
 
 import static com.google.common.base.Strings.isNullOrEmpty;
+import static org.eclipse.che.commons.lang.StringUtils.trimEnd;
 
 import com.google.api.client.util.store.MemoryDataStoreFactory;
 import java.io.IOException;
@@ -31,7 +32,7 @@ import org.eclipse.che.security.oauth.shared.User;
  */
 @Singleton
 public class OpenShiftOAuthAuthenticator extends OAuthAuthenticator {
-  private final String endpointUrl;
+  @Nullable private final String oauthEndpoint;
   private final String verifyTokenUrl;
 
   @Inject
@@ -42,16 +43,17 @@ public class OpenShiftOAuthAuthenticator extends OAuthAuthenticator {
       @Nullable @Named("che.oauth.openshift.verify_token_url") String verifyTokenUrl,
       @Named("che.api") String apiEndpoint)
       throws IOException {
-    this.endpointUrl = oauthEndpoint.endsWith("/") ? oauthEndpoint : oauthEndpoint + "/";
+    this.oauthEndpoint = oauthEndpoint;
     this.verifyTokenUrl = verifyTokenUrl;
     String[] redirectUrl = {apiEndpoint + "/oauth/callback"};
     if (!isNullOrEmpty(clientId) && !isNullOrEmpty(clientSecret) && !isNullOrEmpty(oauthEndpoint)) {
+      oauthEndpoint = oauthEndpoint.endsWith("/") ? oauthEndpoint : oauthEndpoint + "/";
       configure(
           clientId,
           clientSecret,
           redirectUrl,
-          this.endpointUrl + "oauth/authorize",
-          this.endpointUrl + "oauth/token",
+          oauthEndpoint + "oauth/authorize",
+          oauthEndpoint + "oauth/token",
           new MemoryDataStoreFactory());
     }
   }
@@ -95,6 +97,6 @@ public class OpenShiftOAuthAuthenticator extends OAuthAuthenticator {
 
   @Override
   public String getEndpointUrl() {
-    return endpointUrl;
+    return isNullOrEmpty(oauthEndpoint) ? "" : trimEnd(oauthEndpoint, '/');
   }
 }

--- a/wsmaster/che-core-api-auth-openshift/src/main/java/org/eclipse/che/security/oauth/OpenShiftOAuthAuthenticator.java
+++ b/wsmaster/che-core-api-auth-openshift/src/main/java/org/eclipse/che/security/oauth/OpenShiftOAuthAuthenticator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012-2022 Red Hat, Inc.
+ * Copyright (c) 2012-2023 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/wsmaster/che-core-api-auth-openshift/src/main/java/org/eclipse/che/security/oauth/OpenShiftOAuthAuthenticator.java
+++ b/wsmaster/che-core-api-auth-openshift/src/main/java/org/eclipse/che/security/oauth/OpenShiftOAuthAuthenticator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012-2021 Red Hat, Inc.
+ * Copyright (c) 2012-2022 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/
@@ -31,6 +31,7 @@ import org.eclipse.che.security.oauth.shared.User;
  */
 @Singleton
 public class OpenShiftOAuthAuthenticator extends OAuthAuthenticator {
+  private final String endpointUrl;
   private final String verifyTokenUrl;
 
   @Inject
@@ -41,16 +42,16 @@ public class OpenShiftOAuthAuthenticator extends OAuthAuthenticator {
       @Nullable @Named("che.oauth.openshift.verify_token_url") String verifyTokenUrl,
       @Named("che.api") String apiEndpoint)
       throws IOException {
+    this.endpointUrl = oauthEndpoint.endsWith("/") ? oauthEndpoint : oauthEndpoint + "/";
     this.verifyTokenUrl = verifyTokenUrl;
     String[] redirectUrl = {apiEndpoint + "/oauth/callback"};
     if (!isNullOrEmpty(clientId) && !isNullOrEmpty(clientSecret) && !isNullOrEmpty(oauthEndpoint)) {
-      oauthEndpoint = oauthEndpoint.endsWith("/") ? oauthEndpoint : oauthEndpoint + "/";
       configure(
           clientId,
           clientSecret,
           redirectUrl,
-          oauthEndpoint + "oauth/authorize",
-          oauthEndpoint + "oauth/token",
+          this.endpointUrl + "oauth/authorize",
+          this.endpointUrl + "oauth/token",
           new MemoryDataStoreFactory());
     }
   }
@@ -90,5 +91,10 @@ public class OpenShiftOAuthAuthenticator extends OAuthAuthenticator {
       return token;
     }
     return null;
+  }
+
+  @Override
+  public String getEndpointUrl() {
+    return endpointUrl;
   }
 }

--- a/wsmaster/che-core-api-auth-shared/src/main/java/org/eclipse/che/security/oauth/shared/dto/OAuthAuthenticatorDescriptor.java
+++ b/wsmaster/che-core-api-auth-shared/src/main/java/org/eclipse/che/security/oauth/shared/dto/OAuthAuthenticatorDescriptor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012-2018 Red Hat, Inc.
+ * Copyright (c) 2012-2022 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/
@@ -24,6 +24,12 @@ public interface OAuthAuthenticatorDescriptor {
   void setName(String name);
 
   OAuthAuthenticatorDescriptor withName(String name);
+
+  String getEndpointUrl();
+
+  void setEndpointUrl(String endpointUrl);
+
+  OAuthAuthenticatorDescriptor withEndpointUrl(String endpointUrl);
 
   List<Link> getLinks();
 

--- a/wsmaster/che-core-api-auth/pom.xml
+++ b/wsmaster/che-core-api-auth/pom.xml
@@ -61,6 +61,10 @@
         </dependency>
         <dependency>
             <groupId>org.eclipse.che.core</groupId>
+            <artifactId>che-core-api-factory</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.che.core</groupId>
             <artifactId>che-core-commons-annotations</artifactId>
         </dependency>
         <dependency>

--- a/wsmaster/che-core-api-auth/src/main/java/org/eclipse/che/security/oauth/EmbeddedOAuthAPI.java
+++ b/wsmaster/che-core-api-auth/src/main/java/org/eclipse/che/security/oauth/EmbeddedOAuthAPI.java
@@ -127,7 +127,12 @@ public class EmbeddedOAuthAPI implements OAuthAPI {
                   .withName("mode")
                   .withRequired(true)
                   .withDefaultValue("federated_login")));
-      result.add(newDto(OAuthAuthenticatorDescriptor.class).withName(name).withLinks(links));
+      OAuthAuthenticator authenticator = providers.getAuthenticator(name);
+      result.add(
+          newDto(OAuthAuthenticatorDescriptor.class)
+              .withName(name)
+              .withEndpointUrl(authenticator.getEndpointUrl())
+              .withLinks(links));
     }
     return result;
   }

--- a/wsmaster/che-core-api-auth/src/main/java/org/eclipse/che/security/oauth/OAuthAuthenticator.java
+++ b/wsmaster/che-core-api-auth/src/main/java/org/eclipse/che/security/oauth/OAuthAuthenticator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012-2021 Red Hat, Inc.
+ * Copyright (c) 2012-2022 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/
@@ -315,7 +315,7 @@ public abstract class OAuthAuthenticator {
         // if token is not refreshed then old value should be invalidated
         // and null result should be returned
         try {
-          invalidateToken(userId);
+          invalidateTokenByUser(userId);
         } catch (IOException ignored) {
         }
         return null;
@@ -328,17 +328,31 @@ public abstract class OAuthAuthenticator {
    * Invalidate OAuth token for specified user.
    *
    * @param userId user
-   * @return <code>true</code> if OAuth token invalidated and <code>false</code> otherwise, e.g. if
-   *     user does not have token yet
    */
-  public boolean invalidateToken(String userId) throws IOException {
+  private void invalidateTokenByUser(String userId) throws IOException {
     Credential credential = flow.loadCredential(userId);
     if (credential != null) {
       flow.getCredentialDataStore().delete(userId);
-      return true;
     }
-    return false;
   }
+
+  /**
+   * Invalidate OAuth token.
+   *
+   * @param token oauth token
+   * @return <code>true</code> if OAuth token invalidated and <code>false</code> otherwise, e.g. if
+   *     token was not found
+   */
+  public boolean invalidateToken(String token) throws IOException {
+    throw new UnsupportedOperationException("Should be implemented by specific provider");
+  }
+
+  /**
+   * Get endpoint URL.
+   *
+   * @return provider's endpoint URL
+   */
+  public abstract String getEndpointUrl();
 
   /**
    * Checks configuring of authenticator


### PR DESCRIPTION
Signed-off-by: Igor Vinokur <ivinokur@redhat.com>

<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests
-->

### What does this PR do?
Rework the invalidate token oauth API method to send revoke token request to the git provider. After this request Che authorisation is unsynchronised so user is asked to re apply the authentication on new factory create step.

### Screenshot/screencast of this PR
<!-- Please include a screenshot or a screencast explaining what is doing this PR -->


### What issues does this PR fix or reference?
<!-- Please include any related issue from eclipse che repository (or from another issue tracker).
     Include link to other pull requests like documentation PR from [the docs repo](https://github.com/eclipse/che-docs)
-->
fixes https://github.com/eclipse/che/issues/21890

### How to test this PR?
<!-- Please explain for example :
  - The test platform (openshift, kubernetes, minikube, CodeReady Container, docker-desktop, etc)
  - Installation method: chectl / che-operator
  - steps to reproduce
 -->
1. Deploy Che with `quay.io/ivinokur/che-server:next` image.
2. Apply [GitHub oAuth flow](https://www.eclipse.org/che/docs/stable/administration-guide/configuring-oauth-2-for-github/).
3. Start a factory from a GitHub repo: authorisation request is shown.
4. Go to <che-url>/swagger and find the **DELETE** `/oauth/token` method.
5. Input `github` and click `Execute`.
6. Delete current workspace and start a new factory from the GitHub repo.
See: authorisation page is shown.
 


### PR Checklist

[As the author of this Pull Request I made sure that:](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#pull-request-template-and-its-checklist)

- [x] [The Eclipse Contributor Agreement is valid](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-eclipse-contributor-agreement-is-valid)
- [x] [Code produced is complete](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-produced-is-complete)
- [x] [Code builds without errors](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-builds-without-errors)
- [x] [Tests are covering the bugfix](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#tests-are-covering-the-bugfix)
- [ ] [The repository devfile is up to date and works](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-repository-devfile-is-up-to-date-and-works)
- [x] [Sections `What issues does this PR fix or reference` and `How to test this PR` completed](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#sections-what-issues-does-this-pr-fix-or-reference-and-how-to-test-this-pr-completed)
- [ ] [Relevant user documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [Relevant contributing documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [CI/CD changes implemented, documented and communicated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#cicd-changes-implemented-documented-and-communicated)

### Reviewers

Reviewers, please comment how you tested the PR when approving it.
