### PR TITLE
Return empty credentials from bitbucket URL with username

### DIFF
--- a/wsmaster/che-core-api-factory-azure-devops/src/main/java/org/eclipse/che/api/factory/server/azure/devops/AzureDevOpsURLParser.java
+++ b/wsmaster/che-core-api-factory-azure-devops/src/main/java/org/eclipse/che/api/factory/server/azure/devops/AzureDevOpsURLParser.java
@@ -87,6 +87,7 @@ public class AzureDevOpsURLParser {
     // - https://<credentials>@<host>/<organization>/<project>/_git/<repoName>
     // For the first case we need to remove the `organization` from the url to distinguish it from
     // `credentials`
+    // TODO: return empty credentials like the BitBucketUrl
     String organizationCanIgnore = matcher.group("organizationCanIgnore");
     if (!isNullOrEmpty(organization) && organization.equals(organizationCanIgnore)) {
       url = url.replace(organizationCanIgnore + "@", "");

--- a/wsmaster/che-core-api-factory-bitbucket/src/main/java/org/eclipse/che/api/factory/server/bitbucket/BitbucketUrl.java
+++ b/wsmaster/che-core-api-factory-bitbucket/src/main/java/org/eclipse/che/api/factory/server/bitbucket/BitbucketUrl.java
@@ -12,6 +12,7 @@
 package org.eclipse.che.api.factory.server.bitbucket;
 
 import static com.google.common.base.MoreObjects.firstNonNull;
+import static com.google.common.base.Strings.isNullOrEmpty;
 
 import com.google.common.base.Strings;
 import java.util.ArrayList;
@@ -145,6 +146,14 @@ public class BitbucketUrl extends DefaultFactoryUrl {
   @Override
   public String getHostName() {
     return "https://" + HOSTNAME;
+  }
+
+  @Override
+  public Optional<String> getCredentials() {
+    if (!isNullOrEmpty(username) && super.getUrl().getUserInfo().equals(username)) {
+      return Optional.empty();
+    }
+    return super.getCredentials();
   }
 
   /**

--- a/wsmaster/che-core-api-factory-bitbucket/src/main/java/org/eclipse/che/api/factory/server/bitbucket/BitbucketUrl.java
+++ b/wsmaster/che-core-api-factory-bitbucket/src/main/java/org/eclipse/che/api/factory/server/bitbucket/BitbucketUrl.java
@@ -12,7 +12,6 @@
 package org.eclipse.che.api.factory.server.bitbucket;
 
 import static com.google.common.base.MoreObjects.firstNonNull;
-import static com.google.common.base.Strings.isNullOrEmpty;
 
 import com.google.common.base.Strings;
 import java.util.ArrayList;
@@ -150,10 +149,13 @@ public class BitbucketUrl extends DefaultFactoryUrl {
 
   @Override
   public Optional<String> getCredentials() {
-    if (!isNullOrEmpty(username) && super.getUrl().getUserInfo().equals(username)) {
-      return Optional.empty();
-    }
-    return super.getCredentials();
+    // Bitbucket repository URL may contain username e.g.
+    // https://<username>@bitbucket.org/<workspace_ID>/<repo_name>.git. If username is present, it
+    // can not be used as credentials. Moreover, we skip credentials for Bitbucket repository URl at
+    // all, because we do not support credentials in a repository URL. We only support credentials
+    // in a devfile URL, which is handled by the DefaultFactoryUrl class.
+    // Todo: add a new abstraction for divfile URL to be able to retrieve credentials separately.
+    return Optional.empty();
   }
 
   /**

--- a/wsmaster/che-core-api-factory-bitbucket/src/test/java/org/eclipse/che/api/factory/server/bitbucket/BitbucketUrlTest.java
+++ b/wsmaster/che-core-api-factory-bitbucket/src/test/java/org/eclipse/che/api/factory/server/bitbucket/BitbucketUrlTest.java
@@ -15,6 +15,7 @@ import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.when;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertTrue;
 
 import java.util.Arrays;
 import java.util.Iterator;
@@ -61,6 +62,14 @@ public class BitbucketUrlTest {
         iterator.next().location(), "https://bitbucket.org/eclipse/che/raw/HEAD/devfile.yaml");
 
     assertEquals(iterator.next().location(), "https://bitbucket.org/eclipse/che/raw/HEAD/foo.bar");
+  }
+
+  @Test
+  public void shouldReturnEmptyCredentials() {
+    // when
+    BitbucketUrl url = this.bitbucketURLParser.parse("https://user@bitbucket.org/eclipse/che");
+    // then
+    assertTrue(url.getCredentials().isEmpty());
   }
 
   /** Check the original repository */

--- a/wsmaster/che-core-api-factory/src/main/java/org/eclipse/che/api/factory/server/urlfactory/DefaultFactoryUrl.java
+++ b/wsmaster/che-core-api-factory/src/main/java/org/eclipse/che/api/factory/server/urlfactory/DefaultFactoryUrl.java
@@ -66,6 +66,10 @@ public class DefaultFactoryUrl implements RemoteFactoryUrl {
     return null;
   }
 
+  public URL getUrl() {
+    return url;
+  }
+
   @Override
   public Optional<String> getCredentials() {
     if (url == null || isNullOrEmpty(url.getUserInfo())) {


### PR DESCRIPTION
<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests
-->

### What does this PR do?
Override the `getCredentials()` method in the `BitbucketUrl` class to intercept bitbucket URL with username e.g. `https://user@bitbucket.org/eclipse/che`. Return empty credentials for such urls.
 
### Screenshot/screencast of this PR
<!-- Please include a screenshot or a screencast explaining what is doing this PR -->


### What issues does this PR fix or reference?
<!-- Please include any related issue from eclipse che repository (or from another issue tracker).
     Include link to other pull requests like documentation PR from [the docs repo](https://github.com/eclipse/che-docs)
-->
https://issues.redhat.com/browse/CRW-4095

### How to test this PR?
<!-- Please explain for example :
  - The test platform (openshift, kubernetes, minikube, CodeReady Container, docker-desktop, etc)
  - Installation method: chectl / che-operator
  - steps to reproduce
 -->
1. Deploy Che with the test image: `chectl server:deploy -p=minikube -i=quay.io/ivinokur/che-server:next`
2. Start a workspace from a public bitbucket URL e.g. `https://ivinokur@bitbucket.org/ivinokur/public.git`
3. See: workspace starts successfully.

### PR Checklist

[As the author of this Pull Request I made sure that:](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#pull-request-template-and-its-checklist)

- [x] [The Eclipse Contributor Agreement is valid](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-eclipse-contributor-agreement-is-valid)
- [x] [Code produced is complete](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-produced-is-complete)
- [x] [Code builds without errors](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-builds-without-errors)
- [ ] [Tests are covering the bugfix](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#tests-are-covering-the-bugfix)
- [ ] [The repository devfile is up to date and works](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-repository-devfile-is-up-to-date-and-works)
- [ ] [Sections `What issues does this PR fix or reference` and `How to test this PR` completed](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#sections-what-issues-does-this-pr-fix-or-reference-and-how-to-test-this-pr-completed)
- [ ] [Relevant user documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [Relevant contributing documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [CI/CD changes implemented, documented and communicated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#cicd-changes-implemented-documented-and-communicated)

### Reviewers

Reviewers, please comment how you tested the PR when approving it.
