### PR TITLE
Add a null check before reading GitHub response

### DIFF
--- a/wsmaster/che-core-api-factory-github/src/main/java/org/eclipse/che/api/factory/server/github/GithubApiClient.java
+++ b/wsmaster/che-core-api-factory-github/src/main/java/org/eclipse/che/api/factory/server/github/GithubApiClient.java
@@ -275,7 +275,10 @@ public class GithubApiClient {
       } else if (response.statusCode() == HTTP_NO_CONTENT) {
         return null;
       } else {
-        String body = CharStreams.toString(new InputStreamReader(response.body(), Charsets.UTF_8));
+        String body =
+            response.body() == null
+                ? "Unrecognised error"
+                : CharStreams.toString(new InputStreamReader(response.body(), Charsets.UTF_8));
         switch (response.statusCode()) {
           case HTTP_BAD_REQUEST:
             throw new ScmBadRequestException(body);


### PR DESCRIPTION
<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests
-->

### What does this PR do?
Add a `null` check to prevent NullPointer exception while reading `body` from the GitHub API response. `response.body()` should not return `null` according to the java documentation, but the NullPointer exception was found in the customer debug logs:
```
Caused by: java.lang.NullPointerException: null
	at java.base/java.io.Reader.<init>(Reader.java:168)
	at java.base/java.io.InputStreamReader.<init>(InputStreamReader.java:112)
	at org.eclipse.che.api.factory.server.github.GithubApiClient.executeRequest(GithubApiClient.java:278)
	at org.eclipse.che.api.factory.server.github.GithubApiClient.getLatestCommit(GithubApiClient.java:184)
	at org.eclipse.che.api.factory.server.github.GithubURLParser.getLatestCommit(GithubURLParser.java:251)
	at org.eclipse.che.api.factory.server.github.GithubURLParser.parse(GithubURLParser.java:163)
	at org.eclipse.che.api.factory.server.github.GithubURLParser.parse(GithubURLParser.java:115)
	at org.eclipse.che.api.factory.server.github.GithubFactoryParametersResolver.createFactory(GithubFactoryParametersResolver.java:124)
	at org.eclipse.che.api.factory.server.FactoryService.resolveFactory(FactoryService.java:111)
```

### Screenshot/screencast of this PR
<!-- Please include a screenshot or a screencast explaining what is doing this PR -->


### What issues does this PR fix or reference?
<!-- Please include any related issue from eclipse che repository (or from another issue tracker).
     Include link to other pull requests like documentation PR from [the docs repo](https://github.com/eclipse/che-docs)
-->
https://issues.redhat.com/browse/CRW-4506

### How to test this PR?
<!-- Please explain for example :
  - The test platform (openshift, kubernetes, minikube, CodeReady Container, docker-desktop, etc)
  - Installation method: chectl / che-operator
  - steps to reproduce
 -->
N/A

### PR Checklist

[As the author of this Pull Request I made sure that:](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#pull-request-template-and-its-checklist)

- [ ] [The Eclipse Contributor Agreement is valid](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-eclipse-contributor-agreement-is-valid)
- [ ] [Code produced is complete](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-produced-is-complete)
- [ ] [Code builds without errors](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-builds-without-errors)
- [ ] [Tests are covering the bugfix](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#tests-are-covering-the-bugfix)
- [ ] [The repository devfile is up to date and works](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-repository-devfile-is-up-to-date-and-works)
- [ ] [Sections `What issues does this PR fix or reference` and `How to test this PR` completed](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#sections-what-issues-does-this-pr-fix-or-reference-and-how-to-test-this-pr-completed)
- [ ] [Relevant user documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [Relevant contributing documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [CI/CD changes implemented, documented and communicated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#cicd-changes-implemented-documented-and-communicated)

### Reviewers

Reviewers, please comment how you tested the PR when approving it.
