### PR TITLE
fix: extend pattern for BitBacket URL

### DIFF
--- a/wsmaster/che-core-api-factory-bitbucket-server/src/main/java/org/eclipse/che/api/factory/server/bitbucket/BitbucketServerURLParser.java
+++ b/wsmaster/che-core-api-factory-bitbucket-server/src/main/java/org/eclipse/che/api/factory/server/bitbucket/BitbucketServerURLParser.java
@@ -52,6 +52,7 @@ public class BitbucketServerURLParser {
       List.of(
           "^(?<host>%s)/scm/~(?<user>[^/]+)/(?<repo>.*).git$",
           "^(?<host>%s)/users/(?<user>[^/]+)/repos/(?<repo>[^/]+)/browse(\\?at=(?<branch>.*))?",
+          "^(?<host>%s)/users/(?<user>[^/]+)/repos/(?<repo>[^/]+)/?",
           "^(?<host>%s)/scm/(?<project>[^/~]+)/(?<repo>[^/]+).git",
           "^(?<host>%s)/projects/(?<project>[^/]+)/repos/(?<repo>[^/]+)/browse(\\?at=(?<branch>.*))?");
   private final List<Pattern> bitbucketUrlPatterns = new ArrayList<>();

--- a/wsmaster/che-core-api-factory-bitbucket-server/src/main/java/org/eclipse/che/api/factory/server/bitbucket/BitbucketServerUrl.java
+++ b/wsmaster/che-core-api-factory-bitbucket-server/src/main/java/org/eclipse/che/api/factory/server/bitbucket/BitbucketServerUrl.java
@@ -123,6 +123,15 @@ public class BitbucketServerUrl extends DefaultFactoryUrl {
     return this;
   }
 
+  /**
+   * Gets user of this bitbucket server url
+   *
+   * @return the user part
+   */
+  public String getUser() {
+    return this.user;
+  }
+
   protected BitbucketServerUrl withUser(String user) {
     if (!isNullOrEmpty(user)) {
       this.user = user;

--- a/wsmaster/che-core-api-factory-bitbucket-server/src/test/java/org/eclipse/che/api/factory/server/bitbucket/BitbucketServerURLParserTest.java
+++ b/wsmaster/che-core-api-factory-bitbucket-server/src/test/java/org/eclipse/che/api/factory/server/bitbucket/BitbucketServerURLParserTest.java
@@ -73,9 +73,11 @@ public class BitbucketServerURLParserTest {
 
   /** Compare parsing */
   @Test(dataProvider = "parsing")
-  public void checkParsing(String url, String project, String repository, String branch) {
+  public void checkParsing(
+      String url, String user, String project, String repository, String branch) {
     BitbucketServerUrl bitbucketServerUrl = bitbucketURLParser.parse(url);
 
+    assertEquals(bitbucketServerUrl.getUser(), user);
     assertEquals(bitbucketServerUrl.getProject(), project);
     assertEquals(bitbucketServerUrl.getRepository(), repository);
     assertEquals(bitbucketServerUrl.getBranch(), branch);
@@ -123,8 +125,12 @@ public class BitbucketServerURLParserTest {
   @DataProvider(name = "UrlsProvider")
   public Object[][] urls() {
     return new Object[][] {
+      {"https://bitbucket.2mcl.com/scm/~user/repo.git"},
       {"https://bitbucket.2mcl.com/scm/project/test1.git"},
       {"https://bitbucket.2mcl.com/projects/project/repos/test1/browse?at=refs%2Fheads%2Fbranch"},
+      {"https://bitbucket.2mcl.com/projects/project/repos/test1/browse"},
+      {"https://bitbucket.2mcl.com/users/user/repos/repo"},
+      {"https://bitbucket.2mcl.com/users/user/repos/repo/"},
       {"https://bbkt.com/scm/project/test1.git"},
     };
   }
@@ -132,19 +138,22 @@ public class BitbucketServerURLParserTest {
   @DataProvider(name = "parsing")
   public Object[][] expectedParsing() {
     return new Object[][] {
-      {"https://bitbucket.2mcl.com/scm/project/test1.git", "project", "test1", null},
+      {"https://bitbucket.2mcl.com/scm/project/test1.git", null, "project", "test1", null},
       {
         "https://bitbucket.2mcl.com/projects/project/repos/test1/browse?at=refs%2Fheads%2Fbranch",
+        null,
         "project",
         "test1",
         "refs%2Fheads%2Fbranch"
       },
       {
         "https://bbkt.com/projects/project/repos/test1/browse?at=refs%2Fheads%2Fbranch",
+        null,
         "project",
         "test1",
         "refs%2Fheads%2Fbranch"
-      }
+      },
+      {"https://bbkt.com/users/user/repos/repo/", "user", null, "repo", null}
     };
   }
 }


### PR DESCRIPTION
<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests
-->

### What does this PR do?
Extends a pattern for validation BitBucket repository's URl.

It allows to start a workspace using next BB URL schemas:
`https://{bb-host}/users/{user-slug}/repos/{repo-name}/` 
`https://{bb-host}/users/{user-slug}/repos/{repo-name}/browse` 

### Screenshot/screencast of this PR
<!-- Please include a screenshot or a screencast explaining what is doing this PR -->

https://user-images.githubusercontent.com/1271546/224051566-4538a0d8-361b-495c-87f4-c0490c919d15.mp4

### What issues does this PR fix or reference?
<!-- Please include any related issue from eclipse che repository (or from another issue tracker).
     Include link to other pull requests like documentation PR from [the docs repo](https://github.com/eclipse/che-docs)
-->
https://github.com/eclipse/che/issues/21989

### How to test this PR?
<!-- Please explain for example :
  - The test platform (openshift, kubernetes, minikube, CodeReady Container, docker-desktop, etc)
  - Installation method: chectl / che-operator
  - steps to reproduce
 -->
- Use `vsvydenko/che-server:bb-url` in CRD as a che-server image
- Prepare BitBucket server using these scripts: https://github.com/che-incubator/git-srv/tree/main/bitbucket
- Setup BB PAT as described in https://www.eclipse.org/che/docs/stable/end-user-guide/using-a-git-provider-access-token/
- Create a repository in your BB-server under user profile:
 ![screenshot-bitbucket-bitbucket apps cluster-zqmfx zqmfx sandbox1400 opentlc com-2023 03 09-16_25_45](https://user-images.githubusercontent.com/1271546/224054949-2ab8ffd1-8656-4a31-a9e6-fa691c4ee4cc.png)
- Try to start a workspace using a schema `https://{bb-host}/users/{user-slug}/repos/{repo-name}/` 


### PR Checklist

[As the author of this Pull Request I made sure that:](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#pull-request-template-and-its-checklist)

- [x] [The Eclipse Contributor Agreement is valid](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-eclipse-contributor-agreement-is-valid)
- [x] [Code produced is complete](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-produced-is-complete)
- [x] [Code builds without errors](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-builds-without-errors)
- [x] [Tests are covering the bugfix](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#tests-are-covering-the-bugfix)
- [x] [The repository devfile is up to date and works](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-repository-devfile-is-up-to-date-and-works)
- [x] [Sections `What issues does this PR fix or reference` and `How to test this PR` completed](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#sections-what-issues-does-this-pr-fix-or-reference-and-how-to-test-this-pr-completed)
- [x] [Relevant user documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [x] [Relevant contributing documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [x] [CI/CD changes implemented, documented and communicated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#cicd-changes-implemented-documented-and-communicated)

### Reviewers

Reviewers, please comment how you tested the PR when approving it.
