### PR TITLE
Pass string to ObjectMapper instead of InputStream

### DIFF
--- a/wsmaster/che-core-api-factory-azure-devops/src/main/java/org/eclipse/che/api/factory/server/azure/devops/AzureDevOpsApiClient.java
+++ b/wsmaster/che-core-api-factory-azure-devops/src/main/java/org/eclipse/che/api/factory/server/azure/devops/AzureDevOpsApiClient.java
@@ -116,7 +116,9 @@ public class AzureDevOpsApiClient {
         userDataRequest,
         response -> {
           try {
-            return OBJECT_MAPPER.readValue(response.body(), AzureDevOpsUser.class);
+            String result =
+                CharStreams.toString(new InputStreamReader(response.body(), Charsets.UTF_8));
+            return OBJECT_MAPPER.readValue(result, AzureDevOpsUser.class);
           } catch (IOException e) {
             throw new UncheckedIOException(e);
           }

--- a/wsmaster/che-core-api-factory-bitbucket-server/src/main/java/org/eclipse/che/api/factory/server/bitbucket/HttpBitbucketServerApiClient.java
+++ b/wsmaster/che-core-api-factory-bitbucket-server/src/main/java/org/eclipse/che/api/factory/server/bitbucket/HttpBitbucketServerApiClient.java
@@ -176,7 +176,9 @@ public class HttpBitbucketServerApiClient implements BitbucketServerApiClient {
           request,
           inputStream -> {
             try {
-              return OM.readValue(inputStream, BitbucketUser.class);
+              String result =
+                  CharStreams.toString(new InputStreamReader(inputStream, Charsets.UTF_8));
+              return OM.readValue(result, BitbucketUser.class);
             } catch (IOException e) {
               throw new UncheckedIOException(e);
             }
@@ -230,7 +232,9 @@ public class HttpBitbucketServerApiClient implements BitbucketServerApiClient {
           request,
           inputStream -> {
             try {
-              return OM.readValue(inputStream, String.class);
+              String result =
+                  CharStreams.toString(new InputStreamReader(inputStream, Charsets.UTF_8));
+              return OM.readValue(result, String.class);
             } catch (IOException e) {
               throw new UncheckedIOException(e);
             }
@@ -271,7 +275,9 @@ public class HttpBitbucketServerApiClient implements BitbucketServerApiClient {
           request,
           inputStream -> {
             try {
-              return OM.readValue(inputStream, BitbucketPersonalAccessToken.class);
+              String result =
+                  CharStreams.toString(new InputStreamReader(inputStream, Charsets.UTF_8));
+              return OM.readValue(result, BitbucketPersonalAccessToken.class);
             } catch (IOException e) {
               throw new UncheckedIOException(e);
             }
@@ -313,7 +319,9 @@ public class HttpBitbucketServerApiClient implements BitbucketServerApiClient {
           request,
           inputStream -> {
             try {
-              return OM.readValue(inputStream, BitbucketPersonalAccessToken.class);
+              String result =
+                  CharStreams.toString(new InputStreamReader(inputStream, Charsets.UTF_8));
+              return OM.readValue(result, BitbucketPersonalAccessToken.class);
             } catch (IOException e) {
               throw new UncheckedIOException(e);
             }
@@ -388,7 +396,9 @@ public class HttpBitbucketServerApiClient implements BitbucketServerApiClient {
         request,
         inputStream -> {
           try {
-            return OM.readValue(inputStream, typeReference);
+            String result =
+                CharStreams.toString(new InputStreamReader(inputStream, Charsets.UTF_8));
+            return OM.readValue(result, typeReference);
           } catch (IOException e) {
             throw new UncheckedIOException(e);
           }

--- a/wsmaster/che-core-api-factory-bitbucket/src/main/java/org/eclipse/che/api/factory/server/bitbucket/BitbucketApiClient.java
+++ b/wsmaster/che-core-api-factory-bitbucket/src/main/java/org/eclipse/che/api/factory/server/bitbucket/BitbucketApiClient.java
@@ -108,7 +108,9 @@ public class BitbucketApiClient {
         request,
         response -> {
           try {
-            return OBJECT_MAPPER.readValue(response.body(), BitbucketUser.class);
+            String result =
+                CharStreams.toString(new InputStreamReader(response.body(), Charsets.UTF_8));
+            return OBJECT_MAPPER.readValue(result, BitbucketUser.class);
           } catch (IOException e) {
             throw new UncheckedIOException(e);
           }
@@ -154,7 +156,9 @@ public class BitbucketApiClient {
         request,
         response -> {
           try {
-            return OBJECT_MAPPER.readValue(response.body(), BitbucketUserEmail.class);
+            String result =
+                CharStreams.toString(new InputStreamReader(response.body(), Charsets.UTF_8));
+            return OBJECT_MAPPER.readValue(result, BitbucketUserEmail.class);
           } catch (IOException e) {
             throw new UncheckedIOException(e);
           }

--- a/wsmaster/che-core-api-factory-github/src/main/java/org/eclipse/che/api/factory/server/github/GithubApiClient.java
+++ b/wsmaster/che-core-api-factory-github/src/main/java/org/eclipse/che/api/factory/server/github/GithubApiClient.java
@@ -111,7 +111,9 @@ public class GithubApiClient {
         request,
         response -> {
           try {
-            return OBJECT_MAPPER.readValue(response.body(), GithubUser.class);
+            String result =
+                CharStreams.toString(new InputStreamReader(response.body(), Charsets.UTF_8));
+            return OBJECT_MAPPER.readValue(result, GithubUser.class);
           } catch (IOException e) {
             throw new UncheckedIOException(e);
           }
@@ -140,7 +142,9 @@ public class GithubApiClient {
         request,
         response -> {
           try {
-            return OBJECT_MAPPER.readValue(response.body(), GithubPullRequest.class);
+            String result =
+                CharStreams.toString(new InputStreamReader(response.body(), Charsets.UTF_8));
+            return OBJECT_MAPPER.readValue(result, GithubPullRequest.class);
           } catch (IOException e) {
             throw new UncheckedIOException(e);
           }
@@ -181,7 +185,9 @@ public class GithubApiClient {
         request,
         response -> {
           try {
-            return OBJECT_MAPPER.readValue(response.body(), GithubCommit[].class)[0];
+            String result =
+                CharStreams.toString(new InputStreamReader(response.body(), Charsets.UTF_8));
+            return OBJECT_MAPPER.readValue(result, GithubCommit[].class)[0];
           } catch (IOException e) {
             throw new UncheckedIOException(e);
           }

--- a/wsmaster/che-core-api-factory-gitlab/src/main/java/org/eclipse/che/api/factory/server/gitlab/GitlabApiClient.java
+++ b/wsmaster/che-core-api-factory-gitlab/src/main/java/org/eclipse/che/api/factory/server/gitlab/GitlabApiClient.java
@@ -78,7 +78,9 @@ public class GitlabApiClient {
         request,
         inputStream -> {
           try {
-            return OBJECT_MAPPER.readValue(inputStream, GitlabUser.class);
+            String result =
+                CharStreams.toString(new InputStreamReader(inputStream, Charsets.UTF_8));
+            return OBJECT_MAPPER.readValue(result, GitlabUser.class);
           } catch (IOException e) {
             throw new UncheckedIOException(e);
           }
@@ -100,7 +102,9 @@ public class GitlabApiClient {
           request,
           inputStream -> {
             try {
-              return OBJECT_MAPPER.readValue(inputStream, GitlabOauthTokenInfo.class);
+              String result =
+                  CharStreams.toString(new InputStreamReader(inputStream, Charsets.UTF_8));
+              return OBJECT_MAPPER.readValue(result, GitlabOauthTokenInfo.class);
             } catch (IOException e) {
               throw new UncheckedIOException(e);
             }


### PR DESCRIPTION
<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests
-->

### What does this PR do?
Pass string to ObjectMapper instead of InputStream in order to avoid `No content to map due to end-of-input` error caused by `jdk.internal.net.http.ResponseSubscribers$HttpResponseInputStream`.
An error was discovered in our customers environment:
```
2023-07-07 11:31:31,713[nio-8080-exec-2]  [ERROR] [o.e.c.a.f.s.g.GithubApiClient 117]   - Error while parsing response body
com.fasterxml.jackson.databind.exc.MismatchedInputException: No content to map due to end-of-input
 at [Source: (jdk.internal.net.http.ResponseSubscribers$HttpResponseInputStream); line: 1, column: 0]
	at com.fasterxml.jackson.databind.exc.MismatchedInputException.from(MismatchedInputException.java:59)
	at com.fasterxml.jackson.databind.ObjectMapper._initForReading(ObjectMapper.java:4821)
	at com.fasterxml.jackson.databind.ObjectMapper._readMapAndClose(ObjectMapper.java:4723)
	at com.fasterxml.jackson.databind.ObjectMapper.readValue(ObjectMapper.java:3714)
	at org.eclipse.che.api.factory.server.github.GithubApiClient.lambda$getUser$0(GithubApiClient.java:115)
	at org.eclipse.che.api.factory.server.github.GithubApiClient.executeRequest(GithubApiClient.java:260)
	at org.eclipse.che.api.factory.server.github.GithubApiClient.getUser(GithubApiClient.java:109)
	at org.eclipse.che.api.factory.server.github.GithubPersonalAccessTokenFetcher.isValid(GithubPersonalAccessTokenFetcher.java:214)
	at org.eclipse.che.api.factory.server.scm.ScmPersonalAccessTokenFetcher.isValid(ScmPersonalAccessTokenFetcher.java:65)
	at org.eclipse.che.api.factory.server.scm.kubernetes.KubernetesPersonalAccessTokenManager.doGetPersonalAccessToken(KubernetesPersonalAccessTokenManager.java:187)
	at org.eclipse.che.api.factory.server.scm.kubernetes.KubernetesPersonalAccessTokenManager.get(KubernetesPersonalAccessTokenManager.java:152)
	at jdk.internal.reflect.GeneratedMethodAccessor135.invoke(Unknown Source)
	at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.base/java.lang.reflect.Method.invoke(Method.java:566)
	at com.google.inject.internal.DelegatingInvocationHandler.invoke(DelegatingInvocationHandler.java:50)
	at com.sun.proxy.$Proxy101.get(Unknown Source)
	at org.eclipse.che.api.factory.server.scm.AbstractGitUserDataFetcher.fetchGitUserData(AbstractGitUserDataFetcher.java:59)
	at org.eclipse.che.workspace.infrastructure.kubernetes.namespace.configurator.GitconfigUserDataConfigurator.configure(GitconfigUserDataConfigurator.java:57)
	at org.eclipse.che.workspace.infrastructure.kubernetes.namespace.KubernetesNamespaceFactory.configureNamespace(KubernetesNamespaceFactory.java:534)
	at org.eclipse.che.workspace.infrastructure.openshift.project.OpenShiftProjectFactory.getOrCreate(OpenShiftProjectFactory.java:120)
	at org.eclipse.che.workspace.infrastructure.openshift.project.OpenShiftProjectFactory.getOrCreate(OpenShiftProjectFactory.java:58)
	at org.eclipse.che.workspace.infrastructure.kubernetes.provision.NamespaceProvisioner.provision(NamespaceProvisioner.java:42)
	at org.eclipse.che.workspace.infrastructure.kubernetes.api.server.KubernetesNamespaceService.provision(KubernetesNamespaceService.java:95)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.base/java.lang.reflect.Method.invoke(Method.java:566)
	at org.everrest.core.impl.method.DefaultMethodInvoker.invokeMethod(DefaultMethodInvoker.java:174)
	at org.everrest.core.impl.method.DefaultMethodInvoker.invokeMethod(DefaultMethodInvoker.java:61)
	at org.everrest.core.impl.RequestDispatcher.doInvokeResource(RequestDispatcher.java:329)
	at org.everrest.core.impl.RequestDispatcher.invokeSubResourceMethod(RequestDispatcher.java:319)
	at org.everrest.core.impl.RequestDispatcher.dispatch(RequestDispatcher.java:257)
	at org.everrest.core.impl.RequestDispatcher.dispatch(RequestDispatcher.java:131)
	at org.everrest.core.impl.RequestHandlerImpl.handleRequest(RequestHandlerImpl.java:61)
	at org.everrest.core.impl.EverrestProcessor.process(EverrestProcessor.java:130)
	at org.everrest.core.servlet.EverrestServlet.service(EverrestServlet.java:62)
	at jakarta.servlet.http.HttpServlet.service(HttpServlet.java:631)
	at com.google.inject.servlet.ServletDefinition.doServiceImpl(ServletDefinition.java:290)
	at com.google.inject.servlet.ServletDefinition.doService(ServletDefinition.java:280)
	at com.google.inject.servlet.ServletDefinition.service(ServletDefinition.java:184)
	at com.google.inject.servlet.ManagedServletPipeline.service(ManagedServletPipeline.java:89)
	at com.google.inject.servlet.FilterChainInvocation.doFilter(FilterChainInvocation.java:85)
	at org.eclipse.che.core.metrics.ApiResponseMetricFilter.doFilter(ApiResponseMetricFilter.java:46)
	at com.google.inject.servlet.FilterChainInvocation.doFilter(FilterChainInvocation.java:82)
	at org.eclipse.che.multiuser.api.authentication.commons.filter.MultiUserEnvironmentInitializationFilter.doFilter(MultiUserEnvironmentInitializationFilter.java:161)
	at com.google.inject.servlet.FilterChainInvocation.doFilter(FilterChainInvocation.java:82)
	at org.eclipse.che.commons.logback.filter.RequestIdLoggerFilter.doFilter(RequestIdLoggerFilter.java:50)
	at com.google.inject.servlet.FilterChainInvocation.doFilter(FilterChainInvocation.java:82)
	at com.google.inject.servlet.ManagedFilterPipeline.dispatch(ManagedFilterPipeline.java:121)
	at com.google.inject.servlet.GuiceFilter.doFilter(GuiceFilter.java:133)
	at org.apache.catalina.core.ApplicationFilterChain.internalDoFilter(ApplicationFilterChain.java:174)
	at org.apache.catalina.core.ApplicationFilterChain.doFilter(ApplicationFilterChain.java:149)
	at org.apache.catalina.core.StandardWrapperValve.invoke(StandardWrapperValve.java:166)
	at org.apache.catalina.core.StandardContextValve.invoke(StandardContextValve.java:90)
	at org.apache.catalina.authenticator.AuthenticatorBase.invoke(AuthenticatorBase.java:493)
	at org.apache.catalina.core.StandardHostValve.invoke(StandardHostValve.java:115)
	at org.apache.catalina.valves.ErrorReportValve.invoke(ErrorReportValve.java:93)
	at org.apache.catalina.valves.RemoteIpValve.invoke(RemoteIpValve.java:738)
	at org.apache.catalina.valves.AbstractAccessLogValve.invoke(AbstractAccessLogValve.java:676)
	at org.apache.catalina.core.StandardEngineValve.invoke(StandardEngineValve.java:74)
	at org.apache.catalina.connector.CoyoteAdapter.service(CoyoteAdapter.java:357)
	at org.apache.coyote.http11.Http11Processor.service(Http11Processor.java:400)
	at org.apache.coyote.AbstractProcessorLight.process(AbstractProcessorLight.java:63)
	at org.apache.coyote.AbstractProtocol$ConnectionHandler.process(AbstractProtocol.java:894)
	at org.apache.tomcat.util.net.NioEndpoint$SocketProcessor.doRun(NioEndpoint.java:1741)
	at org.apache.tomcat.util.net.SocketProcessorBase.run(SocketProcessorBase.java:52)
	at org.apache.tomcat.util.threads.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1191)
	at org.apache.tomcat.util.threads.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:659)
	at org.apache.tomcat.util.threads.TaskThread$WrappingRunnable.run(TaskThread.java:61)
	at java.base/java.lang.Thread.run(Thread.java:829)
2023-07-07 11:31:31,713[nio-8080-exec-2]  [ERROR] [o.e.c.a.f.s.g.GithubApiClient 118]   - Error while parsing response body No content to map due to end-of-input
 at [Source: (jdk.internal.net.http.ResponseSubscribers$HttpResponseInputStream); line: 1, column: 0]
```

### Screenshot/screencast of this PR
<!-- Please include a screenshot or a screencast explaining what is doing this PR -->


### What issues does this PR fix or reference?
<!-- Please include any related issue from eclipse che repository (or from another issue tracker).
     Include link to other pull requests like documentation PR from [the docs repo](https://github.com/eclipse/che-docs)
-->
https://issues.redhat.com/browse/CRW-4551

### How to test this PR?
<!-- Please explain for example :
  - The test platform (openshift, kubernetes, minikube, CodeReady Container, docker-desktop, etc)
  - Installation method: chectl / che-operator
  - steps to reproduce
 -->

### PR Checklist

[As the author of this Pull Request I made sure that:](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#pull-request-template-and-its-checklist)

- [ ] [The Eclipse Contributor Agreement is valid](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-eclipse-contributor-agreement-is-valid)
- [ ] [Code produced is complete](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-produced-is-complete)
- [ ] [Code builds without errors](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-builds-without-errors)
- [ ] [Tests are covering the bugfix](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#tests-are-covering-the-bugfix)
- [ ] [The repository devfile is up to date and works](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-repository-devfile-is-up-to-date-and-works)
- [ ] [Sections `What issues does this PR fix or reference` and `How to test this PR` completed](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#sections-what-issues-does-this-pr-fix-or-reference-and-how-to-test-this-pr-completed)
- [ ] [Relevant user documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [Relevant contributing documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [CI/CD changes implemented, documented and communicated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#cicd-changes-implemented-documented-and-communicated)

### Reviewers

Reviewers, please comment how you tested the PR when approving it.
