### PR TITLE
fix: trim blank chars in PAT

### DIFF
--- a/infrastructures/infrastructure-factory/src/main/java/org/eclipse/che/api/factory/server/scm/kubernetes/KubernetesPersonalAccessTokenManager.java
+++ b/infrastructures/infrastructure-factory/src/main/java/org/eclipse/che/api/factory/server/scm/kubernetes/KubernetesPersonalAccessTokenManager.java
@@ -153,7 +153,9 @@ public class KubernetesPersonalAccessTokenManager implements PersonalAccessToken
           String trimmedUrl = StringUtils.trimEnd(annotations.get(ANNOTATION_SCM_URL), '/');
           if (annotations.get(ANNOTATION_CHE_USERID).equals(cheUser.getUserId())
               && trimmedUrl.equals(StringUtils.trimEnd(scmServerUrl, '/'))) {
-            PersonalAccessToken token =
+            String token =
+                new String(Base64.getDecoder().decode(secret.getData().get("token"))).trim();
+            PersonalAccessToken personalAccessToken =
                 new PersonalAccessToken(
                     trimmedUrl,
                     annotations.get(ANNOTATION_CHE_USERID),
@@ -162,9 +164,9 @@ public class KubernetesPersonalAccessTokenManager implements PersonalAccessToken
                     annotations.get(ANNOTATION_SCM_USERID),
                     annotations.get(ANNOTATION_SCM_PERSONAL_ACCESS_TOKEN_NAME),
                     annotations.get(ANNOTATION_SCM_PERSONAL_ACCESS_TOKEN_ID),
-                    new String(Base64.getDecoder().decode(secret.getData().get("token"))));
-            if (scmPersonalAccessTokenFetcher.isValid(token)) {
-              return Optional.of(token);
+                    token);
+            if (scmPersonalAccessTokenFetcher.isValid(personalAccessToken)) {
+              return Optional.of(personalAccessToken);
             } else {
               // Removing token that is no longer valid. If several tokens exist the next one could
               // be valid. If no valid token can be found, the caller should react in the same way


### PR DESCRIPTION
<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests
-->

### What does this PR do?
Trim blank chars at the beginning and at the end of the token string provided by PAT

### Screenshot/screencast of this PR
<!-- Please include a screenshot or a screencast explaining what is doing this PR -->

https://user-images.githubusercontent.com/1271546/226328299-ec98f86e-2d94-4dc9-b127-1e10eba783a8.mp4



### What issues does this PR fix or reference?
<!-- Please include any related issue from eclipse che repository (or from another issue tracker).
     Include link to other pull requests like documentation PR from [the docs repo](https://github.com/eclipse/che-docs)
-->
part of https://github.com/eclipse/che/issues/21989

### How to test this PR?
<!-- Please explain for example :
  - The test platform (openshift, kubernetes, minikube, CodeReady Container, docker-desktop, etc)
  - Installation method: chectl / che-operator
  - steps to reproduce
 -->
- Configure  PAT as described https://www.eclipse.org/che/docs/stable/end-user-guide/using-a-git-provider-access-token/
- Modify token by adding blank chars (like spaces or new line at the end) in the secret.
- Try to start a workspace from private repository to use created PAT  

### PR Checklist

[As the author of this Pull Request I made sure that:](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#pull-request-template-and-its-checklist)

- [x] [The Eclipse Contributor Agreement is valid](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-eclipse-contributor-agreement-is-valid)
- [x] [Code produced is complete](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-produced-is-complete)
- [x] [Code builds without errors](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-builds-without-errors)
- [x] [Tests are covering the bugfix](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#tests-are-covering-the-bugfix)
- [x] [The repository devfile is up to date and works](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-repository-devfile-is-up-to-date-and-works)
- [x] [Sections `What issues does this PR fix or reference` and `How to test this PR` completed](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#sections-what-issues-does-this-pr-fix-or-reference-and-how-to-test-this-pr-completed)
- [x] [Relevant user documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [x] [Relevant contributing documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [x] [CI/CD changes implemented, documented and communicated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#cicd-changes-implemented-documented-and-communicated)

### Reviewers

Reviewers, please comment how you tested the PR when approving it.
