### PR TITLE
Encode the authentication reject error to build a proper callback url

### DIFF
--- a/wsmaster/che-core-api-auth/src/main/java/org/eclipse/che/security/oauth/EmbeddedOAuthAPI.java
+++ b/wsmaster/che-core-api-auth/src/main/java/org/eclipse/che/security/oauth/EmbeddedOAuthAPI.java
@@ -27,7 +27,6 @@ import jakarta.ws.rs.core.UriInfo;
 import java.io.IOException;
 import java.net.URI;
 import java.net.URL;
-import java.net.URLDecoder;
 import java.net.URLEncoder;
 import java.util.*;
 import javax.inject.Inject;
@@ -87,16 +86,9 @@ public class EmbeddedOAuthAPI implements OAuthAPI, OAuthTokenFetcher {
     if (!isNullOrEmpty(redirectAfterLogin)
         && errorValues != null
         && errorValues.contains("access_denied")) {
-      String baseUrl = redirectAfterLogin;
-      String query = "";
-      if (redirectAfterLogin.contains("?")) {
-        baseUrl = redirectAfterLogin.substring(0, redirectAfterLogin.indexOf("?") + 1);
-        query =
-            URLDecoder.decode(
-                redirectAfterLogin.substring(redirectAfterLogin.indexOf("?") + 1), UTF_8);
-      }
       return Response.temporaryRedirect(
-              URI.create(baseUrl + URLEncoder.encode(query + "&error_code=access_denied", UTF_8)))
+              URI.create(
+                  redirectAfterLogin + URLEncoder.encode("&error_code=access_denied", UTF_8)))
           .build();
     }
     final String providerName = getParameter(params, "oauth_provider");

--- a/wsmaster/che-core-api-auth/src/main/java/org/eclipse/che/security/oauth/EmbeddedOAuthAPI.java
+++ b/wsmaster/che-core-api-auth/src/main/java/org/eclipse/che/security/oauth/EmbeddedOAuthAPI.java
@@ -12,6 +12,7 @@
 package org.eclipse.che.security.oauth;
 
 import static com.google.common.base.Strings.isNullOrEmpty;
+import static java.nio.charset.StandardCharsets.UTF_8;
 import static java.util.Collections.emptyList;
 import static org.eclipse.che.commons.lang.UrlUtils.*;
 import static org.eclipse.che.commons.lang.UrlUtils.getParameter;
@@ -26,6 +27,8 @@ import jakarta.ws.rs.core.UriInfo;
 import java.io.IOException;
 import java.net.URI;
 import java.net.URL;
+import java.net.URLDecoder;
+import java.net.URLEncoder;
 import java.util.*;
 import javax.inject.Inject;
 import javax.inject.Named;
@@ -84,8 +87,16 @@ public class EmbeddedOAuthAPI implements OAuthAPI, OAuthTokenFetcher {
     if (!isNullOrEmpty(redirectAfterLogin)
         && errorValues != null
         && errorValues.contains("access_denied")) {
+      String baseUrl = redirectAfterLogin;
+      String query = "";
+      if (redirectAfterLogin.contains("?")) {
+        baseUrl = redirectAfterLogin.substring(0, redirectAfterLogin.indexOf("?") + 1);
+        query =
+            URLDecoder.decode(
+                redirectAfterLogin.substring(redirectAfterLogin.indexOf("?") + 1), UTF_8);
+      }
       return Response.temporaryRedirect(
-              URI.create(redirectAfterLogin + "&error_code=access_denied"))
+              URI.create(baseUrl + URLEncoder.encode(query + "&error_code=access_denied", UTF_8)))
           .build();
     }
     final String providerName = getParameter(params, "oauth_provider");

--- a/wsmaster/che-core-api-auth/src/test/java/org/eclipse/che/security/oauth/EmbeddedOAuthAPITest.java
+++ b/wsmaster/che-core-api-auth/src/test/java/org/eclipse/che/security/oauth/EmbeddedOAuthAPITest.java
@@ -11,6 +11,7 @@
  */
 package org.eclipse.che.security.oauth;
 
+import static java.util.Collections.singletonList;
 import static org.eclipse.che.dto.server.DtoFactory.newDto;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
@@ -18,6 +19,10 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 import static org.testng.Assert.assertEquals;
 
+import jakarta.ws.rs.core.Response;
+import jakarta.ws.rs.core.UriInfo;
+import java.lang.reflect.Field;
+import java.net.URI;
 import org.eclipse.che.api.auth.shared.dto.OAuthToken;
 import org.eclipse.che.api.core.NotFoundException;
 import org.mockito.InjectMocks;
@@ -53,5 +58,23 @@ public class EmbeddedOAuthAPITest {
     OAuthToken result = embeddedOAuthAPI.getToken(provider);
 
     assertEquals(result.getToken(), token);
+  }
+
+  @Test
+  public void shouldEncodeRejectErrorForRedirectUrl() throws Exception {
+    // given
+    UriInfo uriInfo = mock(UriInfo.class);
+    when(uriInfo.getRequestUri()).thenReturn(new URI("http://eclipse.che"));
+    Field redirectAfterLogin = EmbeddedOAuthAPI.class.getDeclaredField("redirectAfterLogin");
+    redirectAfterLogin.setAccessible(true);
+    redirectAfterLogin.set(embeddedOAuthAPI, "http://eclipse.che?quary=param");
+
+    // when
+    Response callback = embeddedOAuthAPI.callback(uriInfo, singletonList("access_denied"));
+
+    // then
+    assertEquals(
+        callback.getLocation().toString(),
+        "http://eclipse.che?quary=param%26error_code%3Daccess_denied");
   }
 }

--- a/wsmaster/che-core-api-auth/src/test/java/org/eclipse/che/security/oauth/EmbeddedOAuthAPITest.java
+++ b/wsmaster/che-core-api-auth/src/test/java/org/eclipse/che/security/oauth/EmbeddedOAuthAPITest.java
@@ -75,6 +75,6 @@ public class EmbeddedOAuthAPITest {
     // then
     assertEquals(
         callback.getLocation().toString(),
-        "http://eclipse.che?quary=param%26error_code%3Daccess_denied");
+        "http://eclipse.che?quary%3Dparam%26error_code%3Daccess_denied");
   }
 }

--- a/wsmaster/che-core-api-auth/src/test/java/org/eclipse/che/security/oauth/EmbeddedOAuthAPITest.java
+++ b/wsmaster/che-core-api-auth/src/test/java/org/eclipse/che/security/oauth/EmbeddedOAuthAPITest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012-2018 Red Hat, Inc.
+ * Copyright (c) 2012-2023 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/


### PR DESCRIPTION
<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests
-->

### What does this PR do?
Encode the `&error_code=access_denied` query param for the callback url in order to fix the bug when the authentication request appears again if it was rejected.

**DO NOT MERGE** until https://github.com/eclipse-che/che-dashboard/pull/932 is merged
### Screenshot/screencast of this PR
<!-- Please include a screenshot or a screencast explaining what is doing this PR -->


### What issues does this PR fix or reference?
<!-- Please include any related issue from eclipse che repository (or from another issue tracker).
     Include link to other pull requests like documentation PR from [the docs repo](https://github.com/eclipse/che-docs)
-->
https://github.com/eclipse/che/issues/22499
fixes https://github.com/eclipse/che/issues/22539

### How to test this PR?
<!-- Please explain for example :
  - The test platform (openshift, kubernetes, minikube, CodeReady Container, docker-desktop, etc)
  - Installation method: chectl / che-operator
  - steps to reproduce
 -->
1. Deploy che with the PR image `quay.io/eclipse/che-server:pr-568`
2. Setup the [GitHub oauth flow](https://eclipse.dev/che/docs/stable/administration-guide/configuring-oauth-2-for-github/).
3. Create a workspace from a public GitHub repository.
4. When the authentication page appears, reject the request.

See: the workspace start proceeds without fetching the token. 

### PR Checklist

[As the author of this Pull Request I made sure that:](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#pull-request-template-and-its-checklist)

- [x] [The Eclipse Contributor Agreement is valid](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-eclipse-contributor-agreement-is-valid)
- [x] [Code produced is complete](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-produced-is-complete)
- [x] [Code builds without errors](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-builds-without-errors)
- [x] [Tests are covering the bugfix](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#tests-are-covering-the-bugfix)
- [ ] [The repository devfile is up to date and works](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-repository-devfile-is-up-to-date-and-works)
- [x] [Sections `What issues does this PR fix or reference` and `How to test this PR` completed](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#sections-what-issues-does-this-pr-fix-or-reference-and-how-to-test-this-pr-completed)
- [ ] [Relevant user documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [Relevant contributing documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [CI/CD changes implemented, documented and communicated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#cicd-changes-implemented-documented-and-communicated)

### Reviewers

Reviewers, please comment how you tested the PR when approving it.
