### PR TITLE
Provision git credentials secrets on workspace start

### DIFF
--- a/.ci/openshift-ci/test-github-with-pat-setup-flow.sh
+++ b/.ci/openshift-ci/test-github-with-pat-setup-flow.sh
@@ -29,6 +29,7 @@ trap "catchFinish" EXIT SIGINT
 
 setupTestEnvironment ${OCP_NON_ADMIN_USER_NAME}
 setupPersonalAccessToken  ${GIT_PROVIDER_TYPE} ${GIT_PROVIDER_URL} ${GITHUB_USER_ID} ${GITHUB_PAT}
+requestProvisionNamespace
 testFactoryResolverWithPatOAuth ${PUBLIC_REPO_URL} ${PRIVATE_REPO_URL}
 echo "[INFO] Check clone public repository with PAT setup"
 testCloneGitRepoWithSetupPat ${PUBLIC_REPO_WORKSPACE_NAME} ${PUBLIC_PROJECT_NAME} ${PUBLIC_REPO_URL} ${USER_CHE_NAMESPACE} ${GITHUB_PAT}

--- a/.ci/openshift-ci/test-gitlab-with-pat-setup-flow.sh
+++ b/.ci/openshift-ci/test-gitlab-with-pat-setup-flow.sh
@@ -29,6 +29,7 @@ trap "catchFinish" EXIT SIGINT
 
 setupTestEnvironment ${OCP_NON_ADMIN_USER_NAME}
 setupPersonalAccessToken  ${GIT_PROVIDER_TYPE} ${GIT_PROVIDER_URL} ${GITLAB_USER_ID} ${GITLAB_PAT}
+requestProvisionNamespace
 testFactoryResolverWithPatOAuth ${PUBLIC_REPO_URL} ${PRIVATE_REPO_URL}
 echo "[INFO] Check clone public repository with PAT setup"
 testCloneGitRepoWithSetupPat ${PUBLIC_REPO_WORKSPACE_NAME} ${PUBLIC_PROJECT_NAME} ${PUBLIC_REPO_URL} ${USER_CHE_NAMESPACE} ${GITLAB_PAT}

--- a/infrastructures/infrastructure-factory/src/main/java/org/eclipse/che/api/factory/server/scm/kubernetes/KubernetesPersonalAccessTokenManager.java
+++ b/infrastructures/infrastructure-factory/src/main/java/org/eclipse/che/api/factory/server/scm/kubernetes/KubernetesPersonalAccessTokenManager.java
@@ -153,7 +153,6 @@ public class KubernetesPersonalAccessTokenManager implements PersonalAccessToken
           UnsatisfiedScmPreconditionException {
     Subject subject = EnvironmentContext.getCurrent().getSubject();
     Optional<PersonalAccessToken> tokenOptional = get(subject, scmServerUrl);
-    PersonalAccessToken personalAccessToken;
     if (tokenOptional.isPresent()) {
       return tokenOptional.get();
     } else {

--- a/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/namespace/configurator/CredentialsSecretConfigurator.java
+++ b/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/namespace/configurator/CredentialsSecretConfigurator.java
@@ -11,12 +11,18 @@
  */
 package org.eclipse.che.workspace.infrastructure.kubernetes.namespace.configurator;
 
-import static org.eclipse.che.workspace.infrastructure.kubernetes.namespace.AbstractWorkspaceServiceAccount.CREDENTIALS_SECRET_NAME;
-
+import com.google.common.collect.ImmutableMap;
 import io.fabric8.kubernetes.api.model.Secret;
-import io.fabric8.kubernetes.api.model.SecretBuilder;
+import java.util.Base64;
+import java.util.Map;
+import java.util.Optional;
 import javax.inject.Inject;
 import javax.inject.Singleton;
+import org.eclipse.che.api.factory.server.scm.PersonalAccessTokenManager;
+import org.eclipse.che.api.factory.server.scm.exception.ScmCommunicationException;
+import org.eclipse.che.api.factory.server.scm.exception.ScmConfigurationPersistenceException;
+import org.eclipse.che.api.factory.server.scm.exception.ScmUnauthorizedException;
+import org.eclipse.che.api.factory.server.scm.exception.UnsatisfiedScmPreconditionException;
 import org.eclipse.che.api.workspace.server.spi.InfrastructureException;
 import org.eclipse.che.api.workspace.server.spi.NamespaceResolutionContext;
 import org.eclipse.che.workspace.infrastructure.kubernetes.CheServerKubernetesClientFactory;
@@ -30,27 +36,54 @@ import org.eclipse.che.workspace.infrastructure.kubernetes.CheServerKubernetesCl
 public class CredentialsSecretConfigurator implements NamespaceConfigurator {
 
   private final CheServerKubernetesClientFactory cheServerKubernetesClientFactory;
+  private final PersonalAccessTokenManager personalAccessTokenManager;
+
+  private static final Map<String, String> SEARCH_LABELS =
+      ImmutableMap.of(
+          "app.kubernetes.io/part-of", "che.eclipse.org",
+          "app.kubernetes.io/component", "scm-personal-access-token");
+  private static final String ANNOTATION_SCM_URL = "che.eclipse.org/scm-url";
+  private static final String MERGED_GIT_CREDENTIALS_SECRET_NAME =
+      "devworkspace-merged-git-credentials";
 
   @Inject
   public CredentialsSecretConfigurator(
-      CheServerKubernetesClientFactory cheServerKubernetesClientFactory) {
+      CheServerKubernetesClientFactory cheServerKubernetesClientFactory,
+      PersonalAccessTokenManager personalAccessTokenManager) {
     this.cheServerKubernetesClientFactory = cheServerKubernetesClientFactory;
+    this.personalAccessTokenManager = personalAccessTokenManager;
   }
 
   @Override
   public void configure(NamespaceResolutionContext namespaceResolutionContext, String namespaceName)
       throws InfrastructureException {
     var client = cheServerKubernetesClientFactory.create();
-    if (client.secrets().inNamespace(namespaceName).withName(CREDENTIALS_SECRET_NAME).get()
-        == null) {
-      Secret secret =
-          new SecretBuilder()
-              .withType("opaque")
-              .withNewMetadata()
-              .withName(CREDENTIALS_SECRET_NAME)
-              .endMetadata()
-              .build();
-      client.secrets().inNamespace(namespaceName).create(secret);
-    }
+    Optional<Secret> mergedCredentialsSecret =
+        client.secrets().inNamespace(namespaceName).list().getItems().stream()
+            .filter(s -> s.getMetadata().getName().equals(MERGED_GIT_CREDENTIALS_SECRET_NAME))
+            .findAny();
+
+    client.secrets().inNamespace(namespaceName).withLabels(SEARCH_LABELS).list().getItems().stream()
+        .filter(
+            s ->
+                mergedCredentialsSecret.isEmpty()
+                    || !getCredentialsData(mergedCredentialsSecret.get(), "credentials")
+                        .contains(getCredentialsData(s, "token")))
+        .forEach(
+            s -> {
+              try {
+                personalAccessTokenManager.store(
+                    s.getMetadata().getAnnotations().get(ANNOTATION_SCM_URL));
+              } catch (ScmCommunicationException
+                  | ScmConfigurationPersistenceException
+                  | UnsatisfiedScmPreconditionException
+                  | ScmUnauthorizedException e) {
+                throw new RuntimeException(e);
+              }
+            });
+  }
+
+  private String getCredentialsData(Secret secret, String key) {
+    return new String(Base64.getDecoder().decode(secret.getData().get(key).getBytes()));
   }
 }

--- a/infrastructures/kubernetes/src/test/java/org/eclipse/che/workspace/infrastructure/kubernetes/namespace/KubernetesNamespaceFactoryTest.java
+++ b/infrastructures/kubernetes/src/test/java/org/eclipse/che/workspace/infrastructure/kubernetes/namespace/KubernetesNamespaceFactoryTest.java
@@ -87,7 +87,6 @@ import org.eclipse.che.inject.ConfigurationException;
 import org.eclipse.che.workspace.infrastructure.kubernetes.CheServerKubernetesClientFactory;
 import org.eclipse.che.workspace.infrastructure.kubernetes.api.server.impls.KubernetesNamespaceMetaImpl;
 import org.eclipse.che.workspace.infrastructure.kubernetes.api.shared.KubernetesNamespaceMeta;
-import org.eclipse.che.workspace.infrastructure.kubernetes.namespace.configurator.CredentialsSecretConfigurator;
 import org.eclipse.che.workspace.infrastructure.kubernetes.namespace.configurator.NamespaceConfigurator;
 import org.eclipse.che.workspace.infrastructure.kubernetes.namespace.configurator.PreferencesConfigMapConfigurator;
 import org.eclipse.che.workspace.infrastructure.kubernetes.namespace.configurator.WorkspaceServiceAccountConfigurator;
@@ -449,43 +448,6 @@ public class KubernetesNamespaceFactoryTest {
         defaultNamespace
             .getAttributes()
             .get(PHASE_ATTRIBUTE)); // no phase - means such namespace does not exist
-  }
-
-  @Test
-  public void shouldCreateCredentialsSecretIfNotExists() throws Exception {
-    // given
-    namespaceFactory =
-        spy(
-            new KubernetesNamespaceFactory(
-                "<username>-che",
-                true,
-                true,
-                true,
-                NAMESPACE_LABELS,
-                NAMESPACE_ANNOTATIONS,
-                Set.of(new CredentialsSecretConfigurator(cheServerKubernetesClientFactory)),
-                cheServerKubernetesClientFactory,
-                preferenceManager,
-                pool));
-    KubernetesNamespace toReturnNamespace = mock(KubernetesNamespace.class);
-    when(toReturnNamespace.getName()).thenReturn("namespaceName");
-    doReturn(toReturnNamespace).when(namespaceFactory).doCreateNamespaceAccess(any(), any());
-    MixedOperation mixedOperation = mock(MixedOperation.class);
-    when(k8sClient.secrets()).thenReturn(mixedOperation);
-    when(mixedOperation.inNamespace(anyString())).thenReturn(namespaceOperation);
-    when(namespaceResource.get()).thenReturn(null);
-
-    // when
-    RuntimeIdentity identity =
-        new RuntimeIdentityImpl("workspace123", null, USER_ID, "workspace123");
-    namespaceFactory.getOrCreate(identity);
-
-    // then
-    ArgumentCaptor<Secret> secretsCaptor = ArgumentCaptor.forClass(Secret.class);
-    verify(namespaceOperation).create(secretsCaptor.capture());
-    Secret secret = secretsCaptor.getValue();
-    Assert.assertEquals(secret.getMetadata().getName(), CREDENTIALS_SECRET_NAME);
-    Assert.assertEquals(secret.getType(), "opaque");
   }
 
   @Test

--- a/infrastructures/kubernetes/src/test/java/org/eclipse/che/workspace/infrastructure/kubernetes/namespace/configurator/CredentialsSecretConfiguratorTest.java
+++ b/infrastructures/kubernetes/src/test/java/org/eclipse/che/workspace/infrastructure/kubernetes/namespace/configurator/CredentialsSecretConfiguratorTest.java
@@ -11,20 +11,25 @@
  */
 package org.eclipse.che.workspace.infrastructure.kubernetes.namespace.configurator;
 
-import static org.eclipse.che.workspace.infrastructure.kubernetes.namespace.AbstractWorkspaceServiceAccount.CREDENTIALS_SECRET_NAME;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import com.google.common.collect.ImmutableMap;
 import io.fabric8.kubernetes.api.model.SecretBuilder;
 import io.fabric8.kubernetes.client.KubernetesClient;
 import io.fabric8.kubernetes.client.server.mock.KubernetesServer;
+import java.util.Base64;
 import java.util.Map;
+import org.eclipse.che.api.factory.server.scm.PersonalAccessTokenManager;
 import org.eclipse.che.api.workspace.server.spi.InfrastructureException;
 import org.eclipse.che.api.workspace.server.spi.NamespaceResolutionContext;
 import org.eclipse.che.workspace.infrastructure.kubernetes.CheServerKubernetesClientFactory;
 import org.mockito.Mock;
 import org.mockito.testng.MockitoTestNGListener;
-import org.testng.Assert;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Listeners;
 import org.testng.annotations.Test;
@@ -35,6 +40,7 @@ public class CredentialsSecretConfiguratorTest {
   private NamespaceConfigurator configurator;
 
   @Mock private CheServerKubernetesClientFactory cheServerKubernetesClientFactory;
+  @Mock private PersonalAccessTokenManager personalAccessTokenManager;
   private KubernetesServer serverMock;
 
   private NamespaceResolutionContext namespaceResolutionContext;
@@ -42,10 +48,20 @@ public class CredentialsSecretConfiguratorTest {
   private final String TEST_WORKSPACE_ID = "workspace123";
   private final String TEST_USER_ID = "user123";
   private final String TEST_USERNAME = "jondoe";
+  private final String PAT_SECRET_NAME = "personal-access-token-1";
+  private static final String MERGED_GIT_CREDENTIALS_SECRET_NAME =
+      "devworkspace-merged-git-credentials";
+
+  private static final Map<String, String> SEARCH_LABELS =
+      ImmutableMap.of(
+          "app.kubernetes.io/part-of", "che.eclipse.org",
+          "app.kubernetes.io/component", "scm-personal-access-token");
 
   @BeforeMethod
   public void setUp() throws InfrastructureException {
-    configurator = new CredentialsSecretConfigurator(cheServerKubernetesClientFactory);
+    configurator =
+        new CredentialsSecretConfigurator(
+            cheServerKubernetesClientFactory, personalAccessTokenManager);
 
     serverMock = new KubernetesServer(true, true);
     serverMock.before();
@@ -57,28 +73,8 @@ public class CredentialsSecretConfiguratorTest {
   }
 
   @Test
-  public void createCredentialsSecretWhenDoesNotExist()
-      throws InfrastructureException, InterruptedException {
-    // given - clean env
-
-    // when
-    configurator.configure(namespaceResolutionContext, TEST_NAMESPACE_NAME);
-
-    // then create a secret
-    Assert.assertEquals(serverMock.getLastRequest().getMethod(), "POST");
-    Assert.assertNotNull(
-        serverMock
-            .getClient()
-            .secrets()
-            .inNamespace(TEST_NAMESPACE_NAME)
-            .withName(CREDENTIALS_SECRET_NAME)
-            .get());
-  }
-
-  @Test
-  public void doNothingWhenSecretAlreadyExists()
-      throws InfrastructureException, InterruptedException {
-    // given - secret already exists
+  public void shouldStorePersonalAccessToken() throws Exception {
+    // given
     serverMock
         .getClient()
         .secrets()
@@ -86,19 +82,53 @@ public class CredentialsSecretConfiguratorTest {
         .create(
             new SecretBuilder()
                 .withNewMetadata()
-                .withName(CREDENTIALS_SECRET_NAME)
-                .withAnnotations(Map.of("already", "created"))
+                .withName(PAT_SECRET_NAME)
+                .withLabels(SEARCH_LABELS)
+                .withAnnotations(Map.of("che.eclipse.org/scm-url", "test-url"))
                 .endMetadata()
                 .build());
-
     // when
     configurator.configure(namespaceResolutionContext, TEST_NAMESPACE_NAME);
 
-    // then - don't create the secret
-    Assert.assertEquals(serverMock.getLastRequest().getMethod(), "GET");
-    var secrets =
-        serverMock.getClient().secrets().inNamespace(TEST_NAMESPACE_NAME).list().getItems();
-    Assert.assertEquals(secrets.size(), 1);
-    Assert.assertEquals(secrets.get(0).getMetadata().getAnnotations().get("already"), "created");
+    // then
+    verify(personalAccessTokenManager).store(eq("test-url"));
+  }
+
+  @Test
+  public void doNothingWhenSecretAlreadyStored() throws Exception {
+    // given
+    serverMock
+        .getClient()
+        .secrets()
+        .inNamespace(TEST_NAMESPACE_NAME)
+        .create(
+            new SecretBuilder()
+                .withNewMetadata()
+                .withName(MERGED_GIT_CREDENTIALS_SECRET_NAME)
+                .endMetadata()
+                .withData(
+                    Map.of(
+                        "credentials", Base64.getEncoder().encodeToString("test-token".getBytes())))
+                .build());
+
+    serverMock
+        .getClient()
+        .secrets()
+        .inNamespace(TEST_NAMESPACE_NAME)
+        .create(
+            new SecretBuilder()
+                .withNewMetadata()
+                .withName(PAT_SECRET_NAME)
+                .withLabels(SEARCH_LABELS)
+                .withAnnotations(Map.of("che.eclipse.org/scm-url", "test-url"))
+                .endMetadata()
+                .withData(
+                    Map.of("token", Base64.getEncoder().encodeToString("test-token".getBytes())))
+                .build());
+    // when
+    configurator.configure(namespaceResolutionContext, TEST_NAMESPACE_NAME);
+
+    // then
+    verify(personalAccessTokenManager, never()).store(anyString());
   }
 }

--- a/wsmaster/che-core-api-factory-bitbucket-server/src/test/java/org/eclipse/che/api/factory/server/bitbucket/BitbucketServerAuthorizingFileContentProviderTest.java
+++ b/wsmaster/che-core-api-factory-bitbucket-server/src/test/java/org/eclipse/che/api/factory/server/bitbucket/BitbucketServerAuthorizingFileContentProviderTest.java
@@ -41,7 +41,7 @@ public class BitbucketServerAuthorizingFileContentProviderTest {
             url, urlFetcher, personalAccessTokenManager);
 
     PersonalAccessToken token = new PersonalAccessToken(TEST_HOSTNAME, "user1", "token");
-    when(personalAccessTokenManager.getAndStore(anyString())).thenReturn(token);
+    when(personalAccessTokenManager.get(anyString())).thenReturn(token);
 
     String fileURL = "https://foo.bar/scm/repo/.devfile";
 
@@ -60,7 +60,7 @@ public class BitbucketServerAuthorizingFileContentProviderTest {
             url, urlFetcher, personalAccessTokenManager);
 
     PersonalAccessToken token = new PersonalAccessToken(TEST_HOSTNAME, "user1", "token");
-    when(personalAccessTokenManager.getAndStore(eq(TEST_HOSTNAME))).thenReturn(token);
+    when(personalAccessTokenManager.get(eq(TEST_HOSTNAME))).thenReturn(token);
 
     String fileURL = "https://foo.bar/scm/repo/.devfile";
 
@@ -68,7 +68,7 @@ public class BitbucketServerAuthorizingFileContentProviderTest {
     fileContentProvider.fetchContent(fileURL);
 
     // then
-    verify(personalAccessTokenManager).getAndStore(eq(TEST_HOSTNAME));
+    verify(personalAccessTokenManager).get(eq(TEST_HOSTNAME));
     verify(urlFetcher).fetch(eq(fileURL), eq("Bearer token"));
   }
 
@@ -88,7 +88,7 @@ public class BitbucketServerAuthorizingFileContentProviderTest {
         new BitbucketServerAuthorizingFileContentProvider(
             url, urlFetcher, personalAccessTokenManager);
     PersonalAccessToken token = new PersonalAccessToken(TEST_HOSTNAME, "user1", "token");
-    when(personalAccessTokenManager.getAndStore(anyString())).thenReturn(token);
+    when(personalAccessTokenManager.get(anyString())).thenReturn(token);
 
     // when
     fileContentProvider.fetchContent(relative);

--- a/wsmaster/che-core-api-factory-bitbucket-server/src/test/java/org/eclipse/che/api/factory/server/bitbucket/BitbucketServerScmFileResolverTest.java
+++ b/wsmaster/che-core-api-factory-bitbucket-server/src/test/java/org/eclipse/che/api/factory/server/bitbucket/BitbucketServerScmFileResolverTest.java
@@ -73,7 +73,7 @@ public class BitbucketServerScmFileResolverTest {
   public void shouldReturnContentFromUrlFetcher() throws Exception {
     final String rawContent = "raw_content";
     final String filename = "devfile.yaml";
-    when(personalAccessTokenManager.getAndStore(anyString()))
+    when(personalAccessTokenManager.get(anyString()))
         .thenReturn(new PersonalAccessToken(SCM_URL, "root", "token123"));
 
     when(urlFetcher.fetch(anyString(), eq("Bearer token123"))).thenReturn(rawContent);
@@ -87,7 +87,7 @@ public class BitbucketServerScmFileResolverTest {
   @Test
   public void shouldFetchContentWithoutAuthentication() throws Exception {
     // given
-    when(personalAccessTokenManager.getAndStore(anyString()))
+    when(personalAccessTokenManager.get(anyString()))
         .thenThrow(new ScmUnauthorizedException("message", "bitbucket-server", "v1", "url"));
 
     // when

--- a/wsmaster/che-core-api-factory-github/src/test/java/org/eclipse/che/api/factory/server/github/GithubAuthorizingFileContentProviderTest.java
+++ b/wsmaster/che-core-api-factory-github/src/test/java/org/eclipse/che/api/factory/server/github/GithubAuthorizingFileContentProviderTest.java
@@ -54,7 +54,7 @@ public class GithubAuthorizingFileContentProviderTest {
     FileContentProvider fileContentProvider =
         new GithubAuthorizingFileContentProvider(githubUrl, urlFetcher, personalAccessTokenManager);
 
-    when(personalAccessTokenManager.getAndStore(anyString()))
+    when(personalAccessTokenManager.get(anyString()))
         .thenReturn(new PersonalAccessToken("foo", "che", "my-token"));
 
     fileContentProvider.fetchContent("devfile.yaml");
@@ -81,7 +81,7 @@ public class GithubAuthorizingFileContentProviderTest {
     FileContentProvider fileContentProvider =
         new GithubAuthorizingFileContentProvider(githubUrl, urlFetcher, personalAccessTokenManager);
 
-    when(personalAccessTokenManager.getAndStore(anyString()))
+    when(personalAccessTokenManager.get(anyString()))
         .thenReturn(new PersonalAccessToken(raw_url, "che", "my-token"));
 
     fileContentProvider.fetchContent(raw_url);
@@ -98,8 +98,7 @@ public class GithubAuthorizingFileContentProviderTest {
     FileContentProvider fileContentProvider =
         new GithubAuthorizingFileContentProvider(githubUrl, urlFetcher, personalAccessTokenManager);
 
-    when(personalAccessTokenManager.getAndStore(anyString()))
-        .thenThrow(UnknownScmProviderException.class);
+    when(personalAccessTokenManager.get(anyString())).thenThrow(UnknownScmProviderException.class);
 
     when(urlFetcher.fetch(eq(url))).thenThrow(FileNotFoundException.class);
 
@@ -115,8 +114,7 @@ public class GithubAuthorizingFileContentProviderTest {
     FileContentProvider fileContentProvider =
         new GithubAuthorizingFileContentProvider(githubUrl, urlFetcher, personalAccessTokenManager);
 
-    when(personalAccessTokenManager.getAndStore(anyString()))
-        .thenThrow(UnknownScmProviderException.class);
+    when(personalAccessTokenManager.get(anyString())).thenThrow(UnknownScmProviderException.class);
     when(urlFetcher.fetch(eq(url))).thenThrow(FileNotFoundException.class);
     when(urlFetcher.fetch(eq("https://github.com/eclipse/che"))).thenThrow(IOException.class);
 
@@ -132,7 +130,7 @@ public class GithubAuthorizingFileContentProviderTest {
     FileContentProvider fileContentProvider =
         new GithubAuthorizingFileContentProvider(githubUrl, urlFetcher, personalAccessTokenManager);
     var personalAccessToken = new PersonalAccessToken(raw_url, "che", "my-token");
-    when(personalAccessTokenManager.getAndStore(anyString())).thenReturn(personalAccessToken);
+    when(personalAccessTokenManager.get(anyString())).thenReturn(personalAccessToken);
 
     fileContentProvider.fetchContent(raw_url);
 

--- a/wsmaster/che-core-api-factory-github/src/test/java/org/eclipse/che/api/factory/server/github/GithubScmFileResolverTest.java
+++ b/wsmaster/che-core-api-factory-github/src/test/java/org/eclipse/che/api/factory/server/github/GithubScmFileResolverTest.java
@@ -14,6 +14,7 @@ package org.eclipse.che.api.factory.server.github;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -85,7 +86,8 @@ public class GithubScmFileResolverTest {
             anyString()))
         .thenReturn(rawContent);
 
-    when(personalAccessTokenManager.getAndStore(anyString()))
+    lenient()
+        .when(personalAccessTokenManager.get(anyString()))
         .thenReturn(new PersonalAccessToken("foo", "che", "my-token"));
 
     when(githubApiClient.getLatestCommit(anyString(), anyString(), anyString(), any()))
@@ -103,7 +105,8 @@ public class GithubScmFileResolverTest {
   @Test
   public void shouldReturnContentWithoutAuthentication() throws Exception {
     // given
-    when(personalAccessTokenManager.getAndStore(anyString()))
+    lenient()
+        .when(personalAccessTokenManager.get(anyString()))
         .thenThrow(new ScmUnauthorizedException("message", "github", "v1", "url"));
 
     // when

--- a/wsmaster/che-core-api-factory-gitlab/src/test/java/org/eclipse/che/api/factory/server/gitlab/GitlabAuthorizingFileContentProviderTest.java
+++ b/wsmaster/che-core-api-factory-gitlab/src/test/java/org/eclipse/che/api/factory/server/gitlab/GitlabAuthorizingFileContentProviderTest.java
@@ -37,7 +37,7 @@ public class GitlabAuthorizingFileContentProviderTest {
     FileContentProvider fileContentProvider =
         new GitlabAuthorizingFileContentProvider(gitlabUrl, urlFetcher, personalAccessTokenManager);
     var personalAccessToken = new PersonalAccessToken("foo", "che", "my-token");
-    when(personalAccessTokenManager.getAndStore(anyString())).thenReturn(personalAccessToken);
+    when(personalAccessTokenManager.get(anyString())).thenReturn(personalAccessToken);
     fileContentProvider.fetchContent("devfile.yaml");
     verify(urlFetcher)
         .fetch(
@@ -55,7 +55,7 @@ public class GitlabAuthorizingFileContentProviderTest {
     String url =
         "https://gitlab.net/api/v4/projects/eclipse%2Fche/repository/files/devfile.yaml/raw";
     var personalAccessToken = new PersonalAccessToken(url, "che", "my-token");
-    when(personalAccessTokenManager.getAndStore(anyString())).thenReturn(personalAccessToken);
+    when(personalAccessTokenManager.get(anyString())).thenReturn(personalAccessToken);
 
     fileContentProvider.fetchContent(url);
     verify(urlFetcher).fetch(eq(url), eq("Bearer my-token"));

--- a/wsmaster/che-core-api-factory-gitlab/src/test/java/org/eclipse/che/api/factory/server/gitlab/GitlabScmFileResolverTest.java
+++ b/wsmaster/che-core-api-factory-gitlab/src/test/java/org/eclipse/che/api/factory/server/gitlab/GitlabScmFileResolverTest.java
@@ -72,7 +72,7 @@ public class GitlabScmFileResolverTest {
   public void shouldReturnContentFromUrlFetcher() throws Exception {
     final String rawContent = "raw_content";
     final String filename = "devfile.yaml";
-    when(personalAccessTokenManager.getAndStore(any(String.class)))
+    when(personalAccessTokenManager.get(any(String.class)))
         .thenReturn(new PersonalAccessToken(SCM_URL, "root", "token123"));
 
     when(urlFetcher.fetch(anyString(), eq("Bearer token123"))).thenReturn(rawContent);
@@ -86,7 +86,7 @@ public class GitlabScmFileResolverTest {
   @Test
   public void shouldFetchContentWithoutAuthentication() throws Exception {
     // given
-    when(personalAccessTokenManager.getAndStore(anyString()))
+    when(personalAccessTokenManager.get(anyString()))
         .thenThrow(new ScmUnauthorizedException("message", "gitlab", "v1", "url"));
 
     // when

--- a/wsmaster/che-core-api-factory/src/main/java/org/eclipse/che/api/factory/server/scm/AuthorizingFileContentProvider.java
+++ b/wsmaster/che-core-api-factory/src/main/java/org/eclipse/che/api/factory/server/scm/AuthorizingFileContentProvider.java
@@ -80,7 +80,7 @@ public class AuthorizingFileContentProvider<T extends RemoteFactoryUrl>
         String authorization;
         if (isNullOrEmpty(credentials)) {
           PersonalAccessToken token =
-              personalAccessTokenManager.getAndStore(remoteFactoryUrl.getHostName());
+              personalAccessTokenManager.get(remoteFactoryUrl.getHostName());
           authorization =
               formatAuthorization(
                   token.getToken(),

--- a/wsmaster/che-core-api-factory/src/main/java/org/eclipse/che/api/factory/server/scm/PersonalAccessTokenManager.java
+++ b/wsmaster/che-core-api-factory/src/main/java/org/eclipse/che/api/factory/server/scm/PersonalAccessTokenManager.java
@@ -54,6 +54,22 @@ public interface PersonalAccessTokenManager {
           ScmCommunicationException;
 
   /**
+   * Gets {@link PersonalAccessToken} from permanent storage.
+   *
+   * @param scmServerUrl Git provider endpoint
+   * @throws ScmConfigurationPersistenceException - problem occurred during communication with
+   *     permanent storage.
+   * @throws ScmUnauthorizedException - scm authorization required.
+   * @throws ScmCommunicationException - problem occurred during communication with scm provider.
+   * @throws UnknownScmProviderException - scm provider is unknown.
+   * @throws UnsatisfiedScmPreconditionException - storage preconditions aren't met.
+   */
+  PersonalAccessToken get(String scmServerUrl)
+      throws ScmConfigurationPersistenceException, ScmUnauthorizedException,
+          ScmCommunicationException, UnknownScmProviderException,
+          UnsatisfiedScmPreconditionException;
+
+  /**
    * Gets {@link PersonalAccessToken} from permanent storage for the given OAuth provider name. It
    * is useful when OAuth provider is not configured and Git provider endpoint is unknown. {@code
    * scmServerUrl} can be provided as an additional clause.
@@ -82,4 +98,18 @@ public interface PersonalAccessTokenManager {
       throws ScmCommunicationException, ScmConfigurationPersistenceException,
           UnknownScmProviderException, UnsatisfiedScmPreconditionException,
           ScmUnauthorizedException;
+
+  /**
+   * Set or update git-credentials with {@link PersonalAccessToken} from permanent storage.
+   *
+   * @param scmServerUrl Git provider endpoint
+   * @throws UnsatisfiedScmPreconditionException - storage preconditions aren't met.
+   * @throws ScmConfigurationPersistenceException - problem occurred during communication with
+   *     permanent storage.
+   * @throws ScmCommunicationException - problem occurred during communication with scm provider.
+   * @throws ScmUnauthorizedException - scm authorization required.
+   */
+  void store(String scmServerUrl)
+      throws UnsatisfiedScmPreconditionException, ScmConfigurationPersistenceException,
+          ScmCommunicationException, ScmUnauthorizedException;
 }

--- a/wsmaster/che-core-api-factory/src/test/java/org/eclipse/che/api/factory/server/scm/AuthorizingFactoryParameterResolverTest.java
+++ b/wsmaster/che-core-api-factory/src/test/java/org/eclipse/che/api/factory/server/scm/AuthorizingFactoryParameterResolverTest.java
@@ -48,13 +48,13 @@ public class AuthorizingFactoryParameterResolverTest {
     // given
     when(remoteFactoryUrl.getHostName()).thenReturn("hostName");
     when(urlFetcher.fetch(anyString(), anyString())).thenReturn("content");
-    when(personalAccessTokenManager.getAndStore(anyString())).thenReturn(personalAccessToken);
+    when(personalAccessTokenManager.get(anyString())).thenReturn(personalAccessToken);
 
     // when
     provider.fetchContent("url");
 
     // then
-    verify(personalAccessTokenManager).getAndStore(anyString());
+    verify(personalAccessTokenManager).get(anyString());
   }
 
   @Test


### PR DESCRIPTION
<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests
-->

### What does this PR do?
* On workspace start iterate user PAT secrets. If a PAT secret is not included to the `devworkspace-merged-git-credentials` secret, create a git credentials secret based on the PAT secret.
* Remove the redundant logic of creation an empty `workspace-credentials-secret` secret.

### Screenshot/screencast of this PR
<!-- Please include a screenshot or a screencast explaining what is doing this PR -->


### What issues does this PR fix or reference?
<!-- Please include any related issue from eclipse che repository (or from another issue tracker).
     Include link to other pull requests like documentation PR from [the docs repo](https://github.com/eclipse/che-docs)
-->
fixes https://github.com/eclipse/che/issues/22271

### How to test this PR?
<!-- Please explain for example :
  - The test platform (openshift, kubernetes, minikube, CodeReady Container, docker-desktop, etc)
  - Installation method: chectl / che-operator
  - steps to reproduce
 -->
1. Deploy che from the PR image: `quay.io/ivinokur/che-server:22271`
2. Create a manual PAT from dashboard or from YAML: https://www.eclipse.org/che/docs/stable/end-user-guide/using-a-git-provider-access-token/
3. Start a workspace from the samples list.
See: the PAT is mounted to `/.git-credentials/credentials` file.

### PR Checklist

[As the author of this Pull Request I made sure that:](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#pull-request-template-and-its-checklist)

- [ ] [The Eclipse Contributor Agreement is valid](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-eclipse-contributor-agreement-is-valid)
- [ ] [Code produced is complete](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-produced-is-complete)
- [ ] [Code builds without errors](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-builds-without-errors)
- [ ] [Tests are covering the bugfix](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#tests-are-covering-the-bugfix)
- [ ] [The repository devfile is up to date and works](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-repository-devfile-is-up-to-date-and-works)
- [ ] [Sections `What issues does this PR fix or reference` and `How to test this PR` completed](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#sections-what-issues-does-this-pr-fix-or-reference-and-how-to-test-this-pr-completed)
- [ ] [Relevant user documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [Relevant contributing documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [CI/CD changes implemented, documented and communicated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#cicd-changes-implemented-documented-and-communicated)

### Reviewers

Reviewers, please comment how you tested the PR when approving it.
