### PR TITLE
fix: Simplification of the 'canCreateNamespace' logic

### DIFF
--- a/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/namespace/KubernetesNamespaceFactory.java
+++ b/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/namespace/KubernetesNamespaceFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012-2022 Red Hat, Inc.
+ * Copyright (c) 2012-2023 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/
@@ -265,33 +265,11 @@ public class KubernetesNamespaceFactory {
    * Tells the caller whether the namespace that is being prepared for the provided workspace
    * runtime identity can be created or is expected to already be present.
    *
-   * <p>Note that this method cannot be reduced to merely checking if user-defined namespaces are
-   * allowed or not (and depending on prior validation using the {@link
-   * #checkIfNamespaceIsAllowed(String)} method during the workspace creation) because workspace
-   * start is a) async from workspace creation and the underlying namespaces might have disappeared
-   * and b) can be called during workspace recovery, where we don't even have the current user in
-   * the context.
-   *
-   * @param identity the identity of the workspace runtime
-   * @param userName the user name
    * @return true if the namespace can be created, false if the namespace is expected to already
    *     exist
-   * @throws InfrastructureException on failure
    */
-  protected boolean canCreateNamespace(RuntimeIdentity identity, String userName)
-      throws InfrastructureException {
-    if (!namespaceCreationAllowed) {
-      return false;
-    }
-
-    String requiredNamespace = identity.getInfrastructureNamespace();
-
-    NamespaceResolutionContext resolutionContext =
-        new NamespaceResolutionContext(identity.getWorkspaceId(), identity.getOwnerId(), userName);
-
-    String resolvedDefaultNamespace = evaluateNamespaceName(resolutionContext);
-
-    return resolvedDefaultNamespace.equals(requiredNamespace);
+  protected boolean canCreateNamespace() {
+    return namespaceCreationAllowed;
   }
 
   /**
@@ -316,7 +294,7 @@ public class KubernetesNamespaceFactory {
         evaluateAnnotationPlaceholders(resolutionCtx);
 
     namespace.prepare(
-        canCreateNamespace(identity, userName),
+        canCreateNamespace(),
         labelNamespaces ? namespaceLabels : emptyMap(),
         annotateNamespaces ? namespaceAnnotationsEvaluated : emptyMap());
 

--- a/infrastructures/kubernetes/src/test/java/org/eclipse/che/workspace/infrastructure/kubernetes/namespace/KubernetesNamespaceFactoryTest.java
+++ b/infrastructures/kubernetes/src/test/java/org/eclipse/che/workspace/infrastructure/kubernetes/namespace/KubernetesNamespaceFactoryTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012-2021 Red Hat, Inc.
+ * Copyright (c) 2012-2023 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/
@@ -505,8 +505,6 @@ public class KubernetesNamespaceFactoryTest {
     when(k8sClient.secrets()).thenReturn(mixedOperation);
     when(mixedOperation.inNamespace(anyString())).thenReturn(namespaceOperation);
     when(namespaceResource.get()).thenReturn(null);
-    when(cheClientFactory.create()).thenReturn(k8sClient);
-    when(clientFactory.create()).thenReturn(k8sClient);
 
     // when
     RuntimeIdentity identity =
@@ -753,7 +751,7 @@ public class KubernetesNamespaceFactoryTest {
 
     // then
     assertEquals(toReturnNamespace, namespace);
-    verify(toReturnNamespace).prepare(eq(false), any(), any());
+    verify(toReturnNamespace).prepare(eq(true), any(), any());
   }
 
   @Test
@@ -853,7 +851,6 @@ public class KubernetesNamespaceFactoryTest {
     when(toReturnNamespace.getName()).thenReturn("workspace123");
     doReturn(toReturnNamespace).when(namespaceFactory).doCreateNamespaceAccess(any(), any());
     when(k8sClient.supportsApiPath(eq("/apis/metrics.k8s.io"))).thenReturn(true);
-    when(cheClientFactory.create()).thenReturn(k8sClient);
     when(clientFactory.create(any())).thenReturn(k8sClient);
 
     // pre-create the cluster roles
@@ -930,7 +927,6 @@ public class KubernetesNamespaceFactoryTest {
     when(toReturnNamespace.getName()).thenReturn("workspace123");
     doReturn(toReturnNamespace).when(namespaceFactory).doCreateNamespaceAccess(any(), any());
     when(clientFactory.create(any())).thenReturn(k8sClient);
-    when(cheClientFactory.create()).thenReturn(k8sClient);
 
     // when
     RuntimeIdentity identity =
@@ -978,7 +974,6 @@ public class KubernetesNamespaceFactoryTest {
     doReturn(toReturnNamespace).when(namespaceFactory).doCreateNamespaceAccess(any(), any());
     when(k8sClient.supportsApiPath(eq("/apis/metrics.k8s.io"))).thenReturn(true);
     when(clientFactory.create(any())).thenReturn(k8sClient);
-    when(cheClientFactory.create()).thenReturn(k8sClient);
 
     // when
     RuntimeIdentity identity =
@@ -1452,7 +1447,7 @@ public class KubernetesNamespaceFactoryTest {
     // then
     assertEquals(toReturnNamespace, namespace);
     verify(toReturnNamespace)
-        .prepare(eq(false), any(), eq(Map.of("try_placeholder_here", "jondoe")));
+        .prepare(eq(true), any(), eq(Map.of("try_placeholder_here", "jondoe")));
   }
 
   @Test(dataProvider = "invalidUsernames")

--- a/infrastructures/openshift/src/main/java/org/eclipse/che/workspace/infrastructure/openshift/project/OpenShiftProjectFactory.java
+++ b/infrastructures/openshift/src/main/java/org/eclipse/che/workspace/infrastructure/openshift/project/OpenShiftProjectFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012-2022 Red Hat, Inc.
+ * Copyright (c) 2012-2023 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/
@@ -104,7 +104,6 @@ public class OpenShiftProjectFactory extends KubernetesNamespaceFactory {
 
   public OpenShiftProject getOrCreate(RuntimeIdentity identity) throws InfrastructureException {
     OpenShiftProject osProject = get(identity);
-
     var subject = EnvironmentContext.getCurrent().getSubject();
     var userName = subject.getUserName();
     NamespaceResolutionContext resolutionCtx =
@@ -113,7 +112,7 @@ public class OpenShiftProjectFactory extends KubernetesNamespaceFactory {
         evaluateAnnotationPlaceholders(resolutionCtx);
 
     osProject.prepare(
-        canCreateNamespace(identity, userName),
+        canCreateNamespace(),
         initWithCheServerSa && !isNullOrEmpty(oAuthIdentityProvider),
         labelNamespaces ? namespaceLabels : emptyMap(),
         annotateNamespaces ? namespaceAnnotationsEvaluated : emptyMap());

--- a/infrastructures/openshift/src/test/java/org/eclipse/che/workspace/infrastructure/openshift/project/OpenShiftProjectFactoryTest.java
+++ b/infrastructures/openshift/src/test/java/org/eclipse/che/workspace/infrastructure/openshift/project/OpenShiftProjectFactoryTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012-2021 Red Hat, Inc.
+ * Copyright (c) 2012-2023 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/
@@ -535,7 +535,7 @@ public class OpenShiftProjectFactoryTest {
 
     // then
     assertEquals(toReturnProject, project);
-    verify(toReturnProject).prepare(eq(false), eq(false), any(), any());
+    verify(toReturnProject).prepare(eq(true), eq(false), any(), any());
   }
 
   @Test
@@ -854,7 +854,7 @@ public class OpenShiftProjectFactoryTest {
     // then
     assertEquals(toReturnProject, project);
     verify(toReturnProject)
-        .prepare(eq(false), eq(false), any(), eq(Map.of("try_placeholder_here", "jondoe")));
+        .prepare(eq(true), eq(false), any(), eq(Map.of("try_placeholder_here", "jondoe")));
   }
 
   @Test


### PR DESCRIPTION
### What does this PR do?
Simplification of the 'canCreateNamespace' logic, checking only single property `namespaceCreationAllowed` as part of the method.

### Screenshot/screencast of this PR
`canCreateNamespace` has a pretty sophisticated logic. Since we do not store any relevant data in the db anymore (see https://github.com/eclipse-che/che-server/pull/398 for additional details) this resulted in the bug when the username contains special characters and can not be used as-is as a placeholder for k8s namespace / OpenShift project.

![image](https://user-images.githubusercontent.com/1461122/216041052-28dcb2df-5296-4d09-af85-2f4c46fc6ea9.png)

However, at this point, we probably do not need at all such checks since those were relevant only when workspaces were created and managed by che-server

### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/21958

NOTE: should be also backported to 7.60.x for Eclipse Che 7.60.1 and Dev Spaces 3.5

### How to test this PR?
image `quay.io/ibuziuk/che-server:che-21958`

```
spec:
  components:
    cheServer:
      debug: true
      logLevel: INFO
      deployment:
        containers:
          - image: 'quay.io/ibuziuk/che-server:che-21958'
            name: che
```

### PR Checklist

[As the author of this Pull Request I made sure that:](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#pull-request-template-and-its-checklist)

- [ ] [The Eclipse Contributor Agreement is valid](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-eclipse-contributor-agreement-is-valid)
- [ ] [Code produced is complete](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-produced-is-complete)
- [ ] [Code builds without errors](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-builds-without-errors)
- [ ] [Tests are covering the bugfix](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#tests-are-covering-the-bugfix)
- [ ] [The repository devfile is up to date and works](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-repository-devfile-is-up-to-date-and-works)
- [ ] [Sections `What issues does this PR fix or reference` and `How to test this PR` completed](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#sections-what-issues-does-this-pr-fix-or-reference-and-how-to-test-this-pr-completed)
- [ ] [Relevant user documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [Relevant contributing documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [CI/CD changes implemented, documented and communicated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#cicd-changes-implemented-documented-and-communicated)

### Reviewers

Reviewers, please comment how you tested the PR when approving it.
