### PR TITLE
refactor: Deprecating api/user endpoint. Adding exta GET api/user/id endpoint for easily obtaining user ID

### DIFF
--- a/multiuser/permission/che-multiuser-permission-user/src/main/java/org/eclipse/che/multiuser/permission/user/UserServicePermissionsFilter.java
+++ b/multiuser/permission/che-multiuser-permission-user/src/main/java/org/eclipse/che/multiuser/permission/user/UserServicePermissionsFilter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012-2021 Red Hat, Inc.
+ * Copyright (c) 2012-2023 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/
@@ -53,6 +53,7 @@ public class UserServicePermissionsFilter extends CheMethodInvokerFilter {
       case "getCurrent":
       case "updatePassword":
       case "getById":
+      case "getId":
       case "find":
       case "getSettings":
         // public methods

--- a/wsmaster/che-core-api-user/src/main/java/org/eclipse/che/api/user/server/UserService.java
+++ b/wsmaster/che-core-api-user/src/main/java/org/eclipse/che/api/user/server/UserService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012-2021 Red Hat, Inc.
+ * Copyright (c) 2012-2023 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/
@@ -13,6 +13,7 @@ package org.eclipse.che.api.user.server;
 
 import static jakarta.ws.rs.core.MediaType.APPLICATION_FORM_URLENCODED;
 import static jakarta.ws.rs.core.MediaType.APPLICATION_JSON;
+import static jakarta.ws.rs.core.MediaType.TEXT_PLAIN;
 import static jakarta.ws.rs.core.Response.Status.CREATED;
 import static org.eclipse.che.api.user.server.Constants.LINK_REL_CURRENT_USER;
 import static org.eclipse.che.api.user.server.Constants.LINK_REL_CURRENT_USER_PASSWORD;
@@ -83,6 +84,22 @@ public class UserService extends Service {
     this.userSelfCreationAllowed = userSelfCreationAllowed;
   }
 
+  @GET
+  @Path("/id")
+  @Produces(TEXT_PLAIN)
+  @Operation(
+      summary = "Get current user's id",
+      responses = {
+        @ApiResponse(
+            responseCode = "200",
+            description =
+                "The response contains current user's id ('0000-00-0000' is returned for the anonymous user)"),
+      })
+  public String getId() {
+    return userId();
+  }
+
+  @Deprecated
   @POST
   @Consumes(APPLICATION_JSON)
   @Produces(APPLICATION_JSON)
@@ -121,6 +138,7 @@ public class UserService extends Service {
         .build();
   }
 
+  @Deprecated
   @GET
   @Produces(APPLICATION_JSON)
   @GenerateLink(rel = LINK_REL_CURRENT_USER)
@@ -140,6 +158,7 @@ public class UserService extends Service {
     return linksInjector.injectLinks(asDto(user), getServiceContext());
   }
 
+  @Deprecated
   @POST
   @Path("/password")
   @Consumes(APPLICATION_FORM_URLENCODED)
@@ -165,6 +184,7 @@ public class UserService extends Service {
     userManager.update(user);
   }
 
+  @Deprecated
   @GET
   @Path("/{id}")
   @Produces(APPLICATION_JSON)
@@ -188,6 +208,7 @@ public class UserService extends Service {
     return linksInjector.injectLinks(asDto(user), getServiceContext());
   }
 
+  @Deprecated
   @GET
   @Path("/find")
   @Produces(APPLICATION_JSON)
@@ -224,6 +245,7 @@ public class UserService extends Service {
     return linksInjector.injectLinks(asDto(user), getServiceContext());
   }
 
+  @Deprecated
   @DELETE
   @Path("/{id}")
   @GenerateLink(rel = LINK_REL_USER)
@@ -243,6 +265,7 @@ public class UserService extends Service {
     userManager.remove(id);
   }
 
+  @Deprecated
   @GET
   @Path("/settings")
   @Produces(APPLICATION_JSON)


### PR DESCRIPTION
### What does this PR do?
- Deprecating `api/user` endpoints. 
- Adding extra GET `api/user/id` endpoint for easily obtaining user ID (for OpenShift cases with native OAuth enabled it is OpenShift user id)

N.B. In general, we stop using `che-server` for obtaining user-specific information. However, at this point user can not easily obtain its user id due to permission restrictions e.g.

```
oc describe user ibuziuk
Error from server (Forbidden): users.user.openshift.io "ibuziuk" is forbidden: User "ibuziuk" cannot get resource "users" in API group "user.openshift.io" at the cluster scope
```

### Screenshot/screencast of this PR
![image](https://user-images.githubusercontent.com/1461122/220096784-eedac2de-e1c9-4af4-bbe4-2b8824162fcd.png)

![image](https://user-images.githubusercontent.com/1461122/220107096-5af8749d-33b0-40f4-9477-23fceb6f9477.png)

![image](https://user-images.githubusercontent.com/1461122/220107352-859b0dcb-325a-4f70-9599-f445970b97c2.png)



### What issues does this PR fix or reference?
Related to https://issues.redhat.com/browse/RHDEVDOCS-4840


### How to test this PR?
<!-- Please explain for example :
  - The test platform (openshift, kubernetes, minikube, CodeReady Container, docker-desktop, etc)
  - Installation method: chectl / che-operator
  - steps to reproduce
 -->


### PR Checklist
image for verification: `quay.io/ibuziuk/che-server:getID`

[As the author of this Pull Request I made sure that:](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#pull-request-template-and-its-checklist)

- [ ] [The Eclipse Contributor Agreement is valid](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-eclipse-contributor-agreement-is-valid)
- [ ] [Code produced is complete](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-produced-is-complete)
- [ ] [Code builds without errors](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-builds-without-errors)
- [ ] [Tests are covering the bugfix](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#tests-are-covering-the-bugfix)
- [ ] [The repository devfile is up to date and works](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-repository-devfile-is-up-to-date-and-works)
- [ ] [Sections `What issues does this PR fix or reference` and `How to test this PR` completed](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#sections-what-issues-does-this-pr-fix-or-reference-and-how-to-test-this-pr-completed)
- [ ] [Relevant user documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [Relevant contributing documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [CI/CD changes implemented, documented and communicated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#cicd-changes-implemented-documented-and-communicated)

### Reviewers

PR should be backported to 7.60.x for 3.5

The following docs that fall back on user API should be updated accordingly
- https://www.eclipse.org/che/docs/stable/administration-guide/removing-user-data/
- https://www.eclipse.org/che/docs/stable/end-user-guide/using-a-git-provider-access-token/
