### PR TITLE
Check the devfile content before creating a factory

### DIFF
--- a/wsmaster/che-core-api-factory/src/main/java/org/eclipse/che/api/factory/server/urlfactory/URLFactoryBuilder.java
+++ b/wsmaster/che-core-api-factory/src/main/java/org/eclipse/che/api/factory/server/urlfactory/URLFactoryBuilder.java
@@ -135,9 +135,15 @@ public class URLFactoryBuilder {
       if (isNullOrEmpty(devfileYamlContent)) {
         return Optional.empty();
       }
-
       try {
         JsonNode parsedDevfile = devfileParser.parseYamlRaw(devfileYamlContent);
+        // We might have an html content in the parsed devfile, in case if the access is restricted,
+        // or if the URL points to a wrong resource.
+        try {
+          devfileVersionDetector.devfileVersion(parsedDevfile);
+        } catch (DevfileException e) {
+          throw new ApiException("Failed to fetch devfile");
+        }
         return Optional.of(
             createFactory(parsedDevfile, overrideProperties, fileContentProvider, location));
       } catch (OverrideParameterException e) {

--- a/wsmaster/che-core-api-factory/src/test/java/org/eclipse/che/api/factory/server/urlfactory/URLFactoryBuilderTest.java
+++ b/wsmaster/che-core-api-factory/src/test/java/org/eclipse/che/api/factory/server/urlfactory/URLFactoryBuilderTest.java
@@ -21,6 +21,7 @@ import static org.eclipse.che.dto.server.DtoFactory.newDto;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyMap;
 import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 import static org.testng.Assert.assertEquals;
@@ -442,6 +443,22 @@ public class URLFactoryBuilderTest {
       if (e.getServiceError() instanceof ExtendedError)
         assertEquals(((ExtendedError) e.getServiceError()).getAttributes(), expectedAttributes);
     }
+  }
+
+  @Test(
+      expectedExceptions = ApiException.class,
+      expectedExceptionsMessageRegExp = "Failed to fetch devfile")
+  public void shouldThrowErrorOnUnsupportedDevfileContent()
+      throws ApiException, DevfileException, IOException {
+    JsonNode jsonNode = mock(JsonNode.class);
+    when(fileContentProvider.fetchContent(eq("location"))).thenReturn("unsupported content");
+    when(devfileParser.parseYamlRaw(eq("unsupported content"))).thenReturn(jsonNode);
+    when(devfileVersionDetector.devfileVersion(eq(jsonNode))).thenThrow(new DevfileException(""));
+    urlFactoryBuilder.createFactoryFromDevfile(
+        new DefaultFactoryUrl().withDevfileFileLocation("location"),
+        fileContentProvider,
+        emptyMap(),
+        false);
   }
 
   @DataProvider


### PR DESCRIPTION
<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests
-->

### What does this PR do?
When Che creates a workspace from a repository URL, first we iterate and find a related git provider handler, then we gat a devfile location according to the handler rules. If we pass an unsupported git repository url we will have a default handler which will try find a devfile by the same url as the repository. In that case we will have an html content as a devfile.

We need to check the content before parsing the devfile, and throw a specific error in case if the content is not yaml.
### Screenshot/screencast of this PR
<!-- Please include a screenshot or a screencast explaining what is doing this PR -->


### What issues does this PR fix or reference?
<!-- Please include any related issue from eclipse che repository (or from another issue tracker).
     Include link to other pull requests like documentation PR from [the docs repo](https://github.com/eclipse/che-docs)
-->
https://github.com/eclipse/che/issues/21997

### How to test this PR?
<!-- Please explain for example :
  - The test platform (openshift, kubernetes, minikube, CodeReady Container, docker-desktop, etc)
  - Installation method: chectl / che-operator
  - steps to reproduce
 -->
1. Deploy che via the test image: `chectl server:deploy -p=minikube -i=quay.io/ivinokur/che-server:next`
For the testing purpose I disabled gitlab factory handler in the image.
2. Pass a gitlab public repo with a devfile to start a workspace e.g. 'https://gitlab.com/ivinokur/test.git'
3. See the specific error:
![screenshot-192 168 64 197 nip io-2023 03 10-12_36_53](https://user-images.githubusercontent.com/7668752/224294495-d6233a9f-9970-4292-bf12-8e0358fd6a7f.png)


### PR Checklist

[As the author of this Pull Request I made sure that:](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#pull-request-template-and-its-checklist)

- [ ] [The Eclipse Contributor Agreement is valid](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-eclipse-contributor-agreement-is-valid)
- [ ] [Code produced is complete](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-produced-is-complete)
- [ ] [Code builds without errors](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-builds-without-errors)
- [ ] [Tests are covering the bugfix](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#tests-are-covering-the-bugfix)
- [ ] [The repository devfile is up to date and works](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-repository-devfile-is-up-to-date-and-works)
- [ ] [Sections `What issues does this PR fix or reference` and `How to test this PR` completed](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#sections-what-issues-does-this-pr-fix-or-reference-and-how-to-test-this-pr-completed)
- [ ] [Relevant user documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [Relevant contributing documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [CI/CD changes implemented, documented and communicated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#cicd-changes-implemented-documented-and-communicated)

### Reviewers

Reviewers, please comment how you tested the PR when approving it.
