### PR TITLE
Do not return secret token in the Oauth API

### DIFF
--- a/wsmaster/che-core-api-factory-bitbucket-server/src/main/java/org/eclipse/che/api/factory/server/bitbucket/BitbucketServerPersonalAccessTokenFetcher.java
+++ b/wsmaster/che-core-api-factory-bitbucket-server/src/main/java/org/eclipse/che/api/factory/server/bitbucket/BitbucketServerPersonalAccessTokenFetcher.java
@@ -11,6 +11,7 @@
  */
 package org.eclipse.che.api.factory.server.bitbucket;
 
+import static com.google.common.base.Strings.isNullOrEmpty;
 import static java.lang.String.format;
 import static java.lang.String.valueOf;
 
@@ -159,6 +160,12 @@ public class BitbucketServerPersonalAccessTokenFetcher implements PersonalAccess
       }
     }
     try {
+      // Token is added manually by a user without token id. Validate only by requesting user info.
+      if (isNullOrEmpty(params.getScmTokenId())) {
+        BitbucketUser user = bitbucketServerApiClient.getUser(params.getToken());
+        return Optional.of(Pair.of(Boolean.TRUE, user.getName()));
+      }
+      // Token is added by OAuth. Token id is available.
       BitbucketPersonalAccessToken bitbucketPersonalAccessToken =
           bitbucketServerApiClient.getPersonalAccessToken(Long.valueOf(params.getScmTokenId()));
       return Optional.of(

--- a/wsmaster/che-core-api-factory-bitbucket-server/src/test/java/org/eclipse/che/api/factory/server/bitbucket/BitbucketServerPersonalAccessTokenFetcherTest.java
+++ b/wsmaster/che-core-api-factory-bitbucket-server/src/test/java/org/eclipse/che/api/factory/server/bitbucket/BitbucketServerPersonalAccessTokenFetcherTest.java
@@ -231,6 +231,23 @@ public class BitbucketServerPersonalAccessTokenFetcherTest {
     // then
     assertFalse(result.isEmpty());
     assertTrue(result.get().first);
+    assertEquals(result.get().second, bitbucketUser.getName());
+  }
+
+  @Test
+  public void shouldValidateTokenWithoutId()
+      throws ScmUnauthorizedException, ScmCommunicationException, ScmItemNotFoundException {
+    // given
+    when(personalAccessTokenParams.getScmProviderUrl()).thenReturn(someBitbucketURL);
+    when(personalAccessTokenParams.getToken()).thenReturn("token");
+    when(bitbucketServerApiClient.isConnected(eq(someBitbucketURL))).thenReturn(true);
+    when(bitbucketServerApiClient.getUser(eq("token"))).thenReturn(bitbucketUser);
+    // when
+    Optional<Pair<Boolean, String>> result = fetcher.isValid(personalAccessTokenParams);
+    // then
+    assertFalse(result.isEmpty());
+    assertTrue(result.get().first);
+    assertEquals(result.get().second, bitbucketUser.getName());
   }
 
   @DataProvider


### PR DESCRIPTION
<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests
-->

### What does this PR do?
* Remove the `personalAccessTokenManager.get()` call from the OAuth API `getToken()` method. The OAuth API must not know anything about PAT secrets. It should get tokens only by requesting an SCM provider OAuth API.
* Fix validating the Bitbucket-Server PAT method by requesting user instead of requesting.

This prevents the code execution going to a recursive loop: `bitbucketServerApiClient.getPersonalAccessToken()` calls `oauthApi.getToken()` which referred to `personalAccessTokenManager.getToken()` which validated the token by calling `scmPersonalAccessTokenFetcher.getScmUsername()` -> `bitbucketServerApiClient.getPersonalAccessToken()`.

### Screenshot/screencast of this PR
<!-- Please include a screenshot or a screencast explaining what is doing this PR -->


### What issues does this PR fix or reference?
<!-- Please include any related issue from eclipse che repository (or from another issue tracker).
     Include link to other pull requests like documentation PR from [the docs repo](https://github.com/eclipse/che-docs)
-->
https://issues.redhat.com/browse/CRW-4351

### How to test this PR?
<!-- Please explain for example :
  - The test platform (openshift, kubernetes, minikube, CodeReady Container, docker-desktop, etc)
  - Installation method: chectl / che-operator
  - steps to reproduce
 -->
1. Setup [bitbucket-server oauth](https://eclipse.dev/che/docs/stable/administration-guide/configuring-oauth-2-for-a-bitbucket-server/)
2. Start a workspace from the bitbucket-server repo to initiate the OAuth exchange.
3. Go to dashboard -> User preferences -> Personal Access Tokens tab and add a new bitbucket-server token. You can use a random string for the token input.

See: the token creation is rejected, but no backend errors appear.

### PR Checklist

[As the author of this Pull Request I made sure that:](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#pull-request-template-and-its-checklist)

- [ ] [The Eclipse Contributor Agreement is valid](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-eclipse-contributor-agreement-is-valid)
- [ ] [Code produced is complete](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-produced-is-complete)
- [ ] [Code builds without errors](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-builds-without-errors)
- [ ] [Tests are covering the bugfix](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#tests-are-covering-the-bugfix)
- [ ] [The repository devfile is up to date and works](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-repository-devfile-is-up-to-date-and-works)
- [ ] [Sections `What issues does this PR fix or reference` and `How to test this PR` completed](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#sections-what-issues-does-this-pr-fix-or-reference-and-how-to-test-this-pr-completed)
- [ ] [Relevant user documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [Relevant contributing documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [CI/CD changes implemented, documented and communicated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#cicd-changes-implemented-documented-and-communicated)

### Reviewers

Reviewers, please comment how you tested the PR when approving it.
