### PR TITLE
Omit extracting subfolder from a workspace URL

### DIFF
--- a/wsmaster/che-core-api-factory-github/src/main/java/org/eclipse/che/api/factory/server/github/GithubSourceStorageBuilder.java
+++ b/wsmaster/che-core-api-factory-github/src/main/java/org/eclipse/che/api/factory/server/github/GithubSourceStorageBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012-2021 Red Hat, Inc.
+ * Copyright (c) 2012-2023 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/
@@ -13,7 +13,6 @@ package org.eclipse.che.api.factory.server.github;
 
 import static org.eclipse.che.dto.server.DtoFactory.newDto;
 
-import com.google.common.base.Strings;
 import java.util.HashMap;
 import java.util.Map;
 import javax.inject.Singleton;
@@ -40,9 +39,6 @@ public class GithubSourceStorageBuilder {
     Map<String, String> parameters = new HashMap<>(2);
     parameters.put("branch", githubUrl.getBranch());
 
-    if (!Strings.isNullOrEmpty(githubUrl.getSubfolder())) {
-      parameters.put("keepDir", githubUrl.getSubfolder());
-    }
     return newDto(SourceStorageDto.class)
         .withLocation(githubUrl.repositoryLocation())
         .withType("github")
@@ -59,7 +55,6 @@ public class GithubSourceStorageBuilder {
     return newDto(SourceDto.class)
         .withLocation(githubUrl.repositoryLocation())
         .withType("github")
-        .withBranch(githubUrl.getBranch())
-        .withSparseCheckoutDir(githubUrl.getSubfolder());
+        .withBranch(githubUrl.getBranch());
   }
 }

--- a/wsmaster/che-core-api-factory-github/src/main/java/org/eclipse/che/api/factory/server/github/GithubURLParser.java
+++ b/wsmaster/che-core-api-factory-github/src/main/java/org/eclipse/che/api/factory/server/github/GithubURLParser.java
@@ -104,15 +104,15 @@ public class GithubURLParser {
   }
 
   public boolean isValid(@NotNull String url) {
-    return githubPattern.matcher(url).matches();
+    return githubPattern.matcher(trimEnd(url, '/')).matches();
   }
 
   public GithubUrl parseWithoutAuthentication(String url) throws ApiException {
-    return parse(url, false);
+    return parse(trimEnd(url, '/'), false);
   }
 
   public GithubUrl parse(String url) throws ApiException {
-    return parse(url, true);
+    return parse(trimEnd(url, '/'), true);
   }
 
   private GithubUrl parse(String url, boolean authenticationRequired) throws ApiException {

--- a/wsmaster/che-core-api-factory-github/src/main/java/org/eclipse/che/api/factory/server/github/GithubURLParser.java
+++ b/wsmaster/che-core-api-factory-github/src/main/java/org/eclipse/che/api/factory/server/github/GithubURLParser.java
@@ -99,7 +99,7 @@ public class GithubURLParser {
     this.githubPattern =
         compile(
             format(
-                "^%s/(?<repoUser>[^/]++)/(?<repoName>[^/]++)((/)|(?:/tree/(?<branchName>[^/]++)(?:/(?<subFolder>.*))?)|(/pull/(?<pullRequestId>[^/]++)))?$",
+                "^%s/(?<repoUser>[^/]+)/(?<repoName>[^/]++)((/)|(?:/tree/(?<branchName>.++))|(/pull/(?<pullRequestId>\\d++)))?$",
                 endpoint));
   }
 
@@ -173,7 +173,6 @@ public class GithubURLParser {
         .withDisableSubdomainIsolation(disableSubdomainIsolation)
         .withBranch(branchName)
         .withLatestCommit(latestCommit)
-        .withSubfolder(matcher.group("subFolder"))
         .withDevfileFilenames(devfileFilenamesProvider.getConfiguredDevfileFilenames())
         .withUrl(url);
   }

--- a/wsmaster/che-core-api-factory-github/src/main/java/org/eclipse/che/api/factory/server/github/GithubUrl.java
+++ b/wsmaster/che-core-api-factory-github/src/main/java/org/eclipse/che/api/factory/server/github/GithubUrl.java
@@ -46,9 +46,6 @@ public class GithubUrl extends DefaultFactoryUrl {
   /** SHA of the latest commit in the current branch */
   private String latestCommit;
 
-  /** Subfolder if any */
-  private String subfolder;
-
   private String serverUrl;
 
   private boolean disableSubdomainIsolation;
@@ -140,26 +137,6 @@ public class GithubUrl extends DefaultFactoryUrl {
     if (!isNullOrEmpty(latestCommit)) {
       this.latestCommit = latestCommit;
     }
-    return this;
-  }
-
-  /**
-   * Gets subfolder of this github url
-   *
-   * @return the subfolder part
-   */
-  public String getSubfolder() {
-    return this.subfolder;
-  }
-
-  /**
-   * Sets the subfolder represented by the URL.
-   *
-   * @param subfolder path inside the repository
-   * @return current github instance
-   */
-  protected GithubUrl withSubfolder(String subfolder) {
-    this.subfolder = subfolder;
     return this;
   }
 

--- a/wsmaster/che-core-api-factory-github/src/test/java/org/eclipse/che/api/factory/server/github/GithubURLParserTest.java
+++ b/wsmaster/che-core-api-factory-github/src/test/java/org/eclipse/che/api/factory/server/github/GithubURLParserTest.java
@@ -127,7 +127,13 @@ public class GithubURLParserTest {
       {"https://github.com/eclipse/che/", "eclipse", "che", null},
       {"https://github.com/eclipse/repositorygit", "eclipse", "repositorygit", null},
       {"https://github.com/eclipse/che/tree/4.2.x", "eclipse", "che", "4.2.x"},
-      {"https://github.com/eclipse/che/tree/master", "eclipse", "che", "master"}
+      {"https://github.com/eclipse/che/tree/master", "eclipse", "che", "master"},
+      {
+        "https://github.com/eclipse/che/tree/branch/with/slash",
+        "eclipse",
+        "che",
+        "branch/with/slash"
+      }
     };
   }
 

--- a/wsmaster/che-core-api-factory-github/src/test/java/org/eclipse/che/api/factory/server/github/GithubURLParserTest.java
+++ b/wsmaster/che-core-api-factory-github/src/test/java/org/eclipse/che/api/factory/server/github/GithubURLParserTest.java
@@ -76,15 +76,13 @@ public class GithubURLParserTest {
 
   /** Compare parsing */
   @Test(dataProvider = "parsing")
-  public void checkParsing(
-      String url, String username, String repository, String branch, String subfolder)
+  public void checkParsing(String url, String username, String repository, String branch)
       throws ApiException {
     GithubUrl githubUrl = githubUrlParser.parse(url);
 
     assertEquals(githubUrl.getUsername(), username);
     assertEquals(githubUrl.getRepository(), repository);
     assertEquals(githubUrl.getBranch(), branch);
-    assertEquals(githubUrl.getSubfolder(), subfolder);
   }
 
   /** Compare parsing */
@@ -117,32 +115,19 @@ public class GithubURLParserTest {
   @DataProvider(name = "parsing")
   public Object[][] expectedParsing() {
     return new Object[][] {
-      {"https://github.com/eclipse/che", "eclipse", "che", null, null},
-      {"https://github.com/eclipse/che123", "eclipse", "che123", null, null},
-      {"https://github.com/eclipse/che.git", "eclipse", "che", null, null},
-      {"https://github.com/eclipse/che.with.dot.git", "eclipse", "che.with.dot", null, null},
-      {"https://github.com/eclipse/-.git", "eclipse", "-", null, null},
-      {"https://github.com/eclipse/-j.git", "eclipse", "-j", null, null},
-      {"https://github.com/eclipse/-", "eclipse", "-", null, null},
-      {"https://github.com/eclipse/che-with-hyphen", "eclipse", "che-with-hyphen", null, null},
-      {"https://github.com/eclipse/che-with-hyphen.git", "eclipse", "che-with-hyphen", null, null},
-      {"https://github.com/eclipse/che/", "eclipse", "che", null, null},
-      {"https://github.com/eclipse/repositorygit", "eclipse", "repositorygit", null, null},
-      {"https://github.com/eclipse/che/tree/4.2.x", "eclipse", "che", "4.2.x", null},
-      {
-        "https://github.com/eclipse/che/tree/master/dashboard/",
-        "eclipse",
-        "che",
-        "master",
-        "dashboard/"
-      },
-      {
-        "https://github.com/eclipse/che/tree/master/plugins/plugin-git/che-plugin-git-ext-git",
-        "eclipse",
-        "che",
-        "master",
-        "plugins/plugin-git/che-plugin-git-ext-git"
-      }
+      {"https://github.com/eclipse/che", "eclipse", "che", null},
+      {"https://github.com/eclipse/che123", "eclipse", "che123", null},
+      {"https://github.com/eclipse/che.git", "eclipse", "che", null},
+      {"https://github.com/eclipse/che.with.dot.git", "eclipse", "che.with.dot", null},
+      {"https://github.com/eclipse/-.git", "eclipse", "-", null},
+      {"https://github.com/eclipse/-j.git", "eclipse", "-j", null},
+      {"https://github.com/eclipse/-", "eclipse", "-", null},
+      {"https://github.com/eclipse/che-with-hyphen", "eclipse", "che-with-hyphen", null},
+      {"https://github.com/eclipse/che-with-hyphen.git", "eclipse", "che-with-hyphen", null},
+      {"https://github.com/eclipse/che/", "eclipse", "che", null},
+      {"https://github.com/eclipse/repositorygit", "eclipse", "repositorygit", null},
+      {"https://github.com/eclipse/che/tree/4.2.x", "eclipse", "che", "4.2.x"},
+      {"https://github.com/eclipse/che/tree/master", "eclipse", "che", "master"}
     };
   }
 

--- a/wsmaster/che-core-api-factory-gitlab/src/main/java/org/eclipse/che/api/factory/server/gitlab/GitlabFactoryParametersResolver.java
+++ b/wsmaster/che-core-api-factory-gitlab/src/main/java/org/eclipse/che/api/factory/server/gitlab/GitlabFactoryParametersResolver.java
@@ -136,8 +136,7 @@ public class GitlabFactoryParametersResolver extends RawDevfileUrlFactoryParamet
                       newDto(SourceDto.class)
                           .withLocation(gitlabUrl.repositoryLocation())
                           .withType("git")
-                          .withBranch(gitlabUrl.getBranch())
-                          .withSparseCheckoutDir(gitlabUrl.getSubfolder()))
+                          .withBranch(gitlabUrl.getBranch()))
                   .withName(gitlabUrl.getProject()),
           project -> {
             final String location = project.getSource().getLocation();

--- a/wsmaster/che-core-api-factory-gitlab/src/main/java/org/eclipse/che/api/factory/server/gitlab/GitlabUrl.java
+++ b/wsmaster/che-core-api-factory-gitlab/src/main/java/org/eclipse/che/api/factory/server/gitlab/GitlabUrl.java
@@ -49,9 +49,6 @@ public class GitlabUrl extends DefaultFactoryUrl {
   /** Branch name */
   private String branch;
 
-  /** Subfolder if any */
-  private String subfolder;
-
   /** Devfile filenames list */
   private final List<String> devfileFilenames = new ArrayList<>();
 
@@ -126,26 +123,6 @@ public class GitlabUrl extends DefaultFactoryUrl {
     if (!Strings.isNullOrEmpty(branch)) {
       this.branch = branch;
     }
-    return this;
-  }
-
-  /**
-   * Gets subfolder of this gitlab url
-   *
-   * @return the subfolder part
-   */
-  public String getSubfolder() {
-    return this.subfolder;
-  }
-
-  /**
-   * Sets the subfolder represented by the URL.
-   *
-   * @param subfolder path inside the repository
-   * @return current gitlab URL instance
-   */
-  protected GitlabUrl withSubfolder(String subfolder) {
-    this.subfolder = subfolder;
     return this;
   }
 

--- a/wsmaster/che-core-api-factory-gitlab/src/main/java/org/eclipse/che/api/factory/server/gitlab/GitlabUrlParser.java
+++ b/wsmaster/che-core-api-factory-gitlab/src/main/java/org/eclipse/che/api/factory/server/gitlab/GitlabUrlParser.java
@@ -93,7 +93,8 @@ public class GitlabUrlParser {
   }
 
   public boolean isValid(@NotNull String url) {
-    return gitlabUrlPatterns.stream().anyMatch(pattern -> pattern.matcher(url).matches())
+    return gitlabUrlPatterns.stream()
+            .anyMatch(pattern -> pattern.matcher(trimEnd(url, '/')).matches())
         // If the Gitlab URL is not configured, try to find it in a manually added user namespace
         // token.
         || isUserTokenPresent(url)
@@ -144,15 +145,15 @@ public class GitlabUrlParser {
    * {@link GitlabUrl} objects.
    */
   public GitlabUrl parse(String url) {
-
+    String trimmedUrl = trimEnd(url, '/');
     Optional<Matcher> matcherOptional =
         gitlabUrlPatterns.stream()
-            .map(pattern -> pattern.matcher(url))
+            .map(pattern -> pattern.matcher(trimmedUrl))
             .filter(Matcher::matches)
             .findFirst()
-            .or(() -> getPatternMatcherByUrl(url));
+            .or(() -> getPatternMatcherByUrl(trimmedUrl));
     if (matcherOptional.isPresent()) {
-      return parse(matcherOptional.get()).withUrl(url);
+      return parse(matcherOptional.get()).withUrl(trimmedUrl);
     } else {
       throw new UnsupportedOperationException(
           "The gitlab integration is not configured properly and cannot be used at this moment."

--- a/wsmaster/che-core-api-factory-gitlab/src/main/java/org/eclipse/che/api/factory/server/gitlab/GitlabUrlParser.java
+++ b/wsmaster/che-core-api-factory-gitlab/src/main/java/org/eclipse/che/api/factory/server/gitlab/GitlabUrlParser.java
@@ -46,7 +46,7 @@ public class GitlabUrlParser {
   private final PersonalAccessTokenManager personalAccessTokenManager;
   private static final List<String> gitlabUrlPatternTemplates =
       List.of(
-          "^(?<host>%s)/(?<subgroups>([^/]++/?)+)/-/tree/(?<branch>[^/]++)(/)?(?<subfolder>[^/]++)?",
+          "^(?<host>%s)/(?<subgroups>([^/]++/?)+)/-/tree/(?<branch>.++)(/)?",
           "^(?<host>%s)/(?<subgroups>.*)"); // a wider one, should be the last in the
   // list
   private final List<Pattern> gitlabUrlPatterns = new ArrayList<>();
@@ -168,14 +168,8 @@ public class GitlabUrlParser {
     }
 
     String branch = null;
-    String subfolder = null;
     try {
       branch = matcher.group("branch");
-    } catch (IllegalArgumentException e) {
-      // ok no such group
-    }
-    try {
-      subfolder = matcher.group("subfolder");
     } catch (IllegalArgumentException e) {
       // ok no such group
     }
@@ -184,7 +178,6 @@ public class GitlabUrlParser {
         .withHostName(host)
         .withSubGroups(subGroups)
         .withBranch(branch)
-        .withSubfolder(subfolder)
         .withDevfileFilenames(devfileFilenamesProvider.getConfiguredDevfileFilenames());
   }
 }

--- a/wsmaster/che-core-api-factory-gitlab/src/test/java/org/eclipse/che/api/factory/server/gitlab/GitlabUrlParserTest.java
+++ b/wsmaster/che-core-api-factory-gitlab/src/test/java/org/eclipse/che/api/factory/server/gitlab/GitlabUrlParserTest.java
@@ -71,14 +71,12 @@ public class GitlabUrlParserTest {
 
   /** Compare parsing */
   @Test(dataProvider = "parsing")
-  public void checkParsing(
-      String url, String project, String subGroups, String branch, String subfolder) {
+  public void checkParsing(String url, String project, String subGroups, String branch) {
     GitlabUrl gitlabUrl = gitlabUrlParser.parse(url);
 
     assertEquals(gitlabUrl.getProject(), project);
     assertEquals(gitlabUrl.getSubGroups(), subGroups);
     assertEquals(gitlabUrl.getBranch(), branch);
-    assertEquals(gitlabUrl.getSubfolder(), subfolder);
   }
 
   @Test
@@ -123,33 +121,28 @@ public class GitlabUrlParserTest {
   @DataProvider(name = "parsing")
   public Object[][] expectedParsing() {
     return new Object[][] {
-      {"https://gitlab1.com/user/project1.git", "project1", "user/project1", null, null},
-      {"https://gitlab1.com/user/project/test1.git", "test1", "user/project/test1", null, null},
+      {"https://gitlab1.com/user/project1.git", "project1", "user/project1", null},
+      {"https://gitlab1.com/user/project/test1.git", "test1", "user/project/test1", null},
       {
         "https://gitlab1.com/user/project/group1/group2/test1.git",
         "test1",
         "user/project/group1/group2/test1",
-        null,
         null
       },
-      {"https://gitlab1.com/user/project/", "project", "user/project", null, null},
-      {"https://gitlab1.com/user/project/repo/", "repo", "user/project/repo", null, null},
-      {
-        "https://gitlab1.com/user/project/-/tree/master/", "project", "user/project", "master", null
-      },
+      {"https://gitlab1.com/user/project/", "project", "user/project", null},
+      {"https://gitlab1.com/user/project/repo/", "repo", "user/project/repo", null},
+      {"https://gitlab1.com/user/project/-/tree/master/", "project", "user/project", "master"},
       {
         "https://gitlab1.com/user/project/repo/-/tree/foo/subfolder",
         "repo",
         "user/project/repo",
-        "foo",
-        "subfolder"
+        "foo"
       },
       {
         "https://gitlab1.com/user/project/group1/group2/repo/-/tree/foo/subfolder",
         "repo",
         "user/project/group1/group2/repo",
-        "foo",
-        "subfolder"
+        "foo"
       }
     };
   }

--- a/wsmaster/che-core-api-factory-gitlab/src/test/java/org/eclipse/che/api/factory/server/gitlab/GitlabUrlParserTest.java
+++ b/wsmaster/che-core-api-factory-gitlab/src/test/java/org/eclipse/che/api/factory/server/gitlab/GitlabUrlParserTest.java
@@ -134,6 +134,12 @@ public class GitlabUrlParserTest {
       {"https://gitlab1.com/user/project/-/tree/master/", "project", "user/project", "master"},
       {"https://gitlab1.com/user/project/repo/-/tree/foo", "repo", "user/project/repo", "foo"},
       {
+        "https://gitlab1.com/user/project/repo/-/tree/branch/with/slash",
+        "repo",
+        "user/project/repo",
+        "branch/with/slash"
+      },
+      {
         "https://gitlab1.com/user/project/group1/group2/repo/-/tree/foo/",
         "repo",
         "user/project/group1/group2/repo",

--- a/wsmaster/che-core-api-factory-gitlab/src/test/java/org/eclipse/che/api/factory/server/gitlab/GitlabUrlParserTest.java
+++ b/wsmaster/che-core-api-factory-gitlab/src/test/java/org/eclipse/che/api/factory/server/gitlab/GitlabUrlParserTest.java
@@ -132,14 +132,9 @@ public class GitlabUrlParserTest {
       {"https://gitlab1.com/user/project/", "project", "user/project", null},
       {"https://gitlab1.com/user/project/repo/", "repo", "user/project/repo", null},
       {"https://gitlab1.com/user/project/-/tree/master/", "project", "user/project", "master"},
+      {"https://gitlab1.com/user/project/repo/-/tree/foo", "repo", "user/project/repo", "foo"},
       {
-        "https://gitlab1.com/user/project/repo/-/tree/foo/subfolder",
-        "repo",
-        "user/project/repo",
-        "foo"
-      },
-      {
-        "https://gitlab1.com/user/project/group1/group2/repo/-/tree/foo/subfolder",
+        "https://gitlab1.com/user/project/group1/group2/repo/-/tree/foo/",
         "repo",
         "user/project/group1/group2/repo",
         "foo"

--- a/wsmaster/che-core-api-factory-gitlab/src/test/java/org/eclipse/che/api/factory/server/gitlab/GitlabUrlTest.java
+++ b/wsmaster/che-core-api-factory-gitlab/src/test/java/org/eclipse/che/api/factory/server/gitlab/GitlabUrlTest.java
@@ -85,10 +85,6 @@ public class GitlabUrlTest {
         "https://gitlab.net/eclipse/fooproj/che/-/tree/foobranch/",
         "https://gitlab.net/api/v4/projects/eclipse%%2Ffooproj%%2Fche/repository/files/%s/raw?ref=foobranch"
       },
-      {
-        "https://gitlab.net/eclipse/fooproj/che/-/tree/foobranch/subfolder",
-        "https://gitlab.net/api/v4/projects/eclipse%%2Ffooproj%%2Fche/repository/files/%s/raw?ref=foobranch"
-      },
     };
   }
 


### PR DESCRIPTION
<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests
-->

### What does this PR do?
`sparce-checkout`is no longer available from devfile 2.1, so omit the `subfolder` mechanism in order to support branch names with a `/` sign.

### Screenshot/screencast of this PR
<!-- Please include a screenshot or a screencast explaining what is doing this PR -->


### What issues does this PR fix or reference?
<!-- Please include any related issue from eclipse che repository (or from another issue tracker).
     Include link to other pull requests like documentation PR from [the docs repo](https://github.com/eclipse/che-docs)
-->
fixes https://github.com/eclipse/che/issues/21706

### How to test this PR?
<!-- Please explain for example :
  - The test platform (openshift, kubernetes, minikube, CodeReady Container, docker-desktop, etc)
  - Installation method: chectl / che-operator
  - steps to reproduce
 -->
1. Create branch with a `/` sign in GitHub or GitLab repo
2. Start a workspace from the branch URl

### PR Checklist

[As the author of this Pull Request I made sure that:](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#pull-request-template-and-its-checklist)

- [ ] [The Eclipse Contributor Agreement is valid](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-eclipse-contributor-agreement-is-valid)
- [ ] [Code produced is complete](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-produced-is-complete)
- [ ] [Code builds without errors](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-builds-without-errors)
- [ ] [Tests are covering the bugfix](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#tests-are-covering-the-bugfix)
- [ ] [The repository devfile is up to date and works](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-repository-devfile-is-up-to-date-and-works)
- [ ] [Sections `What issues does this PR fix or reference` and `How to test this PR` completed](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#sections-what-issues-does-this-pr-fix-or-reference-and-how-to-test-this-pr-completed)
- [ ] [Relevant user documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [Relevant contributing documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [CI/CD changes implemented, documented and communicated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#cicd-changes-implemented-documented-and-communicated)

### Reviewers

Reviewers, please comment how you tested the PR when approving it.
