### PR TITLE
chore: remove ref to .ci/set_tag_version_images.sh script since it was deleted two weeks ago

### DIFF
--- a/make-release.sh
+++ b/make-release.sh
@@ -228,11 +228,6 @@ prepareRelease() {
             echo "[INFO] Dependencies updated in che typescript DTO (parent = ${VERSION_CHE_PARENT}, che server = ${CHE_VERSION})"
         popd >/dev/null
 
-        # TODO more elegant way to execute these scripts
-        pushd .ci >/dev/null
-            ./set_tag_version_images.sh ${CHE_VERSION}
-            echo "[INFO] Tag versions of images have been set in che-server"
-        popd >/dev/null
         # run mvn license format, in case some files that have old license headers have been updated
         mvn license:format
     popd >/dev/null


### PR DESCRIPTION
### What does this PR do?

chore: remove ref to .ci/set_tag_version_images.sh script since it was deleted two weeks ago

Change-Id: Ie770b98d6ebd64deacb3e376f4fee0ec675135a0
Signed-off-by: Nick Boldt <nboldt@redhat.com>

### Screenshot/screencast of this PR
N/A

### What issues does this PR fix or reference?
caused by https://github.com/eclipse-che/che-server/commit/3dd20f690af6398dac3cd15b4b801cad5b1b20f7 and an incomplete cleanup after the script was removed

build error is:
```
 ./che-server/make-release.sh: line 232: pushd: .ci: No such file or directory
```

So this skips over the missing file.

### How to test this PR?
N/A

### PR Checklist

[As the author of this Pull Request I made sure that:](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#pull-request-template-and-its-checklist)

- [x] [The Eclipse Contributor Agreement is valid](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-eclipse-contributor-agreement-is-valid)
- [x] [Code produced is complete](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-produced-is-complete)
- [x] [Code builds without errors](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-builds-without-errors)
- [ ] [Tests are covering the bugfix](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#tests-are-covering-the-bugfix)
- [x] [The repository devfile is up to date and works, if one exists](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-repository-devfile-is-up-to-date-and-works)
- [x] [Sections What issues does this PR fix or reference and How to test this PR completed](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#sections-what-issues-does-this-pr-fix-or-reference-and-how-to-test-this-pr-completed)
- [x] [Relevant user documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [x] [Relevant contributing documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [x] [CI/CD changes implemented, documented and communicated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#cicd-changes-implemented-documented-and-communicated)

### Reviewers

Reviewers, please comment how you tested the PR when approving it.