### PR TITLE
Support Bitbucket-server oAuth2 factory

### DIFF
--- a/assembly/assembly-wsmaster-war/src/main/java/org/eclipse/che/api/deploy/WsMasterModule.java
+++ b/assembly/assembly-wsmaster-war/src/main/java/org/eclipse/che/api/deploy/WsMasterModule.java
@@ -395,7 +395,7 @@ public class WsMasterModule extends AbstractModule {
       }
       bind(TokenValidator.class).to(NotImplementedTokenValidator.class);
       bind(ProfileDao.class).to(JpaProfileDao.class);
-      bind(OAuthAPI.class).to(EmbeddedOAuthAPI.class);
+      bind(OAuthAPI.class).to(EmbeddedOAuthAPI.class).asEagerSingleton();
     }
 
     bind(AdminPermissionInitializer.class).asEagerSingleton();

--- a/assembly/assembly-wsmaster-war/src/main/webapp/WEB-INF/classes/che/che.properties
+++ b/assembly/assembly-wsmaster-war/src/main/webapp/WEB-INF/classes/che/che.properties
@@ -155,7 +155,7 @@ che.oauth1.bitbucket.consumerkeypath=NULL
 che.oauth1.bitbucket.privatekeypath=NULL
 # Bitbucket Server URL. To work correctly with factories, the same URL
 # has to be part of `che.integration.bitbucket.server_endpoints` too.
-che.oauth1.bitbucket.endpoint=NULL
+che.oauth.bitbucket.endpoint=https://bitbucket.org
 
 # Configuration of Bitbucket OAuth2 client. Used to obtain Personal access tokens.
 # Location of the file with Bitbucket client id.
@@ -172,7 +172,7 @@ che.oauth.bitbucket.tokenuri= https://bitbucket.org/site/oauth2/access_token
 
 # Bitbucket OAuth redirect URIs.
 # Separate multiple values with comma, for example: URI,URI,URI
-che.oauth.bitbucket.redirecturis= http://localhost:${CHE_PORT}/api/oauth/callback
+che.oauth.bitbucket.redirecturis= https://${CHE_HOST}/api/oauth/callback
 
 ### Internal
 

--- a/wsmaster/che-core-api-auth-bitbucket/pom.xml
+++ b/wsmaster/che-core-api-auth-bitbucket/pom.xml
@@ -36,6 +36,10 @@
             <artifactId>guice</artifactId>
         </dependency>
         <dependency>
+            <groupId>com.google.oauth-client</groupId>
+            <artifactId>google-oauth-client</artifactId>
+        </dependency>
+        <dependency>
             <groupId>jakarta.inject</groupId>
             <artifactId>jakarta.inject-api</artifactId>
         </dependency>
@@ -53,7 +57,7 @@
         </dependency>
         <dependency>
             <groupId>org.eclipse.che.core</groupId>
-            <artifactId>che-core-commons-json</artifactId>
+            <artifactId>che-core-commons-lang</artifactId>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/wsmaster/che-core-api-auth-bitbucket/src/main/java/org/eclipse/che/security/oauth/BitbucketOAuthAuthenticator.java
+++ b/wsmaster/che-core-api-auth-bitbucket/src/main/java/org/eclipse/che/security/oauth/BitbucketOAuthAuthenticator.java
@@ -69,6 +69,11 @@ public class BitbucketOAuthAuthenticator extends OAuthAuthenticator {
     return token;
   }
 
+  /**
+   * Generate an API request URL, to use for a token validation.
+   *
+   * @return Bitbucket Cloud or Server API request URL
+   */
   private String getTestRequestUrl() {
     return bitbucketEndpoint.equals("https://bitbucket.org")
         ? "https://api.bitbucket.org/2.0/user"

--- a/wsmaster/che-core-api-auth-bitbucket/src/main/java/org/eclipse/che/security/oauth/BitbucketOAuthAuthenticator.java
+++ b/wsmaster/che-core-api-auth-bitbucket/src/main/java/org/eclipse/che/security/oauth/BitbucketOAuthAuthenticator.java
@@ -26,7 +26,6 @@ import org.eclipse.che.api.auth.shared.dto.OAuthToken;
 /** OAuth authentication for BitBucket SAAS account. */
 @Singleton
 public class BitbucketOAuthAuthenticator extends OAuthAuthenticator {
-  private final String testRequestUrl;
   private final String bitbucketEndpoint;
 
   public BitbucketOAuthAuthenticator(
@@ -38,10 +37,6 @@ public class BitbucketOAuthAuthenticator extends OAuthAuthenticator {
       String tokenUri)
       throws IOException {
     this.bitbucketEndpoint = bitbucketEndpoint;
-    testRequestUrl =
-        bitbucketEndpoint.equals("https://bitbucket.org")
-            ? "https://api.bitbucket.org/2.0/user"
-            : bitbucketEndpoint + "/rest/api/1.0/application-properties";
     configure(
         clientId, clientSecret, redirectUris, authUri, tokenUri, new MemoryDataStoreFactory());
   }
@@ -67,11 +62,17 @@ public class BitbucketOAuthAuthenticator extends OAuthAuthenticator {
       if (token == null || isNullOrEmpty(token.getToken())) {
         return null;
       }
-      testRequest(testRequestUrl, token.getToken());
+      testRequest(getTestRequestUrl(), token.getToken());
     } catch (OAuthAuthenticationException e) {
       return null;
     }
     return token;
+  }
+
+  private String getTestRequestUrl() {
+    return bitbucketEndpoint.equals("https://bitbucket.org")
+        ? "https://api.bitbucket.org/2.0/user"
+        : bitbucketEndpoint + "/rest/api/1.0/application-properties";
   }
 
   @Override

--- a/wsmaster/che-core-api-auth-bitbucket/src/main/java/org/eclipse/che/security/oauth/BitbucketOAuthAuthenticator.java
+++ b/wsmaster/che-core-api-auth-bitbucket/src/main/java/org/eclipse/che/security/oauth/BitbucketOAuthAuthenticator.java
@@ -75,7 +75,7 @@ public class BitbucketOAuthAuthenticator extends OAuthAuthenticator {
    * @return Bitbucket Cloud or Server API request URL
    */
   private String getTestRequestUrl() {
-    return bitbucketEndpoint.equals("https://bitbucket.org")
+    return "https://bitbucket.org".equals(bitbucketEndpoint)
         ? "https://api.bitbucket.org/2.0/user"
         : bitbucketEndpoint + "/rest/api/1.0/application-properties";
   }

--- a/wsmaster/che-core-api-auth-bitbucket/src/main/java/org/eclipse/che/security/oauth/BitbucketOAuthAuthenticatorProvider.java
+++ b/wsmaster/che-core-api-auth-bitbucket/src/main/java/org/eclipse/che/security/oauth/BitbucketOAuthAuthenticatorProvider.java
@@ -77,14 +77,9 @@ public class BitbucketOAuthAuthenticatorProvider implements Provider<OAuthAuthen
         && Objects.nonNull(redirectUris)
         && redirectUris.length != 0) {
       String trimmedOauthEndpoint = trimEnd(oauthEndpoint, '/');
-      authUri =
-          trimmedOauthEndpoint.equals("https://bitbucket.org")
-              ? authUri
-              : trimmedOauthEndpoint + "/rest/oauth2/1.0/authorize";
-      tokenUri =
-          trimmedOauthEndpoint.equals("https://bitbucket.org")
-              ? tokenUri
-              : trimmedOauthEndpoint + "/rest/oauth2/1.0/token";
+      boolean isBitbucketCloud = trimmedOauthEndpoint.equals("https://bitbucket.org");
+      authUri = isBitbucketCloud ? authUri : trimmedOauthEndpoint + "/rest/oauth2/1.0/authorize";
+      tokenUri = isBitbucketCloud ? tokenUri : trimmedOauthEndpoint + "/rest/oauth2/1.0/token";
       final String clientId = Files.readString(Path.of(clientIdPath)).trim();
       final String clientSecret = Files.readString(Path.of(clientSecretPath)).trim();
       if (!isNullOrEmpty(clientId) && !isNullOrEmpty(clientSecret)) {

--- a/wsmaster/che-core-api-auth-bitbucket/src/main/java/org/eclipse/che/security/oauth1/BitbucketServerOAuthAuthenticatorProvider.java
+++ b/wsmaster/che-core-api-auth-bitbucket/src/main/java/org/eclipse/che/security/oauth1/BitbucketServerOAuthAuthenticatorProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012-2021 Red Hat, Inc.
+ * Copyright (c) 2012-2023 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/
@@ -35,7 +35,7 @@ public class BitbucketServerOAuthAuthenticatorProvider implements Provider<OAuth
   public BitbucketServerOAuthAuthenticatorProvider(
       @Nullable @Named("che.oauth1.bitbucket.consumerkeypath") String consumerKeyPath,
       @Nullable @Named("che.oauth1.bitbucket.privatekeypath") String privateKeyPath,
-      @Nullable @Named("che.oauth1.bitbucket.endpoint") String bitbucketEndpoint,
+      @Nullable @Named("che.oauth.bitbucket.endpoint") String bitbucketEndpoint,
       @Named("che.api") String apiEndpoint)
       throws IOException {
     authenticator =

--- a/wsmaster/che-core-api-auth-github/pom.xml
+++ b/wsmaster/che-core-api-auth-github/pom.xml
@@ -36,10 +36,6 @@
             <artifactId>guice</artifactId>
         </dependency>
         <dependency>
-            <groupId>com.sun.mail</groupId>
-            <artifactId>jakarta.mail</artifactId>
-        </dependency>
-        <dependency>
             <groupId>jakarta.inject</groupId>
             <artifactId>jakarta.inject-api</artifactId>
         </dependency>

--- a/wsmaster/che-core-api-auth-github/src/main/java/org/eclipse/che/security/oauth/GitHubOAuthAuthenticator.java
+++ b/wsmaster/che-core-api-auth-github/src/main/java/org/eclipse/che/security/oauth/GitHubOAuthAuthenticator.java
@@ -15,8 +15,6 @@ import static com.google.common.base.Strings.isNullOrEmpty;
 import static org.eclipse.che.commons.lang.StringUtils.trimEnd;
 
 import com.google.api.client.util.store.MemoryDataStoreFactory;
-import jakarta.mail.internet.AddressException;
-import jakarta.mail.internet.InternetAddress;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.net.HttpURLConnection;
@@ -24,7 +22,6 @@ import java.net.URL;
 import java.util.Base64;
 import javax.inject.Singleton;
 import org.eclipse.che.api.auth.shared.dto.OAuthToken;
-import org.eclipse.che.security.oauth.shared.User;
 
 /** OAuth authentication for github account. */
 @Singleton
@@ -51,24 +48,6 @@ public class GitHubOAuthAuthenticator extends OAuthAuthenticator {
             : providerUrl + "/api/v3";
     configure(
         clientId, clientSecret, redirectUris, authUri, tokenUri, new MemoryDataStoreFactory());
-  }
-
-  @Override
-  public User getUser(OAuthToken accessToken) throws OAuthAuthenticationException {
-    GitHubUser user = getJson(githubApiUrl + "/user", accessToken.getToken(), GitHubUser.class);
-    final String email = user.getEmail();
-
-    if (isNullOrEmpty(email)) {
-      throw new OAuthAuthenticationException(
-          "Sorry, we failed to find any verified emails associated with your GitHub account."
-              + " Please, verify at least one email in your GitHub account and try to connect with GitHub again.");
-    }
-    try {
-      new InternetAddress(email).validate();
-    } catch (AddressException e) {
-      throw new OAuthAuthenticationException(e.getMessage());
-    }
-    return user;
   }
 
   @Override

--- a/wsmaster/che-core-api-auth-github/src/main/java/org/eclipse/che/security/oauth/GitHubOAuthAuthenticatorProvider.java
+++ b/wsmaster/che-core-api-auth-github/src/main/java/org/eclipse/che/security/oauth/GitHubOAuthAuthenticatorProvider.java
@@ -22,9 +22,7 @@ import javax.inject.Inject;
 import javax.inject.Named;
 import javax.inject.Provider;
 import javax.inject.Singleton;
-import org.eclipse.che.api.auth.shared.dto.OAuthToken;
 import org.eclipse.che.commons.annotation.Nullable;
-import org.eclipse.che.security.oauth.shared.User;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -98,12 +96,6 @@ public class GitHubOAuthAuthenticatorProvider implements Provider<OAuthAuthentic
   }
 
   static class NoopOAuthAuthenticator extends OAuthAuthenticator {
-    @Override
-    public User getUser(OAuthToken accessToken) throws OAuthAuthenticationException {
-      throw new OAuthAuthenticationException(
-          "The fallback noop authenticator cannot be used for GitHub authentication. Make sure OAuth is properly configured.");
-    }
-
     @Override
     public String getOAuthProvider() {
       return "Noop";

--- a/wsmaster/che-core-api-auth-gitlab/pom.xml
+++ b/wsmaster/che-core-api-auth-gitlab/pom.xml
@@ -36,10 +36,6 @@
             <artifactId>guice</artifactId>
         </dependency>
         <dependency>
-            <groupId>com.sun.mail</groupId>
-            <artifactId>jakarta.mail</artifactId>
-        </dependency>
-        <dependency>
             <groupId>jakarta.inject</groupId>
             <artifactId>jakarta.inject-api</artifactId>
         </dependency>

--- a/wsmaster/che-core-api-auth-gitlab/src/main/java/org/eclipse/che/security/oauth/GitLabOAuthAuthenticator.java
+++ b/wsmaster/che-core-api-auth-gitlab/src/main/java/org/eclipse/che/security/oauth/GitLabOAuthAuthenticator.java
@@ -11,12 +11,9 @@
  */
 package org.eclipse.che.security.oauth;
 
-import static com.google.common.base.Strings.isNullOrEmpty;
 import static org.eclipse.che.commons.lang.StringUtils.trimEnd;
 
 import com.google.api.client.util.store.MemoryDataStoreFactory;
-import jakarta.mail.internet.AddressException;
-import jakarta.mail.internet.InternetAddress;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.URI;
@@ -28,7 +25,6 @@ import javax.inject.Singleton;
 import org.eclipse.che.api.auth.shared.dto.OAuthToken;
 import org.eclipse.che.commons.json.JsonHelper;
 import org.eclipse.che.commons.json.JsonParseException;
-import org.eclipse.che.security.oauth.shared.User;
 
 /**
  * OAuth2 authenticator for GitLab account.
@@ -55,24 +51,6 @@ public class GitLabOAuthAuthenticator extends OAuthAuthenticator {
         trimmedGitlabEndpoint + "/oauth/authorize",
         trimmedGitlabEndpoint + "/oauth/token",
         new MemoryDataStoreFactory());
-  }
-
-  @Override
-  public User getUser(OAuthToken accessToken) throws OAuthAuthenticationException {
-    GitLabUser user = getJson(gitlabUserEndpoint, accessToken.getToken(), GitLabUser.class);
-    final String email = user.getEmail();
-
-    if (isNullOrEmpty(email)) {
-      throw new OAuthAuthenticationException(
-          "Sorry, we failed to find any verified email associated with your GitLab account."
-              + " Please, verify at least one email in your account and try to connect with GitLab again.");
-    }
-    try {
-      new InternetAddress(email).validate();
-    } catch (AddressException e) {
-      throw new OAuthAuthenticationException(e.getMessage());
-    }
-    return user;
   }
 
   @Override

--- a/wsmaster/che-core-api-auth-gitlab/src/main/java/org/eclipse/che/security/oauth/GitLabOAuthAuthenticatorProvider.java
+++ b/wsmaster/che-core-api-auth-gitlab/src/main/java/org/eclipse/che/security/oauth/GitLabOAuthAuthenticatorProvider.java
@@ -20,9 +20,7 @@ import javax.inject.Inject;
 import javax.inject.Named;
 import javax.inject.Provider;
 import javax.inject.Singleton;
-import org.eclipse.che.api.auth.shared.dto.OAuthToken;
 import org.eclipse.che.commons.annotation.Nullable;
-import org.eclipse.che.security.oauth.shared.User;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -69,11 +67,6 @@ public class GitLabOAuthAuthenticatorProvider implements Provider<OAuthAuthentic
   }
 
   static class NoopOAuthAuthenticator extends OAuthAuthenticator {
-    @Override
-    public User getUser(OAuthToken accessToken) throws OAuthAuthenticationException {
-      throw new OAuthAuthenticationException(
-          "The fallback noop authenticator cannot be used for GitLab authentication. Make sure OAuth is properly configured.");
-    }
 
     @Override
     public String getOAuthProvider() {

--- a/wsmaster/che-core-api-auth-openshift/src/main/java/org/eclipse/che/security/oauth/OpenShiftOAuthAuthenticator.java
+++ b/wsmaster/che-core-api-auth-openshift/src/main/java/org/eclipse/che/security/oauth/OpenShiftOAuthAuthenticator.java
@@ -23,7 +23,6 @@ import javax.inject.Named;
 import javax.inject.Singleton;
 import org.eclipse.che.api.auth.shared.dto.OAuthToken;
 import org.eclipse.che.commons.annotation.Nullable;
-import org.eclipse.che.security.oauth.shared.User;
 
 /**
  * OAuth authentication for OpenShift.
@@ -56,11 +55,6 @@ public class OpenShiftOAuthAuthenticator extends OAuthAuthenticator {
           oauthEndpoint + "oauth/token",
           new MemoryDataStoreFactory());
     }
-  }
-
-  @Override
-  public User getUser(OAuthToken accessToken) throws OAuthAuthenticationException {
-    throw new OAuthAuthenticationException("not supported");
   }
 
   @Override

--- a/wsmaster/che-core-api-auth/src/main/java/org/eclipse/che/security/oauth/OAuthAuthenticator.java
+++ b/wsmaster/che-core-api-auth/src/main/java/org/eclipse/che/security/oauth/OAuthAuthenticator.java
@@ -42,7 +42,6 @@ import org.eclipse.che.commons.env.EnvironmentContext;
 import org.eclipse.che.commons.json.JsonHelper;
 import org.eclipse.che.commons.json.JsonParseException;
 import org.eclipse.che.security.oauth.shared.OAuthTokenProvider;
-import org.eclipse.che.security.oauth.shared.User;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -222,15 +221,6 @@ public abstract class OAuthAuthenticator {
       throw new OAuthAuthenticationException(ioe.getMessage());
     }
   }
-
-  /**
-   * Get user info.
-   *
-   * @param accessToken oauth access token
-   * @return user info
-   * @throws OAuthAuthenticationException if fail to get user info
-   */
-  public abstract User getUser(OAuthToken accessToken) throws OAuthAuthenticationException;
 
   /**
    * Get the name of OAuth provider supported by current implementation.

--- a/wsmaster/che-core-api-factory-bitbucket-server/pom.xml
+++ b/wsmaster/che-core-api-factory-bitbucket-server/pom.xml
@@ -68,6 +68,10 @@
         </dependency>
         <dependency>
             <groupId>org.eclipse.che.core</groupId>
+            <artifactId>che-core-api-auth-shared</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.che.core</groupId>
             <artifactId>che-core-api-core</artifactId>
         </dependency>
         <dependency>
@@ -118,6 +122,11 @@
         <dependency>
             <groupId>com.github.tomakehurst</groupId>
             <artifactId>wiremock-jre8-standalone</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>jakarta.servlet</groupId>
+            <artifactId>jakarta.servlet-api</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/wsmaster/che-core-api-factory-bitbucket-server/src/main/java/org/eclipse/che/api/factory/server/bitbucket/BitbucketServerApiProvider.java
+++ b/wsmaster/che-core-api-factory-bitbucket-server/src/main/java/org/eclipse/che/api/factory/server/bitbucket/BitbucketServerApiProvider.java
@@ -64,14 +64,14 @@ public class BitbucketServerApiProvider implements Provider<BitbucketServerApiCl
       String rawBitbucketEndpoints,
       String bitbucketOauthEndpoint,
       Set<OAuthAuthenticator> authenticators) {
-    boolean isCloudEndpoint = bitbucketOauthEndpoint.equals("https://bitbucket.org");
-    if (isCloudEndpoint && isNullOrEmpty(rawBitbucketEndpoints)) {
+    boolean isBitbucketCloud = bitbucketOauthEndpoint.equals("https://bitbucket.org");
+    if (isBitbucketCloud && isNullOrEmpty(rawBitbucketEndpoints)) {
       return new NoopBitbucketServerApiClient();
-    } else if (!isCloudEndpoint && isNullOrEmpty(rawBitbucketEndpoints)) {
+    } else if (!isBitbucketCloud && isNullOrEmpty(rawBitbucketEndpoints)) {
       throw new ConfigurationException(
           "`che.integration.bitbucket.server_endpoints` bitbucket configuration is missing."
               + " It should contain values from 'che.oauth.bitbucket.endpoint'");
-    } else if (isCloudEndpoint && !isNullOrEmpty(rawBitbucketEndpoints)) {
+    } else if (isBitbucketCloud && !isNullOrEmpty(rawBitbucketEndpoints)) {
       return new HttpBitbucketServerApiClient(
           sanitizedEndpoints(rawBitbucketEndpoints).get(0),
           new NoopOAuthAuthenticator(),

--- a/wsmaster/che-core-api-factory-bitbucket-server/src/main/java/org/eclipse/che/api/factory/server/bitbucket/BitbucketServerModule.java
+++ b/wsmaster/che-core-api-factory-bitbucket-server/src/main/java/org/eclipse/che/api/factory/server/bitbucket/BitbucketServerModule.java
@@ -16,7 +16,6 @@ import com.google.inject.multibindings.Multibinder;
 import org.eclipse.che.api.factory.server.bitbucket.server.BitbucketServerApiClient;
 import org.eclipse.che.api.factory.server.scm.GitUserDataFetcher;
 import org.eclipse.che.api.factory.server.scm.PersonalAccessTokenFetcher;
-import org.eclipse.che.security.oauth1.BitbucketServerApiProvider;
 
 public class BitbucketServerModule extends AbstractModule {
   @Override

--- a/wsmaster/che-core-api-factory-bitbucket-server/src/main/java/org/eclipse/che/api/factory/server/bitbucket/BitbucketServerURLParser.java
+++ b/wsmaster/che-core-api-factory-bitbucket-server/src/main/java/org/eclipse/che/api/factory/server/bitbucket/BitbucketServerURLParser.java
@@ -24,7 +24,6 @@ import java.util.regex.Pattern;
 import javax.inject.Inject;
 import javax.inject.Named;
 import javax.inject.Singleton;
-import org.eclipse.che.api.factory.server.bitbucket.server.HttpBitbucketServerApiClient;
 import org.eclipse.che.api.factory.server.scm.PersonalAccessToken;
 import org.eclipse.che.api.factory.server.scm.PersonalAccessTokenManager;
 import org.eclipse.che.api.factory.server.scm.exception.ScmCommunicationException;
@@ -35,6 +34,7 @@ import org.eclipse.che.api.factory.server.urlfactory.DevfileFilenamesProvider;
 import org.eclipse.che.commons.annotation.Nullable;
 import org.eclipse.che.commons.env.EnvironmentContext;
 import org.eclipse.che.commons.lang.StringUtils;
+import org.eclipse.che.security.oauth.OAuthAPI;
 import org.eclipse.che.security.oauth1.BitbucketServerOAuthAuthenticator;
 
 /**
@@ -46,6 +46,7 @@ import org.eclipse.che.security.oauth1.BitbucketServerOAuthAuthenticator;
 public class BitbucketServerURLParser {
 
   private final DevfileFilenamesProvider devfileFilenamesProvider;
+  private final OAuthAPI oAuthAPI;
   private final PersonalAccessTokenManager personalAccessTokenManager;
   private static final List<String> bitbucketUrlPatternTemplates =
       List.of(
@@ -60,8 +61,10 @@ public class BitbucketServerURLParser {
   public BitbucketServerURLParser(
       @Nullable @Named("che.integration.bitbucket.server_endpoints") String bitbucketEndpoints,
       DevfileFilenamesProvider devfileFilenamesProvider,
+      OAuthAPI oAuthAPI,
       PersonalAccessTokenManager personalAccessTokenManager) {
     this.devfileFilenamesProvider = devfileFilenamesProvider;
+    this.oAuthAPI = oAuthAPI;
     this.personalAccessTokenManager = personalAccessTokenManager;
     if (bitbucketEndpoints != null) {
       for (String bitbucketEndpoint : Splitter.on(",").split(bitbucketEndpoints)) {
@@ -106,7 +109,10 @@ public class BitbucketServerURLParser {
     try {
       HttpBitbucketServerApiClient bitbucketServerApiClient =
           new HttpBitbucketServerApiClient(
-              getServerUrl(repositoryUrl), new BitbucketServerOAuthAuthenticator("", "", "", ""));
+              getServerUrl(repositoryUrl),
+              new BitbucketServerOAuthAuthenticator("", "", "", ""),
+              oAuthAPI,
+              "");
       // If the token request catches the unauthorised error, it means that the provided url
       // belongs to Bitbucket.
       bitbucketServerApiClient.getPersonalAccessToken("", 0L);

--- a/wsmaster/che-core-api-factory-bitbucket-server/src/test/java/org/eclipse/che/api/factory/server/bitbucket/BitbucketServerAuthorizingFactoryParametersResolverTest.java
+++ b/wsmaster/che-core-api-factory-bitbucket-server/src/test/java/org/eclipse/che/api/factory/server/bitbucket/BitbucketServerAuthorizingFactoryParametersResolverTest.java
@@ -45,6 +45,7 @@ import org.eclipse.che.api.workspace.server.devfile.URLFetcher;
 import org.eclipse.che.api.workspace.shared.dto.devfile.DevfileDto;
 import org.eclipse.che.api.workspace.shared.dto.devfile.MetadataDto;
 import org.eclipse.che.api.workspace.shared.dto.devfile.SourceDto;
+import org.eclipse.che.security.oauth.OAuthAPI;
 import org.mockito.Mock;
 import org.mockito.testng.MockitoTestNGListener;
 import org.testng.annotations.BeforeMethod;
@@ -54,6 +55,7 @@ import org.testng.annotations.Test;
 @Listeners(MockitoTestNGListener.class)
 public class BitbucketServerAuthorizingFactoryParametersResolverTest {
 
+  @Mock private OAuthAPI oAuthAPI;
   @Mock private URLFactoryBuilder urlFactoryBuilder;
 
   @Mock private URLFetcher urlFetcher;
@@ -72,6 +74,7 @@ public class BitbucketServerAuthorizingFactoryParametersResolverTest {
         new BitbucketServerURLParser(
             "http://bitbucket.2mcl.com",
             devfileFilenamesProvider,
+            oAuthAPI,
             mock(PersonalAccessTokenManager.class));
     assertNotNull(this.bitbucketURLParser);
     bitbucketServerFactoryParametersResolver =

--- a/wsmaster/che-core-api-factory-bitbucket-server/src/test/java/org/eclipse/che/api/factory/server/bitbucket/BitbucketServerScmFileResolverTest.java
+++ b/wsmaster/che-core-api-factory-bitbucket-server/src/test/java/org/eclipse/che/api/factory/server/bitbucket/BitbucketServerScmFileResolverTest.java
@@ -13,7 +13,6 @@ package org.eclipse.che.api.factory.server.bitbucket;
 
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.testng.Assert.*;
@@ -23,6 +22,7 @@ import org.eclipse.che.api.factory.server.scm.PersonalAccessTokenManager;
 import org.eclipse.che.api.factory.server.scm.exception.ScmUnauthorizedException;
 import org.eclipse.che.api.factory.server.urlfactory.DevfileFilenamesProvider;
 import org.eclipse.che.api.workspace.server.devfile.URLFetcher;
+import org.eclipse.che.security.oauth.OAuthAPI;
 import org.mockito.Mock;
 import org.mockito.testng.MockitoTestNGListener;
 import org.testng.annotations.BeforeMethod;
@@ -35,6 +35,7 @@ public class BitbucketServerScmFileResolverTest {
   public static final String SCM_URL = "https://foo.bar";
   BitbucketServerURLParser bitbucketURLParser;
 
+  @Mock private OAuthAPI oAuthAPI;
   @Mock private URLFetcher urlFetcher;
 
   @Mock private DevfileFilenamesProvider devfileFilenamesProvider;
@@ -46,7 +47,7 @@ public class BitbucketServerScmFileResolverTest {
   protected void init() {
     bitbucketURLParser =
         new BitbucketServerURLParser(
-            SCM_URL, devfileFilenamesProvider, mock(PersonalAccessTokenManager.class));
+            SCM_URL, devfileFilenamesProvider, oAuthAPI, personalAccessTokenManager);
     assertNotNull(this.bitbucketURLParser);
     serverScmFileResolver =
         new BitbucketServerScmFileResolver(

--- a/wsmaster/che-core-api-factory-bitbucket-server/src/test/java/org/eclipse/che/api/factory/server/bitbucket/BitbucketServerURLParserTest.java
+++ b/wsmaster/che-core-api-factory-bitbucket-server/src/test/java/org/eclipse/che/api/factory/server/bitbucket/BitbucketServerURLParserTest.java
@@ -26,6 +26,7 @@ import com.github.tomakehurst.wiremock.client.WireMock;
 import com.github.tomakehurst.wiremock.common.Slf4jNotifier;
 import org.eclipse.che.api.factory.server.scm.PersonalAccessTokenManager;
 import org.eclipse.che.api.factory.server.urlfactory.DevfileFilenamesProvider;
+import org.eclipse.che.security.oauth.OAuthAPI;
 import org.mockito.Mock;
 import org.mockito.testng.MockitoTestNGListener;
 import org.testng.annotations.BeforeClass;
@@ -38,6 +39,7 @@ import org.testng.annotations.Test;
 public class BitbucketServerURLParserTest {
 
   @Mock private DevfileFilenamesProvider devfileFilenamesProvider;
+  @Mock private OAuthAPI oAuthAPI;
 
   /** Instance of component that will be tested. */
   private BitbucketServerURLParser bitbucketURLParser;
@@ -59,6 +61,7 @@ public class BitbucketServerURLParserTest {
         new BitbucketServerURLParser(
             "https://bitbucket.2mcl.com,https://bbkt.com",
             devfileFilenamesProvider,
+            oAuthAPI,
             mock(PersonalAccessTokenManager.class));
   }
 
@@ -91,7 +94,7 @@ public class BitbucketServerURLParserTest {
     // given
     bitbucketURLParser =
         new BitbucketServerURLParser(
-            null, devfileFilenamesProvider, mock(PersonalAccessTokenManager.class));
+            null, devfileFilenamesProvider, oAuthAPI, mock(PersonalAccessTokenManager.class));
     String url = wireMockServer.url("/users/user/repos/repo");
     stubFor(
         get(urlEqualTo("/rest/access-tokens/1.0/users/0")).willReturn(aResponse().withStatus(401)));


### PR DESCRIPTION
Signed-off-by: Igor Vinokur <ivinokur@redhat.com>

<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests
-->

### What does this PR do?
Apply Bitbucket Server oAuth-2 configuration for the factory flow.

Depends on https://github.com/eclipse-che/che-operator/pull/1618
### Screenshot/screencast of this PR
<!-- Please include a screenshot or a screencast explaining what is doing this PR -->


### What issues does this PR fix or reference?
<!-- Please include any related issue from eclipse che repository (or from another issue tracker).
     Include link to other pull requests like documentation PR from [the docs repo](https://github.com/eclipse/che-docs)
-->
https://github.com/eclipse/che/issues/21949

### How to test this PR?
<!-- Please explain for example :
  - The test platform (openshift, kubernetes, minikube, CodeReady Container, docker-desktop, etc)
  - Installation method: chectl / che-operator
  - steps to reproduce
 -->
1. Deploy che with the test image and related modified operator image: `chectl server:deploy -p=openshift --che-operator-image=quay.io/ivinokur/che-operator:next -i=quay.io/ivinokur/che-server:next`
2. Deploy the latest Bitbucket Server instance: https://github.com/che-incubator/git-srv/blob/main/bitbucket/1_deploy_bitbucket.sh
3. Configure an `Application link` in the Bitbucket instance: https://confluence.atlassian.com/bitbucketserver0720/configure-an-incoming-link-1116282013.html:
   - Use `<che url>/api/oauth/callback` as a `Redirect URL`
   - Set **Admin** in the `application permissions` section
4. Create an oauth config secret in the `eclipse-che` namespace:
```
kind: Secret
apiVersion: v1
metadata:
  name: bitbucket-oauth-config
  labels:
    app.kubernetes.io/part-of: che.eclipse.org
    app.kubernetes.io/component: oauth-scm-configuration
  annotations:
    che.eclipse.org/oauth-scm-server: bitbucket
    che.eclipse.org/scm-server-endpoint: <bitbucket-server endpoint url>
type: Opaque
data:
  id: <base 64 client id from the bitbucket server application link>
  secret: <base 64 client secret from the bitbucket server application link> 
```
5. Create a repository with a `devfile.yaml` in the Bitbucket Server instance.
6. Start a factory from the repository https url.

### PR Checklist

[As the author of this Pull Request I made sure that:](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#pull-request-template-and-its-checklist)

- [x] [The Eclipse Contributor Agreement is valid](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-eclipse-contributor-agreement-is-valid)
- [x] [Code produced is complete](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-produced-is-complete)
- [x] [Code builds without errors](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-builds-without-errors)
- [x] [Tests are covering the bugfix](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#tests-are-covering-the-bugfix)
- [ ] [The repository devfile is up to date and works](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-repository-devfile-is-up-to-date-and-works)
- [x] [Sections `What issues does this PR fix or reference` and `How to test this PR` completed](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#sections-what-issues-does-this-pr-fix-or-reference-and-how-to-test-this-pr-completed)
- [ ] [Relevant user documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [Relevant contributing documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [CI/CD changes implemented, documented and communicated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#cicd-changes-implemented-documented-and-communicated)

### Reviewers

Reviewers, please comment how you tested the PR when approving it.
