### PR TITLE
chore: comment out node10 (updated to node18) and maven 3.6 (updated to 3.8) installs, as we likely don't need them (either not required or handled by GH action) #22616

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2020 Red Hat, Inc.
+# Copyright (c) 2020-2023 Red Hat, Inc.
 # This program and the accompanying materials are made
 # available under the terms of the Eclipse Public License 2.0
 # which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/make-release.sh
+++ b/make-release.sh
@@ -50,21 +50,22 @@ loadMvnSettingsGpgKey() {
     gpg --version
 }
 
-installDebDeps(){
-    set +x
-    # TODO should this be node 12?
-    curl -sL https://deb.nodesource.com/setup_10.x | sudo -E bash -
-    sudo apt-get install -y nodejs
-}
+# comment out: why do we think we need nodejs installed for a java build?
+# installDebDeps(){
+#     set +x
+#     curl -sL https://deb.nodesource.com/setup_18.x | sudo -E bash -
+#     sudo apt-get install -y nodejs
+# }
 
-installMaven(){
-    set -x
-    mkdir -p /opt/apache-maven && curl -sSL https://downloads.apache.org/maven/maven-3/3.6.3/binaries/apache-maven-3.6.3-bin.tar.gz | tar -xz --strip=1 -C /opt/apache-maven
-    export M2_HOME="/opt/apache-maven"
-    export PATH="/opt/apache-maven/bin:${PATH}"
-    mvn -version || die_with "mvn not found in path: ${PATH} !"
-    set +x
-}
+# comment out: already installed via GH action so no need to do it again
+# installMaven(){
+#     set -x
+#     mkdir -p /opt/apache-maven && curl -sSL https://downloads.apache.org/maven/maven-3/3.8.8/binaries/apache-maven-3.8.8-bin.tar.gz | tar -xz --strip=1 -C /opt/apache-maven
+#     export M2_HOME="/opt/apache-maven"
+#     export PATH="/opt/apache-maven/bin:${PATH}"
+#     mvn -version || die_with "mvn not found in path: ${PATH} !"
+#     set +x
+# }
 
 evaluateCheVariables() {
     echo "Che version: ${CHE_VERSION}"
@@ -414,9 +415,14 @@ updateImageTagsInCheServer() {
     popd >/dev/null
 }
 
-installMaven
+# already installed via GH action so no need to do it again
+# installMaven
+
 loadMvnSettingsGpgKey
-installDebDeps
+
+# why do we think we need nodejs installed for a java build?
+# installDebDeps 
+
 set -x
 setupGitconfig
 

--- a/typescript-dto/build.sh
+++ b/typescript-dto/build.sh
@@ -17,7 +17,7 @@ rm -f ./index.d.ts
 set +e
 docker run -i --rm -v "$HOME/.m2:/root/.m2" \
                    -v "$(pwd)/dto-pom.xml:/usr/src/mymaven/pom.xml" \
-                   -w /usr/src/mymaven maven:3.6.1-jdk-11 \
+                   -w /usr/src/mymaven docker.io/maven:3.8-jdk-11 \
                     /bin/bash -c "mvn -q -U -DskipTests=true -Dfindbugs.skip=true -Dskip-validate-sources install \
                     && cat target/dts-dto-typescript.d.ts" >> index.d.ts
 

--- a/typescript-dto/build.sh
+++ b/typescript-dto/build.sh
@@ -15,7 +15,9 @@ set -u
 rm -f ./index.d.ts
 
 set +e
-docker run -i --rm -v "$HOME/.m2:/root/.m2" \
+BUILDER=$(command -v podman)
+if [ ! -x "$BUILDER" ]; then BUILDER=$(command -v docker); fi
+$BUILDER run -i --rm -v "$HOME/.m2:/root/.m2" \
                    -v "$(pwd)/dto-pom.xml:/usr/src/mymaven/pom.xml" \
                    -w /usr/src/mymaven docker.io/maven:3.8-jdk-11 \
                     /bin/bash -c "mvn -q -U -DskipTests=true -Dfindbugs.skip=true -Dskip-validate-sources install \
@@ -31,4 +33,4 @@ fi
 
 CHE_VERSION=$(mvn -q -Dexec.executable=echo -Dexec.args="\${project.version}" --non-recursive exec:exec -f ../pom.xml)
 
-docker build -t eclipse-che-ts-api --build-arg CHE_VERSION="${CHE_VERSION}" --build-arg NPM_AUTH_TOKEN="${CHE_NPM_AUTH_TOKEN}" .
+$BUILDER build -t eclipse-che-ts-api --build-arg CHE_VERSION="${CHE_VERSION}" --build-arg NPM_AUTH_TOKEN="${CHE_NPM_AUTH_TOKEN}" .


### PR DESCRIPTION
### What does this PR do?

comment out node10 (updated to node18) and maven 3.6 (updated to 3.8) installs, as we likely don't need them (either not required or handled by GH action) #22616

use maven 3.8 for typescript-dto build too (not 3.6.1)

Change-Id: I5d0920b58e413247fd5466a269fb26b1af60578c
Signed-off-by: Nick Boldt <nboldt@redhat.com>

### Screenshot/screencast of this PR
N/A

### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/22616

Recommend merging https://github.com/eclipse-che/che-server/pull/573 before this PR, after Che 7.76.0 is released.

### How to test this PR?
N/A

### PR Checklist

[As the author of this Pull Request I made sure that:](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#pull-request-template-and-its-checklist)

- [x] [The Eclipse Contributor Agreement is valid](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-eclipse-contributor-agreement-is-valid)
- [x] [Code produced is complete](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-produced-is-complete)
- [x] [Code builds without errors](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-builds-without-errors)
- [ ] [Tests are covering the bugfix](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#tests-are-covering-the-bugfix)
- [x] [The repository devfile is up to date and works, if one exists](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-repository-devfile-is-up-to-date-and-works)
- [x] [Sections What issues does this PR fix or reference and How to test this PR completed](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#sections-what-issues-does-this-pr-fix-or-reference-and-how-to-test-this-pr-completed)
- [x] [Relevant user documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [x] [Relevant contributing documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [x] [CI/CD changes implemented, documented and communicated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#cicd-changes-implemented-documented-and-communicated)

### Reviewers

Reviewers, please comment how you tested the PR when approving it.