### PR TITLE
Duplicate creating a git-credentials secret on token fetch

### DIFF
--- a/infrastructures/infrastructure-factory/src/main/java/org/eclipse/che/api/factory/server/scm/kubernetes/KubernetesPersonalAccessTokenManager.java
+++ b/infrastructures/infrastructure-factory/src/main/java/org/eclipse/che/api/factory/server/scm/kubernetes/KubernetesPersonalAccessTokenManager.java
@@ -232,15 +232,7 @@ public class KubernetesPersonalAccessTokenManager implements PersonalAccessToken
       throws ScmCommunicationException, ScmConfigurationPersistenceException,
           UnknownScmProviderException, UnsatisfiedScmPreconditionException,
           ScmUnauthorizedException {
-    Subject subject = EnvironmentContext.getCurrent().getSubject();
-    Optional<PersonalAccessToken> tokenOptional = get(subject, scmServerUrl);
-    PersonalAccessToken personalAccessToken;
-    if (tokenOptional.isPresent()) {
-      personalAccessToken = tokenOptional.get();
-    } else {
-      // try to authenticate for the given URL
-      personalAccessToken = fetchAndSave(subject, scmServerUrl);
-    }
+    PersonalAccessToken personalAccessToken = get(scmServerUrl);
     gitCredentialManager.createOrReplace(personalAccessToken);
     return personalAccessToken;
   }

--- a/wsmaster/che-core-api-factory-bitbucket-server/src/test/java/org/eclipse/che/api/factory/server/bitbucket/BitbucketServerAuthorizingFileContentProviderTest.java
+++ b/wsmaster/che-core-api-factory-bitbucket-server/src/test/java/org/eclipse/che/api/factory/server/bitbucket/BitbucketServerAuthorizingFileContentProviderTest.java
@@ -44,7 +44,7 @@ public class BitbucketServerAuthorizingFileContentProviderTest {
 
     PersonalAccessToken token =
         new PersonalAccessToken(TEST_SCHEME + "://" + TEST_HOSTNAME, "user1", "token");
-    when(personalAccessTokenManager.get(anyString())).thenReturn(token);
+    when(personalAccessTokenManager.getAndStore(anyString())).thenReturn(token);
 
     String fileURL = "https://foo.bar/scm/repo/.devfile";
 
@@ -65,7 +65,8 @@ public class BitbucketServerAuthorizingFileContentProviderTest {
 
     PersonalAccessToken token =
         new PersonalAccessToken(TEST_SCHEME + "://" + TEST_HOSTNAME, "user1", "token");
-    when(personalAccessTokenManager.get(eq(TEST_SCHEME + "://" + TEST_HOSTNAME))).thenReturn(token);
+    when(personalAccessTokenManager.getAndStore(eq(TEST_SCHEME + "://" + TEST_HOSTNAME)))
+        .thenReturn(token);
 
     String fileURL = "https://foo.bar/scm/repo/.devfile";
 
@@ -73,7 +74,7 @@ public class BitbucketServerAuthorizingFileContentProviderTest {
     fileContentProvider.fetchContent(fileURL);
 
     // then
-    verify(personalAccessTokenManager).get(eq(TEST_SCHEME + "://" + TEST_HOSTNAME));
+    verify(personalAccessTokenManager).getAndStore(eq(TEST_SCHEME + "://" + TEST_HOSTNAME));
     verify(urlFetcher).fetch(eq(fileURL), eq("Bearer token"));
   }
 
@@ -95,7 +96,7 @@ public class BitbucketServerAuthorizingFileContentProviderTest {
             url, urlFetcher, personalAccessTokenManager);
     PersonalAccessToken token =
         new PersonalAccessToken(TEST_SCHEME + "://" + TEST_HOSTNAME, "user1", "token");
-    when(personalAccessTokenManager.get(anyString())).thenReturn(token);
+    when(personalAccessTokenManager.getAndStore(anyString())).thenReturn(token);
 
     // when
     fileContentProvider.fetchContent(relative);

--- a/wsmaster/che-core-api-factory-bitbucket-server/src/test/java/org/eclipse/che/api/factory/server/bitbucket/BitbucketServerScmFileResolverTest.java
+++ b/wsmaster/che-core-api-factory-bitbucket-server/src/test/java/org/eclipse/che/api/factory/server/bitbucket/BitbucketServerScmFileResolverTest.java
@@ -73,7 +73,7 @@ public class BitbucketServerScmFileResolverTest {
   public void shouldReturnContentFromUrlFetcher() throws Exception {
     final String rawContent = "raw_content";
     final String filename = "devfile.yaml";
-    when(personalAccessTokenManager.get(anyString()))
+    when(personalAccessTokenManager.getAndStore(anyString()))
         .thenReturn(new PersonalAccessToken(SCM_URL, "root", "token123"));
 
     when(urlFetcher.fetch(anyString(), eq("Bearer token123"))).thenReturn(rawContent);
@@ -87,7 +87,7 @@ public class BitbucketServerScmFileResolverTest {
   @Test
   public void shouldFetchContentWithoutAuthentication() throws Exception {
     // given
-    when(personalAccessTokenManager.get(anyString()))
+    when(personalAccessTokenManager.getAndStore(anyString()))
         .thenThrow(new ScmUnauthorizedException("message", "bitbucket-server", "v1", "url"));
 
     // when

--- a/wsmaster/che-core-api-factory-github/src/test/java/org/eclipse/che/api/factory/server/github/GithubAuthorizingFileContentProviderTest.java
+++ b/wsmaster/che-core-api-factory-github/src/test/java/org/eclipse/che/api/factory/server/github/GithubAuthorizingFileContentProviderTest.java
@@ -54,7 +54,7 @@ public class GithubAuthorizingFileContentProviderTest {
     FileContentProvider fileContentProvider =
         new GithubAuthorizingFileContentProvider(githubUrl, urlFetcher, personalAccessTokenManager);
 
-    when(personalAccessTokenManager.get(anyString()))
+    when(personalAccessTokenManager.getAndStore(anyString()))
         .thenReturn(new PersonalAccessToken("foo", "che", "my-token"));
 
     fileContentProvider.fetchContent("devfile.yaml");
@@ -81,7 +81,7 @@ public class GithubAuthorizingFileContentProviderTest {
     FileContentProvider fileContentProvider =
         new GithubAuthorizingFileContentProvider(githubUrl, urlFetcher, personalAccessTokenManager);
 
-    when(personalAccessTokenManager.get(anyString()))
+    when(personalAccessTokenManager.getAndStore(anyString()))
         .thenReturn(new PersonalAccessToken(raw_url, "che", "my-token"));
 
     fileContentProvider.fetchContent(raw_url);
@@ -98,7 +98,8 @@ public class GithubAuthorizingFileContentProviderTest {
     FileContentProvider fileContentProvider =
         new GithubAuthorizingFileContentProvider(githubUrl, urlFetcher, personalAccessTokenManager);
 
-    when(personalAccessTokenManager.get(anyString())).thenThrow(UnknownScmProviderException.class);
+    when(personalAccessTokenManager.getAndStore(anyString()))
+        .thenThrow(UnknownScmProviderException.class);
 
     when(urlFetcher.fetch(eq(url))).thenThrow(FileNotFoundException.class);
 
@@ -114,7 +115,8 @@ public class GithubAuthorizingFileContentProviderTest {
     FileContentProvider fileContentProvider =
         new GithubAuthorizingFileContentProvider(githubUrl, urlFetcher, personalAccessTokenManager);
 
-    when(personalAccessTokenManager.get(anyString())).thenThrow(UnknownScmProviderException.class);
+    when(personalAccessTokenManager.getAndStore(anyString()))
+        .thenThrow(UnknownScmProviderException.class);
     when(urlFetcher.fetch(eq(url))).thenThrow(FileNotFoundException.class);
     when(urlFetcher.fetch(eq("https://github.com/eclipse/che"))).thenThrow(IOException.class);
 
@@ -130,7 +132,7 @@ public class GithubAuthorizingFileContentProviderTest {
     FileContentProvider fileContentProvider =
         new GithubAuthorizingFileContentProvider(githubUrl, urlFetcher, personalAccessTokenManager);
     var personalAccessToken = new PersonalAccessToken(raw_url, "che", "my-token");
-    when(personalAccessTokenManager.get(anyString())).thenReturn(personalAccessToken);
+    when(personalAccessTokenManager.getAndStore(anyString())).thenReturn(personalAccessToken);
 
     fileContentProvider.fetchContent(raw_url);
 

--- a/wsmaster/che-core-api-factory-github/src/test/java/org/eclipse/che/api/factory/server/github/GithubScmFileResolverTest.java
+++ b/wsmaster/che-core-api-factory-github/src/test/java/org/eclipse/che/api/factory/server/github/GithubScmFileResolverTest.java
@@ -87,7 +87,7 @@ public class GithubScmFileResolverTest {
         .thenReturn(rawContent);
 
     lenient()
-        .when(personalAccessTokenManager.get(anyString()))
+        .when(personalAccessTokenManager.getAndStore(anyString()))
         .thenReturn(new PersonalAccessToken("foo", "che", "my-token"));
 
     when(githubApiClient.getLatestCommit(anyString(), anyString(), anyString(), any()))
@@ -106,7 +106,7 @@ public class GithubScmFileResolverTest {
   public void shouldReturnContentWithoutAuthentication() throws Exception {
     // given
     lenient()
-        .when(personalAccessTokenManager.get(anyString()))
+        .when(personalAccessTokenManager.getAndStore(anyString()))
         .thenThrow(new ScmUnauthorizedException("message", "github", "v1", "url"));
 
     // when

--- a/wsmaster/che-core-api-factory-gitlab/src/test/java/org/eclipse/che/api/factory/server/gitlab/GitlabAuthorizingFileContentProviderTest.java
+++ b/wsmaster/che-core-api-factory-gitlab/src/test/java/org/eclipse/che/api/factory/server/gitlab/GitlabAuthorizingFileContentProviderTest.java
@@ -36,7 +36,7 @@ public class GitlabAuthorizingFileContentProviderTest {
     FileContentProvider fileContentProvider =
         new GitlabAuthorizingFileContentProvider(gitlabUrl, urlFetcher, personalAccessTokenManager);
     var personalAccessToken = new PersonalAccessToken("foo", "che", "my-token");
-    when(personalAccessTokenManager.get(anyString())).thenReturn(personalAccessToken);
+    when(personalAccessTokenManager.getAndStore(anyString())).thenReturn(personalAccessToken);
     fileContentProvider.fetchContent("devfile.yaml");
     verify(urlFetcher)
         .fetch(
@@ -54,7 +54,7 @@ public class GitlabAuthorizingFileContentProviderTest {
     String url =
         "https://gitlab.net/api/v4/projects/eclipse%2Fche/repository/files/devfile.yaml/raw";
     var personalAccessToken = new PersonalAccessToken(url, "che", "my-token");
-    when(personalAccessTokenManager.get(anyString())).thenReturn(personalAccessToken);
+    when(personalAccessTokenManager.getAndStore(anyString())).thenReturn(personalAccessToken);
 
     fileContentProvider.fetchContent(url);
     verify(urlFetcher).fetch(eq(url), eq("Bearer my-token"));

--- a/wsmaster/che-core-api-factory-gitlab/src/test/java/org/eclipse/che/api/factory/server/gitlab/GitlabScmFileResolverTest.java
+++ b/wsmaster/che-core-api-factory-gitlab/src/test/java/org/eclipse/che/api/factory/server/gitlab/GitlabScmFileResolverTest.java
@@ -72,7 +72,7 @@ public class GitlabScmFileResolverTest {
   public void shouldReturnContentFromUrlFetcher() throws Exception {
     final String rawContent = "raw_content";
     final String filename = "devfile.yaml";
-    when(personalAccessTokenManager.get(any(String.class)))
+    when(personalAccessTokenManager.getAndStore(any(String.class)))
         .thenReturn(new PersonalAccessToken(SCM_URL, "root", "token123"));
 
     when(urlFetcher.fetch(anyString(), eq("Bearer token123"))).thenReturn(rawContent);
@@ -86,7 +86,7 @@ public class GitlabScmFileResolverTest {
   @Test
   public void shouldFetchContentWithoutAuthentication() throws Exception {
     // given
-    when(personalAccessTokenManager.get(anyString()))
+    when(personalAccessTokenManager.getAndStore(anyString()))
         .thenThrow(new ScmUnauthorizedException("message", "gitlab", "v1", "url"));
 
     // when

--- a/wsmaster/che-core-api-factory/src/main/java/org/eclipse/che/api/factory/server/scm/AuthorizingFileContentProvider.java
+++ b/wsmaster/che-core-api-factory/src/main/java/org/eclipse/che/api/factory/server/scm/AuthorizingFileContentProvider.java
@@ -80,7 +80,7 @@ public class AuthorizingFileContentProvider<T extends RemoteFactoryUrl>
         String authorization;
         if (isNullOrEmpty(credentials)) {
           PersonalAccessToken token =
-              personalAccessTokenManager.get(remoteFactoryUrl.getProviderUrl());
+              personalAccessTokenManager.getAndStore(remoteFactoryUrl.getProviderUrl());
           authorization =
               formatAuthorization(
                   token.getToken(),

--- a/wsmaster/che-core-api-factory/src/test/java/org/eclipse/che/api/factory/server/scm/AuthorizingFactoryParameterResolverTest.java
+++ b/wsmaster/che-core-api-factory/src/test/java/org/eclipse/che/api/factory/server/scm/AuthorizingFactoryParameterResolverTest.java
@@ -48,13 +48,13 @@ public class AuthorizingFactoryParameterResolverTest {
     // given
     when(remoteFactoryUrl.getProviderUrl()).thenReturn("https://provider.url");
     when(urlFetcher.fetch(anyString(), anyString())).thenReturn("content");
-    when(personalAccessTokenManager.get(anyString())).thenReturn(personalAccessToken);
+    when(personalAccessTokenManager.getAndStore(anyString())).thenReturn(personalAccessToken);
 
     // when
     provider.fetchContent("url");
 
     // then
-    verify(personalAccessTokenManager).get(anyString());
+    verify(personalAccessTokenManager).getAndStore(anyString());
   }
 
   @Test


### PR DESCRIPTION
<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests
-->

### What does this PR do?
* Duplicate the `git-credentials` secret creation step on create personal access token secret. Currently this step is performed on workspace provision step but in this case the PAT secret might be initialised when the provision is finished. In order to synchronise the personal access token secret and git credentials secret creation step duplicate the git credentials secret creation step after the PAT secret creation step.
* Refactor the `get(scmServerUrl)` function in the `KubernetesPersonalAccessTokenManager` class

### Screenshot/screencast of this PR
<!-- Please include a screenshot or a screencast explaining what is doing this PR -->


### What issues does this PR fix or reference?
<!-- Please include any related issue from eclipse che repository (or from another issue tracker).
     Include link to other pull requests like documentation PR from [the docs repo](https://github.com/eclipse/che-docs)
-->
https://issues.redhat.com/browse/CRW-4816

### How to test this PR?
<!-- Please explain for example :
  - The test platform (openshift, kubernetes, minikube, CodeReady Container, docker-desktop, etc)
  - Installation method: chectl / che-operator
  - steps to reproduce
 -->
The issue can not be reproduced permanently

### PR Checklist

[As the author of this Pull Request I made sure that:](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#pull-request-template-and-its-checklist)

- [ ] [The Eclipse Contributor Agreement is valid](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-eclipse-contributor-agreement-is-valid)
- [ ] [Code produced is complete](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-produced-is-complete)
- [ ] [Code builds without errors](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-builds-without-errors)
- [ ] [Tests are covering the bugfix](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#tests-are-covering-the-bugfix)
- [ ] [The repository devfile is up to date and works](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-repository-devfile-is-up-to-date-and-works)
- [ ] [Sections `What issues does this PR fix or reference` and `How to test this PR` completed](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#sections-what-issues-does-this-pr-fix-or-reference-and-how-to-test-this-pr-completed)
- [ ] [Relevant user documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [Relevant contributing documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [CI/CD changes implemented, documented and communicated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#cicd-changes-implemented-documented-and-communicated)

### Reviewers

Reviewers, please comment how you tested the PR when approving it.
