### PR TITLE
Use `login` instead of `name` in the GitHub scopes/username request

### DIFF
--- a/wsmaster/che-core-api-factory-github/src/main/java/org/eclipse/che/api/factory/server/github/GithubApiClient.java
+++ b/wsmaster/che-core-api-factory-github/src/main/java/org/eclipse/che/api/factory/server/github/GithubApiClient.java
@@ -228,7 +228,7 @@ public class GithubApiClient {
             String result =
                 CharStreams.toString(new InputStreamReader(response.body(), Charsets.UTF_8));
             GithubUser user = OBJECT_MAPPER.readValue(result, GithubUser.class);
-            return Pair.of(user.getName(), scopes);
+            return Pair.of(user.getLogin(), scopes);
           } catch (IOException e) {
             throw new UncheckedIOException(e);
           }

--- a/wsmaster/che-core-api-factory-github/src/test/java/org/eclipse/che/api/factory/server/github/GithubApiClientTest.java
+++ b/wsmaster/che-core-api-factory-github/src/test/java/org/eclipse/che/api/factory/server/github/GithubApiClientTest.java
@@ -36,6 +36,7 @@ import java.lang.reflect.Field;
 import org.eclipse.che.api.factory.server.scm.exception.ScmBadRequestException;
 import org.eclipse.che.api.factory.server.scm.exception.ScmCommunicationException;
 import org.eclipse.che.api.factory.server.scm.exception.ScmItemNotFoundException;
+import org.eclipse.che.commons.lang.Pair;
 import org.mockito.testng.MockitoTestNGListener;
 import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeMethod;
@@ -165,11 +166,13 @@ public class GithubApiClientTest {
                     .withHeader(GithubApiClient.GITHUB_OAUTH_SCOPES_HEADER, "repo, user:email")
                     .withBodyFile("github/rest/user/response.json")));
 
-    String[] scopes = client.getTokenScopes("token1").second;
+    Pair<String, String[]> pair = client.getTokenScopes("token1");
+    String[] scopes = pair.second;
     String[] expectedScopes = {"repo", "user:email"};
     assertNotNull(scopes, "GitHub API should have returned a non-null scope array");
     assertEqualsNoOrder(
         scopes, expectedScopes, "Returned scope array does not match expected values");
+    assertEquals(pair.first, "github-user");
   }
 
   @Test


### PR DESCRIPTION
<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests
-->

### What does this PR do?
Change `user.getName()` to `user.getLogin()` in the GitHub `getTokenScopes()` API request, in order to fix a bug where `NullPointer` exception is appeared when a GitHub user request returns a user with `null` in the `name` field.

### Screenshot/screencast of this PR
<!-- Please include a screenshot or a screencast explaining what is doing this PR -->


### What issues does this PR fix or reference?
<!-- Please include any related issue from eclipse che repository (or from another issue tracker).
     Include link to other pull requests like documentation PR from [the docs repo](https://github.com/eclipse/che-docs)
-->
fixes https://github.com/eclipse/che/issues/22413

### How to test this PR?
<!-- Please explain for example :
  - The test platform (openshift, kubernetes, minikube, CodeReady Container, docker-desktop, etc)
  - Installation method: chectl / che-operator
  - steps to reproduce
 -->
1. In your GitHub profile clear the `Name` input and hit `Save`
2. In your user namespace remove next secrets:
- `personal-access-token-****`
- `git-credentials-secret-****`
- `devworkspace-merged-git-credentials`
3. Apply [GitHub OAuth](https://eclipse.dev/che/docs/stable/administration-guide/configuring-oauth-2-for-github/)
4. Start a workspace from GitHub repo

### PR Checklist

[As the author of this Pull Request I made sure that:](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#pull-request-template-and-its-checklist)

- [ ] [The Eclipse Contributor Agreement is valid](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-eclipse-contributor-agreement-is-valid)
- [ ] [Code produced is complete](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-produced-is-complete)
- [ ] [Code builds without errors](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-builds-without-errors)
- [ ] [Tests are covering the bugfix](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#tests-are-covering-the-bugfix)
- [ ] [The repository devfile is up to date and works](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-repository-devfile-is-up-to-date-and-works)
- [ ] [Sections `What issues does this PR fix or reference` and `How to test this PR` completed](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#sections-what-issues-does-this-pr-fix-or-reference-and-how-to-test-this-pr-completed)
- [ ] [Relevant user documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [Relevant contributing documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [CI/CD changes implemented, documented and communicated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#cicd-changes-implemented-documented-and-communicated)

### Reviewers

Reviewers, please comment how you tested the PR when approving it.
