### PR TITLE
Pass user name instead of user id when creating a PAT for bitbucket-server

### DIFF
--- a/wsmaster/che-core-api-factory-bitbucket-server/src/main/java/org/eclipse/che/api/factory/server/bitbucket/BitbucketServerPersonalAccessTokenFetcher.java
+++ b/wsmaster/che-core-api-factory-bitbucket-server/src/main/java/org/eclipse/che/api/factory/server/bitbucket/BitbucketServerPersonalAccessTokenFetcher.java
@@ -97,7 +97,7 @@ public class BitbucketServerPersonalAccessTokenFetcher implements PersonalAccess
           scmServerUrl,
           EnvironmentContext.getCurrent().getSubject().getUserId(),
           user.getName(),
-          valueOf(user.getId()),
+          user.getSlug(),
           token.getName(),
           valueOf(token.getId()),
           token.getToken());

--- a/wsmaster/che-core-api-factory-bitbucket-server/src/test/java/org/eclipse/che/api/factory/server/bitbucket/BitbucketServerPersonalAccessTokenFetcherTest.java
+++ b/wsmaster/che-core-api-factory-bitbucket-server/src/test/java/org/eclipse/che/api/factory/server/bitbucket/BitbucketServerPersonalAccessTokenFetcherTest.java
@@ -11,11 +11,13 @@
  */
 package org.eclipse.che.api.factory.server.bitbucket;
 
+import static java.lang.String.valueOf;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
+import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertFalse;
 import static org.testng.Assert.assertNotNull;
 import static org.testng.Assert.assertNull;
@@ -72,7 +74,8 @@ public class BitbucketServerPersonalAccessTokenFetcherTest {
     URL apiEndpoint = new URL("https://che.server.com");
     subject = new SubjectImpl("another_user", "user987", "token111", false);
     bitbucketUser =
-        new BitbucketUser("User", "user", 32423523, "NORMAL", true, "user", "user@users.com");
+        new BitbucketUser(
+            "User User", "user-name", 32423523, "NORMAL", true, "user-slug", "user@users.com");
     bitbucketPersonalAccessToken =
         new BitbucketPersonalAccessToken(
             234234,
@@ -153,6 +156,12 @@ public class BitbucketServerPersonalAccessTokenFetcherTest {
     PersonalAccessToken result = fetcher.fetchPersonalAccessToken(subject, someBitbucketURL);
     // then
     assertNotNull(result);
+    assertEquals(result.getScmProviderUrl(), someBitbucketURL);
+    assertEquals(result.getCheUserId(), subject.getUserId());
+    assertEquals(result.getScmOrganization(), bitbucketUser.getName());
+    assertEquals(result.getScmUserName(), bitbucketUser.getSlug());
+    assertEquals(result.getScmTokenId(), valueOf(bitbucketPersonalAccessToken.getId()));
+    assertEquals(result.getToken(), bitbucketPersonalAccessToken.getToken());
   }
 
   @Test


### PR DESCRIPTION

<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests
-->

### What does this PR do?
Pass user neme instead of user id when creating a PAT secret for bitbucket-server in order to fix the generation of the`git-credentials-secret` secret which requires the user name: `https://<user name>:<token>@<host name>`.

### Screenshot/screencast of this PR
<!-- Please include a screenshot or a screencast explaining what is doing this PR -->


### What issues does this PR fix or reference?
<!-- Please include any related issue from eclipse che repository (or from another issue tracker).
     Include link to other pull requests like documentation PR from [the docs repo](https://github.com/eclipse/che-docs)
-->
https://github.com/eclipse/che/issues/22199

### How to test this PR?
<!-- Please explain for example :
  - The test platform (openshift, kubernetes, minikube, CodeReady Container, docker-desktop, etc)
  - Installation method: chectl / che-operator
  - steps to reproduce
 -->
1. Deploy Che using the PR image: `chectl server:deploy -p=openshift -i=quay.io/ivinokur/che-server:next`
2. Apply [bitbucket server oAuth secret](https://www.eclipse.org/che/docs/stable/administration-guide/configuring-oauth-2-for-a-bitbucket-server/)
3. Start a workspace from the bitbucket-server instance repo
See workspace starts and the project is cloned successfully.

### PR Checklist

[As the author of this Pull Request I made sure that:](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#pull-request-template-and-its-checklist)

- [x] [The Eclipse Contributor Agreement is valid](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-eclipse-contributor-agreement-is-valid)
- [ ] [Code produced is complete](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-produced-is-complete)
- [x] [Code builds without errors](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-builds-without-errors)
- [x] [Tests are covering the bugfix](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#tests-are-covering-the-bugfix)
- [ ] [The repository devfile is up to date and works](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-repository-devfile-is-up-to-date-and-works)
- [x] [Sections `What issues does this PR fix or reference` and `How to test this PR` completed](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#sections-what-issues-does-this-pr-fix-or-reference-and-how-to-test-this-pr-completed)
- [ ] [Relevant user documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [Relevant contributing documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [CI/CD changes implemented, documented and communicated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#cicd-changes-implemented-documented-and-communicated)

### Reviewers

Reviewers, please comment how you tested the PR when approving it.
