### PR TITLE
Support Basic authentication for devfile factory URL

### DIFF
--- a/wsmaster/che-core-api-factory-bitbucket-server/src/main/java/org/eclipse/che/api/factory/server/bitbucket/BitbucketServerURLParser.java
+++ b/wsmaster/che-core-api-factory-bitbucket-server/src/main/java/org/eclipse/che/api/factory/server/bitbucket/BitbucketServerURLParser.java
@@ -169,7 +169,7 @@ public class BitbucketServerURLParser {
                         format(
                             "The given url %s is not a valid Bitbucket server URL. Check either URL or server configuration.",
                             url)));
-    return parse(matcher);
+    return parse(matcher).withUrl(url);
   }
 
   private BitbucketServerUrl parse(Matcher matcher) {

--- a/wsmaster/che-core-api-factory-bitbucket-server/src/main/java/org/eclipse/che/api/factory/server/bitbucket/BitbucketServerUrl.java
+++ b/wsmaster/che-core-api-factory-bitbucket-server/src/main/java/org/eclipse/che/api/factory/server/bitbucket/BitbucketServerUrl.java
@@ -19,10 +19,10 @@ import java.util.List;
 import java.util.Optional;
 import java.util.StringJoiner;
 import java.util.stream.Collectors;
-import org.eclipse.che.api.factory.server.urlfactory.RemoteFactoryUrl;
+import org.eclipse.che.api.factory.server.urlfactory.DefaultFactoryUrl;
 
 /** Representation of a bitbucket Server URL, allowing to get details from it. */
-public class BitbucketServerUrl implements RemoteFactoryUrl {
+public class BitbucketServerUrl extends DefaultFactoryUrl {
 
   private final String NAME = "bitbucket";
 

--- a/wsmaster/che-core-api-factory-bitbucket/src/main/java/org/eclipse/che/api/factory/server/bitbucket/BitbucketURLParser.java
+++ b/wsmaster/che-core-api-factory-bitbucket/src/main/java/org/eclipse/che/api/factory/server/bitbucket/BitbucketURLParser.java
@@ -61,6 +61,7 @@ public class BitbucketURLParser {
         .withRepository(repoName)
         .withBranch(branchName)
         .withWorkspaceId(workspaceId)
-        .withDevfileFilenames(devfileFilenamesProvider.getConfiguredDevfileFilenames());
+        .withDevfileFilenames(devfileFilenamesProvider.getConfiguredDevfileFilenames())
+        .withUrl(url);
   }
 }

--- a/wsmaster/che-core-api-factory-bitbucket/src/main/java/org/eclipse/che/api/factory/server/bitbucket/BitbucketUrl.java
+++ b/wsmaster/che-core-api-factory-bitbucket/src/main/java/org/eclipse/che/api/factory/server/bitbucket/BitbucketUrl.java
@@ -19,14 +19,14 @@ import java.util.List;
 import java.util.Optional;
 import java.util.StringJoiner;
 import java.util.stream.Collectors;
-import org.eclipse.che.api.factory.server.urlfactory.RemoteFactoryUrl;
+import org.eclipse.che.api.factory.server.urlfactory.DefaultFactoryUrl;
 
 /**
  * Representation of a bitbucket URL, allowing to get details from it.
  *
  * <p>like https://<your_username>@bitbucket.org/<workspace_ID>/<repo_name>.git
  */
-public class BitbucketUrl implements RemoteFactoryUrl {
+public class BitbucketUrl extends DefaultFactoryUrl {
 
   private final String NAME = "bitbucket";
 

--- a/wsmaster/che-core-api-factory-github/src/main/java/org/eclipse/che/api/factory/server/github/GithubURLParser.java
+++ b/wsmaster/che-core-api-factory-github/src/main/java/org/eclipse/che/api/factory/server/github/GithubURLParser.java
@@ -174,7 +174,8 @@ public class GithubURLParser {
         .withBranch(branchName)
         .withLatestCommit(latestCommit)
         .withSubfolder(matcher.group("subFolder"))
-        .withDevfileFilenames(devfileFilenamesProvider.getConfiguredDevfileFilenames());
+        .withDevfileFilenames(devfileFilenamesProvider.getConfiguredDevfileFilenames())
+        .withUrl(url);
   }
 
   private GithubPullRequest getPullRequest(

--- a/wsmaster/che-core-api-factory-github/src/main/java/org/eclipse/che/api/factory/server/github/GithubUrl.java
+++ b/wsmaster/che-core-api-factory-github/src/main/java/org/eclipse/che/api/factory/server/github/GithubUrl.java
@@ -18,7 +18,7 @@ import java.util.List;
 import java.util.Optional;
 import java.util.StringJoiner;
 import java.util.stream.Collectors;
-import org.eclipse.che.api.factory.server.urlfactory.RemoteFactoryUrl;
+import org.eclipse.che.api.factory.server.urlfactory.DefaultFactoryUrl;
 
 /**
  * Representation of a github URL, allowing to get details from it.
@@ -28,7 +28,7 @@ import org.eclipse.che.api.factory.server.urlfactory.RemoteFactoryUrl;
  *
  * @author Florent Benoit
  */
-public class GithubUrl implements RemoteFactoryUrl {
+public class GithubUrl extends DefaultFactoryUrl {
 
   private final String NAME = "github";
 

--- a/wsmaster/che-core-api-factory-gitlab/src/main/java/org/eclipse/che/api/factory/server/gitlab/GitlabUrl.java
+++ b/wsmaster/che-core-api-factory-gitlab/src/main/java/org/eclipse/che/api/factory/server/gitlab/GitlabUrl.java
@@ -20,7 +20,7 @@ import java.util.List;
 import java.util.Optional;
 import java.util.StringJoiner;
 import java.util.stream.Collectors;
-import org.eclipse.che.api.factory.server.urlfactory.RemoteFactoryUrl;
+import org.eclipse.che.api.factory.server.urlfactory.DefaultFactoryUrl;
 
 /**
  * Representation of a gitlab URL, allowing to get details from it.
@@ -30,7 +30,7 @@ import org.eclipse.che.api.factory.server.urlfactory.RemoteFactoryUrl;
  *
  * @author Max Shaposhnyk
  */
-public class GitlabUrl implements RemoteFactoryUrl {
+public class GitlabUrl extends DefaultFactoryUrl {
 
   private final String NAME = "gitlab";
 

--- a/wsmaster/che-core-api-factory-gitlab/src/main/java/org/eclipse/che/api/factory/server/gitlab/GitlabUrlParser.java
+++ b/wsmaster/che-core-api-factory-gitlab/src/main/java/org/eclipse/che/api/factory/server/gitlab/GitlabUrlParser.java
@@ -153,7 +153,7 @@ public class GitlabUrlParser {
             .findFirst()
             .or(() -> getPatternMatcherByUrl(url));
     if (matcherOptional.isPresent()) {
-      return parse(matcherOptional.get());
+      return parse(matcherOptional.get()).withUrl(url);
     } else {
       throw new UnsupportedOperationException(
           "The gitlab integration is not configured properly and cannot be used at this moment."

--- a/wsmaster/che-core-api-factory/src/main/java/org/eclipse/che/api/factory/server/DefaultFactoryParameterResolver.java
+++ b/wsmaster/che-core-api-factory/src/main/java/org/eclipse/che/api/factory/server/DefaultFactoryParameterResolver.java
@@ -88,7 +88,9 @@ public class DefaultFactoryParameterResolver implements FactoryParametersResolve
     }
     return urlFactoryBuilder
         .createFactoryFromDevfile(
-            new DefaultFactoryUrl().withDevfileFileLocation(devfileLocation),
+            new DefaultFactoryUrl()
+                .withDevfileFileLocation(devfileLocation)
+                .withUrl(devfileLocation),
             new URLFileContentProvider(devfileURI, urlFetcher),
             extractOverrideParams(factoryParameters),
             false)

--- a/wsmaster/che-core-api-factory/src/main/java/org/eclipse/che/api/factory/server/scm/AuthorizingFileContentProvider.java
+++ b/wsmaster/che-core-api-factory/src/main/java/org/eclipse/che/api/factory/server/scm/AuthorizingFileContentProvider.java
@@ -11,10 +11,13 @@
  */
 package org.eclipse.che.api.factory.server.scm;
 
+import static com.google.common.base.Strings.isNullOrEmpty;
+
 import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.net.URI;
 import java.net.URISyntaxException;
+import java.util.Base64;
 import javax.net.ssl.SSLException;
 import org.eclipse.che.api.factory.server.scm.exception.ScmCommunicationException;
 import org.eclipse.che.api.factory.server.scm.exception.ScmConfigurationPersistenceException;
@@ -25,6 +28,7 @@ import org.eclipse.che.api.factory.server.urlfactory.RemoteFactoryUrl;
 import org.eclipse.che.api.workspace.server.devfile.FileContentProvider;
 import org.eclipse.che.api.workspace.server.devfile.URLFetcher;
 import org.eclipse.che.api.workspace.server.devfile.exception.DevfileException;
+import org.eclipse.che.commons.annotation.Nullable;
 
 /**
  * Common implementation of file content provider which is able to access content of private
@@ -48,16 +52,23 @@ public class AuthorizingFileContentProvider<T extends RemoteFactoryUrl>
 
   @Override
   public String fetchContent(String fileURL) throws IOException, DevfileException {
-    return fetchContent(fileURL, false);
+    return fetchContent(fileURL, false, null);
+  }
+
+  @Override
+  public String fetchContent(String fileURL, String credentials)
+      throws IOException, DevfileException {
+    return fetchContent(fileURL, false, credentials);
   }
 
   @Override
   public String fetchContentWithoutAuthentication(String fileURL)
       throws IOException, DevfileException {
-    return fetchContent(fileURL, true);
+    return fetchContent(fileURL, true, null);
   }
 
-  protected String fetchContent(String fileURL, boolean skipAuthentication)
+  private String fetchContent(
+      String fileURL, boolean skipAuthentication, @Nullable String credentials)
       throws IOException, DevfileException {
     final String requestURL = formatUrl(fileURL);
     try {
@@ -65,9 +76,17 @@ public class AuthorizingFileContentProvider<T extends RemoteFactoryUrl>
         return urlFetcher.fetch(requestURL);
       } else {
         // try to authenticate for the given URL
-        PersonalAccessToken token =
-            personalAccessTokenManager.getAndStore(remoteFactoryUrl.getHostName());
-        return urlFetcher.fetch(requestURL, formatAuthorization(token.getToken()));
+        String authorization;
+        if (isNullOrEmpty(credentials)) {
+          authorization =
+              formatAuthorization(
+                  personalAccessTokenManager
+                      .getAndStore(remoteFactoryUrl.getHostName())
+                      .getToken());
+        } else {
+          authorization = getCredentialsAuthorization(credentials);
+        }
+        return urlFetcher.fetch(requestURL, authorization);
       }
     } catch (UnknownScmProviderException e) {
       return fetchContentWithoutToken(requestURL, e);
@@ -142,5 +161,9 @@ public class AuthorizingFileContentProvider<T extends RemoteFactoryUrl>
 
   protected String formatAuthorization(String token) {
     return "Bearer " + token;
+  }
+
+  private String getCredentialsAuthorization(String credentials) {
+    return "Basic " + new String(Base64.getEncoder().encode(credentials.getBytes()));
   }
 }

--- a/wsmaster/che-core-api-factory/src/main/java/org/eclipse/che/api/factory/server/urlfactory/DefaultFactoryUrl.java
+++ b/wsmaster/che-core-api-factory/src/main/java/org/eclipse/che/api/factory/server/urlfactory/DefaultFactoryUrl.java
@@ -68,9 +68,9 @@ public class DefaultFactoryUrl implements RemoteFactoryUrl {
   }
 
   @Override
-  public @Nullable String getCredentials() {
+  public @Nullable Optional<String> getCredentials() {
     if (isNullOrEmpty(url)) {
-      return null;
+      return Optional.empty();
     }
     Matcher matcher =
         compile("https?://((?<username>[^:|@]+)?:?(?<password>[^@]+)?@)?.*").matcher(url);
@@ -87,11 +87,12 @@ public class DefaultFactoryUrl implements RemoteFactoryUrl {
       // no such group
     }
     if (!isNullOrEmpty(username) || !isNullOrEmpty(password)) {
-      return format(
-          "%s:%s",
-          isNullOrEmpty(username) ? "" : username, isNullOrEmpty(password) ? "" : password);
+      return Optional.of(
+          format(
+              "%s:%s",
+              isNullOrEmpty(username) ? "" : username, isNullOrEmpty(password) ? "" : password));
     }
-    return null;
+    return Optional.empty();
   }
 
   public <T extends DefaultFactoryUrl> T withUrl(String url) {

--- a/wsmaster/che-core-api-factory/src/main/java/org/eclipse/che/api/factory/server/urlfactory/DefaultFactoryUrl.java
+++ b/wsmaster/che-core-api-factory/src/main/java/org/eclipse/che/api/factory/server/urlfactory/DefaultFactoryUrl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012-2021 Red Hat, Inc.
+ * Copyright (c) 2012-2023 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/
@@ -11,11 +11,16 @@
  */
 package org.eclipse.che.api.factory.server.urlfactory;
 
+import static com.google.common.base.Strings.isNullOrEmpty;
+import static java.lang.String.format;
 import static java.util.Collections.singletonList;
+import static java.util.regex.Pattern.compile;
 
 import java.net.URI;
 import java.util.List;
 import java.util.Optional;
+import java.util.regex.Matcher;
+import org.eclipse.che.commons.annotation.Nullable;
 
 /**
  * Default implementation of {@link RemoteFactoryUrl} which used with all factory URL's until there
@@ -24,6 +29,7 @@ import java.util.Optional;
 public class DefaultFactoryUrl implements RemoteFactoryUrl {
 
   private String devfileFileLocation;
+  private String url;
 
   @Override
   public String getProviderName() {
@@ -59,6 +65,38 @@ public class DefaultFactoryUrl implements RemoteFactoryUrl {
   @Override
   public String getBranch() {
     return null;
+  }
+
+  @Override
+  public @Nullable String getCredentials() {
+    if (isNullOrEmpty(url)) {
+      return null;
+    }
+    Matcher matcher =
+        compile("https?://((?<username>[^:|@]+)?:?(?<password>[^@]+)?@)?.*").matcher(url);
+    String password = null;
+    String username = null;
+    try {
+      username = matcher.matches() ? matcher.group("username") : null;
+    } catch (IllegalArgumentException e) {
+      // no such group
+    }
+    try {
+      password = matcher.matches() ? matcher.group("password") : null;
+    } catch (IllegalArgumentException e) {
+      // no such group
+    }
+    if (!isNullOrEmpty(username) || !isNullOrEmpty(password)) {
+      return format(
+          "%s:%s",
+          isNullOrEmpty(username) ? "" : username, isNullOrEmpty(password) ? "" : password);
+    }
+    return null;
+  }
+
+  public <T extends DefaultFactoryUrl> T withUrl(String url) {
+    this.url = url;
+    return (T) this;
   }
 
   public DefaultFactoryUrl withDevfileFileLocation(String devfileFileLocation) {

--- a/wsmaster/che-core-api-factory/src/main/java/org/eclipse/che/api/factory/server/urlfactory/RemoteFactoryUrl.java
+++ b/wsmaster/che-core-api-factory/src/main/java/org/eclipse/che/api/factory/server/urlfactory/RemoteFactoryUrl.java
@@ -42,8 +42,8 @@ public interface RemoteFactoryUrl {
   /** Remote branch */
   String getBranch();
 
-  /** Credentials in format <username>:<password> */
-  String getCredentials();
+  /** Optional of Credentials in format <username>:<password> */
+  Optional<String> getCredentials();
 
   /** Describes devfile location, including filename if any. */
   interface DevfileLocation {

--- a/wsmaster/che-core-api-factory/src/main/java/org/eclipse/che/api/factory/server/urlfactory/RemoteFactoryUrl.java
+++ b/wsmaster/che-core-api-factory/src/main/java/org/eclipse/che/api/factory/server/urlfactory/RemoteFactoryUrl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012-2021 Red Hat, Inc.
+ * Copyright (c) 2012-2023 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/
@@ -41,6 +41,9 @@ public interface RemoteFactoryUrl {
 
   /** Remote branch */
   String getBranch();
+
+  /** Credentials in format <username>:<password> */
+  String getCredentials();
 
   /** Describes devfile location, including filename if any. */
   interface DevfileLocation {

--- a/wsmaster/che-core-api-factory/src/main/java/org/eclipse/che/api/factory/server/urlfactory/RemoteFactoryUrl.java
+++ b/wsmaster/che-core-api-factory/src/main/java/org/eclipse/che/api/factory/server/urlfactory/RemoteFactoryUrl.java
@@ -42,7 +42,7 @@ public interface RemoteFactoryUrl {
   /** Remote branch */
   String getBranch();
 
-  /** Optional of Credentials in format <username>:<password> */
+  /** Optional of credentials in format <username>:<password> or <username>: */
   Optional<String> getCredentials();
 
   /** Describes devfile location, including filename if any. */

--- a/wsmaster/che-core-api-factory/src/main/java/org/eclipse/che/api/factory/server/urlfactory/URLFactoryBuilder.java
+++ b/wsmaster/che-core-api-factory/src/main/java/org/eclipse/che/api/factory/server/urlfactory/URLFactoryBuilder.java
@@ -115,7 +115,8 @@ public class URLFactoryBuilder {
         devfileYamlContent =
             skipAuthentication
                 ? fileContentProvider.fetchContentWithoutAuthentication(location.location())
-                : fileContentProvider.fetchContent(location.location());
+                : fileContentProvider.fetchContent(
+                    location.location(), remoteFactoryUrl.getCredentials());
       } catch (IOException ex) {
         // try next location
         LOG.debug(

--- a/wsmaster/che-core-api-factory/src/test/java/org/eclipse/che/api/factory/server/DefaultFactoryParameterResolverTest.java
+++ b/wsmaster/che-core-api-factory/src/test/java/org/eclipse/che/api/factory/server/DefaultFactoryParameterResolverTest.java
@@ -91,14 +91,14 @@ public class DefaultFactoryParameterResolverTest {
     // set up our factory with the location of our devfile that is referencing our localfile
     Map<String, String> factoryParameters = new HashMap<>();
     factoryParameters.put(URL_PARAMETER_NAME, "http://myloc.com/aa/bb/devfile");
-    doReturn(DEVFILE).when(urlFetcher).fetch(eq("http://myloc.com/aa/bb/devfile"));
-    doReturn("localfile").when(urlFetcher).fetch("http://myloc.com/aa/localfile");
+    doReturn(DEVFILE).when(urlFetcher).fetch(eq("http://myloc.com/aa/bb/devfile"), eq(null));
+    doReturn("localfile").when(urlFetcher).fetch("http://myloc.com/aa/localfile", null);
 
     // when
     res.createFactory(factoryParameters);
 
     // then
-    verify(urlFetcher).fetch(eq("http://myloc.com/aa/localfile"));
+    verify(urlFetcher).fetch(eq("http://myloc.com/aa/localfile"), eq(null));
   }
 
   @Test

--- a/wsmaster/che-core-api-factory/src/test/java/org/eclipse/che/api/factory/server/urlfactory/DefaultFactoryUrlTest.java
+++ b/wsmaster/che-core-api-factory/src/test/java/org/eclipse/che/api/factory/server/urlfactory/DefaultFactoryUrlTest.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright (c) 2012-2023 Red Hat, Inc.
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+package org.eclipse.che.api.factory.server.urlfactory;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNull;
+
+import org.mockito.testng.MockitoTestNGListener;
+import org.testng.annotations.Listeners;
+import org.testng.annotations.Test;
+
+/** Testing {@link DefaultFactoryUrl} */
+@Listeners(MockitoTestNGListener.class)
+public class DefaultFactoryUrlTest {
+  @Test
+  public void shouldCredentials() {
+    // given
+    DefaultFactoryUrl factoryUrl =
+        new DefaultFactoryUrl().withUrl("https://username:password@hostname/path");
+    // when
+    String credentials = factoryUrl.getCredentials();
+    // then
+    assertEquals(credentials, "username:password");
+  }
+
+  @Test
+  public void shouldCredentialsWithoutPassword() {
+    // given
+    DefaultFactoryUrl factoryUrl =
+        new DefaultFactoryUrl().withUrl("https://username@hostname/path");
+    // when
+    String credentials = factoryUrl.getCredentials();
+    // then
+    assertEquals(credentials, "username:");
+  }
+
+  @Test
+  public void shouldGetNullCredentials() {
+    // given
+    DefaultFactoryUrl factoryUrl = new DefaultFactoryUrl().withUrl("https://hostname/path");
+    // when
+    String credentials = factoryUrl.getCredentials();
+    // then
+    assertNull(credentials);
+  }
+}

--- a/wsmaster/che-core-api-factory/src/test/java/org/eclipse/che/api/factory/server/urlfactory/DefaultFactoryUrlTest.java
+++ b/wsmaster/che-core-api-factory/src/test/java/org/eclipse/che/api/factory/server/urlfactory/DefaultFactoryUrlTest.java
@@ -42,12 +42,12 @@ public class DefaultFactoryUrlTest {
       {"https://token@hostname/path/user/repo/", "token:"},
       {"http://token@hostname/path/user/repo/", "token:"},
       {"https://token@dev.azure.com/user/repo/", "token:"},
+      {"https://token@gitlub.com/user/repo/", "token:"},
+      {"https://token@bitbucket.org/user/repo/", "token:"},
       {
         "https://personal-access-token@raw.githubusercontent.com/user/repo/branch/.devfile.yaml",
         "personal-access-token:"
-      },
-      {"https://token@gitlub.com/user/repo/", "token:"},
-      {"https://token@bitbucket.org/user/repo/", "token:"},
+      }
     };
   }
 

--- a/wsmaster/che-core-api-factory/src/test/java/org/eclipse/che/api/factory/server/urlfactory/DefaultFactoryUrlTest.java
+++ b/wsmaster/che-core-api-factory/src/test/java/org/eclipse/che/api/factory/server/urlfactory/DefaultFactoryUrlTest.java
@@ -42,6 +42,7 @@ public class DefaultFactoryUrlTest {
       {"https://token@hostname/path/user/repo/", "token:"},
       {"http://token@hostname/path/user/repo/", "token:"},
       {"https://token@dev.azure.com/user/repo/", "token:"},
+      {"https://token@dev.azure.com/user/repo?a=&b=b&c=/.devfile.yaml&api-version=7.0", "token:"},
       {"https://token@gitlub.com/user/repo/", "token:"},
       {"https://token@bitbucket.org/user/repo/", "token:"},
       {

--- a/wsmaster/che-core-api-factory/src/test/java/org/eclipse/che/api/factory/server/urlfactory/DefaultFactoryUrlTest.java
+++ b/wsmaster/che-core-api-factory/src/test/java/org/eclipse/che/api/factory/server/urlfactory/DefaultFactoryUrlTest.java
@@ -12,8 +12,10 @@
 package org.eclipse.che.api.factory.server.urlfactory;
 
 import static org.testng.Assert.assertEquals;
-import static org.testng.Assert.assertNull;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertTrue;
 
+import java.util.Optional;
 import org.mockito.testng.MockitoTestNGListener;
 import org.testng.annotations.Listeners;
 import org.testng.annotations.Test;
@@ -27,9 +29,10 @@ public class DefaultFactoryUrlTest {
     DefaultFactoryUrl factoryUrl =
         new DefaultFactoryUrl().withUrl("https://username:password@hostname/path");
     // when
-    String credentials = factoryUrl.getCredentials();
+    Optional<String> credentialsOptional = factoryUrl.getCredentials();
     // then
-    assertEquals(credentials, "username:password");
+    assertTrue(credentialsOptional.isPresent());
+    assertEquals(credentialsOptional.get(), "username:password");
   }
 
   @Test
@@ -38,18 +41,19 @@ public class DefaultFactoryUrlTest {
     DefaultFactoryUrl factoryUrl =
         new DefaultFactoryUrl().withUrl("https://username@hostname/path");
     // when
-    String credentials = factoryUrl.getCredentials();
+    Optional<String> credentialsOptional = factoryUrl.getCredentials();
     // then
-    assertEquals(credentials, "username:");
+    assertTrue(credentialsOptional.isPresent());
+    assertEquals(credentialsOptional.get(), "username:");
   }
 
   @Test
-  public void shouldGetNullCredentials() {
+  public void shouldGetEmptyCredentials() {
     // given
     DefaultFactoryUrl factoryUrl = new DefaultFactoryUrl().withUrl("https://hostname/path");
     // when
-    String credentials = factoryUrl.getCredentials();
+    Optional<String> credentialsOptional = factoryUrl.getCredentials();
     // then
-    assertNull(credentials);
+    assertFalse(credentialsOptional.isPresent());
   }
 }

--- a/wsmaster/che-core-api-factory/src/test/java/org/eclipse/che/api/factory/server/urlfactory/DefaultFactoryUrlTest.java
+++ b/wsmaster/che-core-api-factory/src/test/java/org/eclipse/che/api/factory/server/urlfactory/DefaultFactoryUrlTest.java
@@ -17,34 +17,38 @@ import static org.testng.Assert.assertTrue;
 
 import java.util.Optional;
 import org.mockito.testng.MockitoTestNGListener;
+import org.testng.annotations.DataProvider;
 import org.testng.annotations.Listeners;
 import org.testng.annotations.Test;
 
 /** Testing {@link DefaultFactoryUrl} */
 @Listeners(MockitoTestNGListener.class)
 public class DefaultFactoryUrlTest {
-  @Test
-  public void shouldCredentials() {
+  @Test(dataProvider = "urlsProvider")
+  public void shouldGetCredentials(String url, String credentials) {
     // given
-    DefaultFactoryUrl factoryUrl =
-        new DefaultFactoryUrl().withUrl("https://username:password@hostname/path");
+    DefaultFactoryUrl factoryUrl = new DefaultFactoryUrl().withUrl(url);
     // when
     Optional<String> credentialsOptional = factoryUrl.getCredentials();
     // then
     assertTrue(credentialsOptional.isPresent());
-    assertEquals(credentialsOptional.get(), "username:password");
+    assertEquals(credentialsOptional.get(), credentials);
   }
 
-  @Test
-  public void shouldCredentialsWithoutPassword() {
-    // given
-    DefaultFactoryUrl factoryUrl =
-        new DefaultFactoryUrl().withUrl("https://username@hostname/path");
-    // when
-    Optional<String> credentialsOptional = factoryUrl.getCredentials();
-    // then
-    assertTrue(credentialsOptional.isPresent());
-    assertEquals(credentialsOptional.get(), "username:");
+  @DataProvider(name = "urlsProvider")
+  private Object[][] urlsProvider() {
+    return new Object[][] {
+      {"https://username:password@hostname/path", "username:password"},
+      {"https://token@hostname/path/user/repo/", "token:"},
+      {"http://token@hostname/path/user/repo/", "token:"},
+      {"https://token@dev.azure.com/user/repo/", "token:"},
+      {
+        "https://personal-access-token@raw.githubusercontent.com/user/repo/branch/.devfile.yaml",
+        "personal-access-token:"
+      },
+      {"https://token@gitlub.com/user/repo/", "token:"},
+      {"https://token@bitbucket.org/user/repo/", "token:"},
+    };
   }
 
   @Test

--- a/wsmaster/che-core-api-factory/src/test/java/org/eclipse/che/api/factory/server/urlfactory/URLFactoryBuilderTest.java
+++ b/wsmaster/che-core-api-factory/src/test/java/org/eclipse/che/api/factory/server/urlfactory/URLFactoryBuilderTest.java
@@ -21,6 +21,7 @@ import static org.eclipse.che.dto.server.DtoFactory.newDto;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyMap;
 import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 import static org.testng.Assert.assertEquals;
@@ -127,12 +128,12 @@ public class URLFactoryBuilderTest {
         .thenReturn(new ObjectNode(JsonNodeFactory.instance));
     when(devfileParser.parseJsonNode(any(JsonNode.class), anyMap())).thenReturn(devfile);
     when(devfileVersionDetector.devfileMajorVersion(any(JsonNode.class))).thenReturn(1);
-    when(fileContentProvider.fetchContent(anyString())).thenReturn("content");
+    when(fileContentProvider.fetchContent(anyString(), eq(null))).thenReturn("content");
 
     FactoryMetaDto factory =
         urlFactoryBuilder
             .createFactoryFromDevfile(
-                new DefaultFactoryUrl().withDevfileFileLocation(myLocation),
+                new DefaultFactoryUrl().withDevfileFileLocation(myLocation).withUrl("url"),
                 fileContentProvider,
                 emptyMap(),
                 false)
@@ -152,12 +153,12 @@ public class URLFactoryBuilderTest {
     when(devfileParser.parseYamlRaw(anyString())).thenReturn(devfile);
     when(devfileParser.convertYamlToMap(devfile)).thenReturn(devfileAsMap);
     when(devfileVersionDetector.devfileMajorVersion(devfile)).thenReturn(2);
-    when(fileContentProvider.fetchContent(anyString())).thenReturn("content");
+    when(fileContentProvider.fetchContent(anyString(), eq(null))).thenReturn("content");
 
     FactoryMetaDto factory =
         urlFactoryBuilder
             .createFactoryFromDevfile(
-                new DefaultFactoryUrl().withDevfileFileLocation(myLocation),
+                new DefaultFactoryUrl().withDevfileFileLocation(myLocation).withUrl("url"),
                 fileContentProvider,
                 emptyMap(),
                 false)
@@ -178,7 +179,7 @@ public class URLFactoryBuilderTest {
     when(devfileParser.parseYamlRaw(anyString())).thenReturn(devfile);
     when(devfileParser.convertYamlToMap(devfile)).thenReturn(devfileAsMap);
     when(devfileVersionDetector.devfileMajorVersion(devfile)).thenReturn(2);
-    when(fileContentProvider.fetchContent(anyString())).thenReturn("content");
+    when(fileContentProvider.fetchContent(anyString(), eq(null))).thenReturn("content");
 
     RemoteFactoryUrl githubLikeRemoteUrl =
         new RemoteFactoryUrl() {
@@ -219,6 +220,11 @@ public class URLFactoryBuilderTest {
           }
 
           @Override
+          public String getCredentials() {
+            return null;
+          }
+
+          @Override
           public void setDevfileFilename(String devfileName) {}
         };
 
@@ -242,7 +248,7 @@ public class URLFactoryBuilderTest {
     when(devfileParser.parseYamlRaw(anyString())).thenReturn(devfile);
     when(devfileParser.convertYamlToMap(devfile)).thenReturn(devfileAsMap);
     when(devfileVersionDetector.devfileMajorVersion(devfile)).thenReturn(2);
-    when(fileContentProvider.fetchContent(anyString())).thenReturn("content");
+    when(fileContentProvider.fetchContent(anyString(), eq(null))).thenReturn("content");
 
     RemoteFactoryUrl githubLikeRemoteUrl =
         new RemoteFactoryUrl() {
@@ -286,6 +292,11 @@ public class URLFactoryBuilderTest {
           }
 
           @Override
+          public String getCredentials() {
+            return null;
+          }
+
+          @Override
           public void setDevfileFilename(String devfileName) {
             this.devfileName = devfileName;
           }
@@ -317,7 +328,7 @@ public class URLFactoryBuilderTest {
     when(devfileParser.parseYamlRaw(anyString())).thenReturn(devfile);
     when(devfileParser.convertYamlToMap(devfile)).thenReturn(devfileAsMap);
     when(devfileVersionDetector.devfileMajorVersion(devfile)).thenReturn(2);
-    when(fileContentProvider.fetchContent(anyString())).thenReturn("content");
+    when(fileContentProvider.fetchContent(anyString(), eq(null))).thenReturn("content");
 
     URLFactoryBuilder localUrlFactoryBuilder =
         new URLFactoryBuilder(
@@ -326,7 +337,7 @@ public class URLFactoryBuilderTest {
     FactoryMetaDto factory =
         localUrlFactoryBuilder
             .createFactoryFromDevfile(
-                new DefaultFactoryUrl().withDevfileFileLocation(myLocation),
+                new DefaultFactoryUrl().withDevfileFileLocation(myLocation).withUrl("url"),
                 fileContentProvider,
                 emptyMap(),
                 false)
@@ -381,7 +392,7 @@ public class URLFactoryBuilderTest {
                     return "http://foo.bar/anything";
                   }
                 }));
-    when(fileContentProvider.fetchContent(anyString())).thenReturn("anything");
+    when(fileContentProvider.fetchContent(anyString(), eq(null))).thenReturn("anything");
     when(devfileParser.parseYamlRaw("anything"))
         .thenReturn(new ObjectNode(JsonNodeFactory.instance));
     when(devfileParser.parseJsonNode(any(JsonNode.class), anyMap())).thenReturn(devfile);
@@ -420,7 +431,8 @@ public class URLFactoryBuilderTest {
                   }
                 }));
 
-    when(fileContentProvider.fetchContent(anyString())).thenThrow(new DevfileException("", cause));
+    when(fileContentProvider.fetchContent(anyString(), eq(null)))
+        .thenThrow(new DevfileException("", cause));
 
     // when
     try {

--- a/wsmaster/che-core-api-factory/src/test/java/org/eclipse/che/api/factory/server/urlfactory/URLFactoryBuilderTest.java
+++ b/wsmaster/che-core-api-factory/src/test/java/org/eclipse/che/api/factory/server/urlfactory/URLFactoryBuilderTest.java
@@ -21,7 +21,6 @@ import static org.eclipse.che.dto.server.DtoFactory.newDto;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyMap;
 import static org.mockito.ArgumentMatchers.anyString;
-import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 import static org.testng.Assert.assertEquals;
@@ -128,7 +127,7 @@ public class URLFactoryBuilderTest {
         .thenReturn(new ObjectNode(JsonNodeFactory.instance));
     when(devfileParser.parseJsonNode(any(JsonNode.class), anyMap())).thenReturn(devfile);
     when(devfileVersionDetector.devfileMajorVersion(any(JsonNode.class))).thenReturn(1);
-    when(fileContentProvider.fetchContent(anyString(), eq(null))).thenReturn("content");
+    when(fileContentProvider.fetchContent(anyString())).thenReturn("content");
 
     FactoryMetaDto factory =
         urlFactoryBuilder
@@ -153,7 +152,7 @@ public class URLFactoryBuilderTest {
     when(devfileParser.parseYamlRaw(anyString())).thenReturn(devfile);
     when(devfileParser.convertYamlToMap(devfile)).thenReturn(devfileAsMap);
     when(devfileVersionDetector.devfileMajorVersion(devfile)).thenReturn(2);
-    when(fileContentProvider.fetchContent(anyString(), eq(null))).thenReturn("content");
+    when(fileContentProvider.fetchContent(anyString())).thenReturn("content");
 
     FactoryMetaDto factory =
         urlFactoryBuilder
@@ -179,7 +178,7 @@ public class URLFactoryBuilderTest {
     when(devfileParser.parseYamlRaw(anyString())).thenReturn(devfile);
     when(devfileParser.convertYamlToMap(devfile)).thenReturn(devfileAsMap);
     when(devfileVersionDetector.devfileMajorVersion(devfile)).thenReturn(2);
-    when(fileContentProvider.fetchContent(anyString(), eq(null))).thenReturn("content");
+    when(fileContentProvider.fetchContent(anyString())).thenReturn("content");
 
     RemoteFactoryUrl githubLikeRemoteUrl =
         new RemoteFactoryUrl() {
@@ -220,8 +219,8 @@ public class URLFactoryBuilderTest {
           }
 
           @Override
-          public String getCredentials() {
-            return null;
+          public Optional<String> getCredentials() {
+            return Optional.empty();
           }
 
           @Override
@@ -248,7 +247,7 @@ public class URLFactoryBuilderTest {
     when(devfileParser.parseYamlRaw(anyString())).thenReturn(devfile);
     when(devfileParser.convertYamlToMap(devfile)).thenReturn(devfileAsMap);
     when(devfileVersionDetector.devfileMajorVersion(devfile)).thenReturn(2);
-    when(fileContentProvider.fetchContent(anyString(), eq(null))).thenReturn("content");
+    when(fileContentProvider.fetchContent(anyString())).thenReturn("content");
 
     RemoteFactoryUrl githubLikeRemoteUrl =
         new RemoteFactoryUrl() {
@@ -292,8 +291,8 @@ public class URLFactoryBuilderTest {
           }
 
           @Override
-          public String getCredentials() {
-            return null;
+          public Optional<String> getCredentials() {
+            return Optional.empty();
           }
 
           @Override
@@ -328,7 +327,7 @@ public class URLFactoryBuilderTest {
     when(devfileParser.parseYamlRaw(anyString())).thenReturn(devfile);
     when(devfileParser.convertYamlToMap(devfile)).thenReturn(devfileAsMap);
     when(devfileVersionDetector.devfileMajorVersion(devfile)).thenReturn(2);
-    when(fileContentProvider.fetchContent(anyString(), eq(null))).thenReturn("content");
+    when(fileContentProvider.fetchContent(anyString())).thenReturn("content");
 
     URLFactoryBuilder localUrlFactoryBuilder =
         new URLFactoryBuilder(
@@ -392,7 +391,7 @@ public class URLFactoryBuilderTest {
                     return "http://foo.bar/anything";
                   }
                 }));
-    when(fileContentProvider.fetchContent(anyString(), eq(null))).thenReturn("anything");
+    when(fileContentProvider.fetchContent(anyString())).thenReturn("anything");
     when(devfileParser.parseYamlRaw("anything"))
         .thenReturn(new ObjectNode(JsonNodeFactory.instance));
     when(devfileParser.parseJsonNode(any(JsonNode.class), anyMap())).thenReturn(devfile);
@@ -431,8 +430,7 @@ public class URLFactoryBuilderTest {
                   }
                 }));
 
-    when(fileContentProvider.fetchContent(anyString(), eq(null)))
-        .thenThrow(new DevfileException("", cause));
+    when(fileContentProvider.fetchContent(anyString())).thenThrow(new DevfileException("", cause));
 
     // when
     try {

--- a/wsmaster/che-core-api-workspace/src/main/java/org/eclipse/che/api/workspace/server/devfile/FileContentProvider.java
+++ b/wsmaster/che-core-api-workspace/src/main/java/org/eclipse/che/api/workspace/server/devfile/FileContentProvider.java
@@ -41,6 +41,18 @@ public interface FileContentProvider {
    * Fetches content of the specified file without the authentication step.
    *
    * @param fileURL absolute or devfile-relative file URL to fetch content
+   * @param credentials a string representation of credentials in format: <username>:<password>
+   * @return content of the specified file
+   * @throws IOException when there is an error during content retrieval
+   * @throws DevfileException when implementation does not support fetching of additional files
+   *     content
+   */
+  String fetchContent(String fileURL, String credentials) throws IOException, DevfileException;
+
+  /**
+   * Fetches content of the specified file without the authentication step.
+   *
+   * @param fileURL absolute or devfile-relative file URL to fetch content
    * @return content of the specified file
    * @throws IOException when there is an error during content retrieval
    * @throws DevfileException when implementation does not support fetching of additional files
@@ -78,8 +90,7 @@ public interface FileContentProvider {
       this.provider = provider;
     }
 
-    private String fetchContent(String fileURL, boolean skipAuthentication)
-        throws IOException, DevfileException {
+    private String fetchContentInternal(String fileURL) throws IOException, DevfileException {
       SoftReference<String> ref = cache.get(fileURL);
       String ret = ref == null ? null : ref.get();
 
@@ -93,13 +104,19 @@ public interface FileContentProvider {
 
     @Override
     public String fetchContent(String fileURL) throws IOException, DevfileException {
-      return fetchContent(fileURL, false);
+      return fetchContentInternal(fileURL);
+    }
+
+    @Override
+    public String fetchContent(String fileURL, String credentials)
+        throws IOException, DevfileException {
+      return fetchContentInternal(fileURL);
     }
 
     @Override
     public String fetchContentWithoutAuthentication(String fileURL)
         throws IOException, DevfileException {
-      return fetchContent(fileURL, true);
+      return fetchContentInternal(fileURL);
     }
   }
 }

--- a/wsmaster/che-core-api-workspace/src/main/java/org/eclipse/che/api/workspace/server/devfile/URLFetcher.java
+++ b/wsmaster/che-core-api-workspace/src/main/java/org/eclipse/che/api/workspace/server/devfile/URLFetcher.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012-2021 Red Hat, Inc.
+ * Copyright (c) 2012-2023 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/
@@ -31,6 +31,7 @@ import java.util.stream.Collectors;
 import javax.inject.Inject;
 import javax.inject.Named;
 import javax.inject.Singleton;
+import org.eclipse.che.commons.annotation.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -91,10 +92,12 @@ public class URLFetcher {
    * URLFetcher#CONNECTION_READ_TIMEOUT}
    *
    * @param url the URL to fetch
+   * @param authorization Authorisation string or {@code null}
    * @return content of the requested URL
    * @throws IOException if fetch error occurs
    */
-  public String fetch(@NotNull final String url, String authorization) throws IOException {
+  public String fetch(@NotNull final String url, @Nullable String authorization)
+      throws IOException {
     return fetch(url, CONNECTION_READ_TIMEOUT, authorization);
   }
 
@@ -115,12 +118,14 @@ public class URLFetcher {
    * Fetches the url provided and return its content.
    *
    * @param url the URL to fetch
+   * @param authorization Authorisation string or {@code null}
    * @param timeout read and connection timeout (see {@link URLConnection#setConnectTimeout(int)}
    *     and {@link URLConnection#setReadTimeout(int)}
    * @return content of the requested URL
    * @throws IOException if fetch error occurs
    */
-  String fetch(@NotNull final String url, int timeout, String authorization) throws IOException {
+  String fetch(@NotNull final String url, int timeout, @Nullable String authorization)
+      throws IOException {
     requireNonNull(url, "url parameter can't be null");
     URLConnection connection = new URL(sanitized(url)).openConnection();
     connection.setConnectTimeout(timeout);

--- a/wsmaster/che-core-api-workspace/src/test/java/org/eclipse/che/api/workspace/server/devfile/URLFileContentProviderTest.java
+++ b/wsmaster/che-core-api-workspace/src/test/java/org/eclipse/che/api/workspace/server/devfile/URLFileContentProviderTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012-2021 Red Hat, Inc.
+ * Copyright (c) 2012-2023 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/
@@ -11,6 +11,7 @@
  */
 package org.eclipse.che.api.workspace.server.devfile;
 
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.verify;
 import static org.testng.Assert.assertEquals;
 
@@ -42,7 +43,7 @@ public class URLFileContentProviderTest {
     URLFileContentProvider provider = new URLFileContentProvider(null, urlFetcher);
     ArgumentCaptor<String> captor = ArgumentCaptor.forClass(String.class);
     provider.fetchContent(url);
-    verify(urlFetcher).fetch(captor.capture());
+    verify(urlFetcher).fetch(captor.capture(), eq(null));
     assertEquals(captor.getValue(), url);
   }
 
@@ -53,7 +54,7 @@ public class URLFileContentProviderTest {
     URLFileContentProvider provider = new URLFileContentProvider(new URI(devfileUrl), urlFetcher);
     ArgumentCaptor<String> captor = ArgumentCaptor.forClass(String.class);
     provider.fetchContent(relativeUrl);
-    verify(urlFetcher).fetch(captor.capture());
+    verify(urlFetcher).fetch(captor.capture(), eq(null));
     assertEquals(captor.getValue(), "http://myhost.com/relative/relative.yaml");
   }
 }


### PR DESCRIPTION
<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests
-->

### What does this PR do?
* Add a parsing rule to detect credentials in factory URLs if it is in a format `https://<username>:<pasword>@hostname`.
* Extract the credentials from factory URLs and pass them to the devfile content request.

### Screenshot/screencast of this PR
<!-- Please include a screenshot or a screencast explaining what is doing this PR -->


### What issues does this PR fix or reference?
<!-- Please include any related issue from eclipse che repository (or from another issue tracker).
     Include link to other pull requests like documentation PR from [the docs repo](https://github.com/eclipse/che-docs)
-->
https://github.com/eclipse/che/issues/21998

### How to test this PR?
<!-- Please explain for example :
  - The test platform (openshift, kubernetes, minikube, CodeReady Container, docker-desktop, etc)
  - Installation method: chectl / che-operator
  - steps to reproduce
 -->
1. Deploy che from the test image: `quay.io/ivinokur/che-server:next`
2. Create a factory from a private raw devfile url with personal access token e.g. `https://<PAT>@github.com/<path to devfile.yaml>`

### PR Checklist

[As the author of this Pull Request I made sure that:](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#pull-request-template-and-its-checklist)

- [ ] [The Eclipse Contributor Agreement is valid](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-eclipse-contributor-agreement-is-valid)
- [ ] [Code produced is complete](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-produced-is-complete)
- [ ] [Code builds without errors](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-builds-without-errors)
- [ ] [Tests are covering the bugfix](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#tests-are-covering-the-bugfix)
- [ ] [The repository devfile is up to date and works](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-repository-devfile-is-up-to-date-and-works)
- [ ] [Sections `What issues does this PR fix or reference` and `How to test this PR` completed](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#sections-what-issues-does-this-pr-fix-or-reference-and-how-to-test-this-pr-completed)
- [ ] [Relevant user documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [Relevant contributing documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [CI/CD changes implemented, documented and communicated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#cicd-changes-implemented-documented-and-communicated)

### Reviewers

Reviewers, please comment how you tested the PR when approving it.
