### PR TITLE
Fix update token on workspace start

### DIFF
--- a/wsmaster/che-core-api-factory-azure-devops/pom.xml
+++ b/wsmaster/che-core-api-factory-azure-devops/pom.xml
@@ -140,5 +140,10 @@
             <artifactId>testng</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.wiremock</groupId>
+            <artifactId>wiremock-standalone</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 </project>

--- a/wsmaster/che-core-api-factory-github/src/test/java/org/eclipse/che/api/factory/server/github/GithubPersonalAccessTokenFetcherTest.java
+++ b/wsmaster/che-core-api-factory-github/src/test/java/org/eclipse/che/api/factory/server/github/GithubPersonalAccessTokenFetcherTest.java
@@ -161,6 +161,21 @@ public class GithubPersonalAccessTokenFetcherTest {
     githubPATFetcher.fetchPersonalAccessToken(subject, wireMockServer.url("/"));
   }
 
+  @Test(
+      expectedExceptions = ScmUnauthorizedException.class,
+      expectedExceptionsMessageRegExp = "Username is not authorized in github OAuth provider.")
+  public void shouldThrowUnauthorizedExceptionIfTokenIsNotValid() throws Exception {
+    Subject subject = new SubjectImpl("Username", "id1", "token", false);
+    OAuthToken oAuthToken = newDto(OAuthToken.class).withToken(githubOauthToken).withScope("");
+    when(oAuthAPI.getToken(anyString())).thenReturn(oAuthToken);
+    stubFor(
+        get(urlEqualTo("/api/v3/user"))
+            .withHeader(HttpHeaders.AUTHORIZATION, equalTo("token " + githubOauthToken))
+            .willReturn(aResponse().withStatus(HTTP_FORBIDDEN)));
+
+    githubPATFetcher.fetchPersonalAccessToken(subject, wireMockServer.url("/"));
+  }
+
   @Test
   public void shouldReturnToken() throws Exception {
     Subject subject = new SubjectImpl("Username", "id1", "token", false);

--- a/wsmaster/che-core-api-factory/src/main/java/org/eclipse/che/api/factory/server/FactoryService.java
+++ b/wsmaster/che-core-api-factory/src/main/java/org/eclipse/che/api/factory/server/FactoryService.java
@@ -151,10 +151,8 @@ public class FactoryService extends Service {
       FactoryParametersResolver factoryParametersResolver =
           factoryParametersResolverHolder.getFactoryParametersResolver(
               singletonMap(URL_PARAMETER_NAME, url));
-      if (!authorisationRequestManager.isStored(factoryParametersResolver.getProviderName())) {
-        personalAccessTokenManager.getAndStore(
-            factoryParametersResolver.parseFactoryUrl(url).getHostName());
-      }
+      personalAccessTokenManager.getAndStore(
+          factoryParametersResolver.parseFactoryUrl(url).getProviderUrl());
     } catch (ScmCommunicationException
         | ScmConfigurationPersistenceException
         | UnknownScmProviderException

--- a/wsmaster/che-core-api-factory/src/main/java/org/eclipse/che/api/factory/server/FactoryService.java
+++ b/wsmaster/che-core-api-factory/src/main/java/org/eclipse/che/api/factory/server/FactoryService.java
@@ -153,6 +153,7 @@ public class FactoryService extends Service {
               singletonMap(URL_PARAMETER_NAME, url));
       if (!authorisationRequestManager.isStored(factoryParametersResolver.getProviderName())) {
         personalAccessTokenManager.getAndStore(
+            // get the provider URL from the factory URL
             factoryParametersResolver.parseFactoryUrl(url).getProviderUrl());
       }
     } catch (ScmCommunicationException

--- a/wsmaster/che-core-api-factory/src/main/java/org/eclipse/che/api/factory/server/FactoryService.java
+++ b/wsmaster/che-core-api-factory/src/main/java/org/eclipse/che/api/factory/server/FactoryService.java
@@ -151,8 +151,10 @@ public class FactoryService extends Service {
       FactoryParametersResolver factoryParametersResolver =
           factoryParametersResolverHolder.getFactoryParametersResolver(
               singletonMap(URL_PARAMETER_NAME, url));
-      personalAccessTokenManager.getAndStore(
-          factoryParametersResolver.parseFactoryUrl(url).getProviderUrl());
+      if (!authorisationRequestManager.isStored(factoryParametersResolver.getProviderName())) {
+        personalAccessTokenManager.getAndStore(
+            factoryParametersResolver.parseFactoryUrl(url).getProviderUrl());
+      }
     } catch (ScmCommunicationException
         | ScmConfigurationPersistenceException
         | UnknownScmProviderException

--- a/wsmaster/che-core-api-factory/src/test/java/org/eclipse/che/api/factory/server/FactoryServiceTest.java
+++ b/wsmaster/che-core-api-factory/src/test/java/org/eclipse/che/api/factory/server/FactoryServiceTest.java
@@ -95,6 +95,8 @@ public class FactoryServiceTest {
 
   private static final DtoFactory DTO = DtoFactory.getInstance();
 
+  private final String scmServerUrl = "https://hostName.com";
+
   @Mock private FactoryAcceptValidator acceptValidator;
   @Mock private PreferenceManager preferenceManager;
   @Mock private UserManager userManager;
@@ -240,7 +242,7 @@ public class FactoryServiceTest {
     FactoryParametersResolver factoryParametersResolver = mock(FactoryParametersResolver.class);
     RemoteFactoryUrl remoteFactoryUrl = mock(RemoteFactoryUrl.class);
     when(factoryParametersResolver.parseFactoryUrl(eq("someUrl"))).thenReturn(remoteFactoryUrl);
-    when(remoteFactoryUrl.getHostName()).thenReturn("hostName");
+    when(remoteFactoryUrl.getProviderUrl()).thenReturn(scmServerUrl);
     doReturn(factoryParametersResolver).when(dummyHolder).getFactoryParametersResolver(anyMap());
     service =
         new FactoryService(
@@ -258,7 +260,7 @@ public class FactoryServiceTest {
         .post(SERVICE_PATH + "/token/refresh");
 
     // then
-    verify(personalAccessTokenManager).getAndStore(eq("hostName"));
+    verify(personalAccessTokenManager).getAndStore(eq(scmServerUrl));
   }
 
   @Test
@@ -267,7 +269,6 @@ public class FactoryServiceTest {
     final FactoryParametersResolverHolder dummyHolder = spy(factoryParametersResolverHolder);
     FactoryParametersResolver factoryParametersResolver = mock(FactoryParametersResolver.class);
     doReturn(factoryParametersResolver).when(dummyHolder).getFactoryParametersResolver(anyMap());
-    when(authorisationRequestManager.isStored(any())).thenReturn(true);
     service =
         new FactoryService(
             acceptValidator,
@@ -284,7 +285,7 @@ public class FactoryServiceTest {
         .post(SERVICE_PATH + "/token/refresh");
 
     // then
-    verify(personalAccessTokenManager, never()).getAndStore(eq("hostName"));
+    verify(personalAccessTokenManager, never()).getAndStore(eq(scmServerUrl));
   }
 
   @Test

--- a/wsmaster/che-core-api-factory/src/test/java/org/eclipse/che/api/factory/server/FactoryServiceTest.java
+++ b/wsmaster/che-core-api-factory/src/test/java/org/eclipse/che/api/factory/server/FactoryServiceTest.java
@@ -269,6 +269,7 @@ public class FactoryServiceTest {
     final FactoryParametersResolverHolder dummyHolder = spy(factoryParametersResolverHolder);
     FactoryParametersResolver factoryParametersResolver = mock(FactoryParametersResolver.class);
     doReturn(factoryParametersResolver).when(dummyHolder).getFactoryParametersResolver(anyMap());
+    when(authorisationRequestManager.isStored(any())).thenReturn(true);
     service =
         new FactoryService(
             acceptValidator,


### PR DESCRIPTION
<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests
-->

### What does this PR do?
* Change the `getHostName()` function to `getProviderUrl()` in order to fix an error while updating an oauth token on workspace start.
* Throw `ScmUnauthorizedException` if an oAuth token is not valid, for the dashboard to open the authorisation page and update the token.

### Screenshot/screencast of this PR
<!-- Please include a screenshot or a screencast explaining what is doing this PR -->


### What issues does this PR fix or reference?
<!-- Please include any related issue from eclipse che repository (or from another issue tracker).
     Include link to other pull requests like documentation PR from [the docs repo](https://github.com/eclipse/che-docs)
-->
https://issues.redhat.com/browse/CRW-4957

### How to test this PR?
<!-- Please explain for example :
  - The test platform (openshift, kubernetes, minikube, CodeReady Container, docker-desktop, etc)
  - Installation method: chectl / che-operator
  - steps to reproduce
 -->
1. Deploy che from the PR image: `quay.io/eclipse/che-server:pr-597`
2. Configure GitHub (or other) oAuth2 flow.
3. Start a workspace from the GitHub repository, accept the authorisation page.
4. Go to the GitHub settings and revoke the authorisation.
5. Stop the workspace and start it again.

See: Authorisation appears and token secret is updated in the user namespace.

### PR Checklist

[As the author of this Pull Request I made sure that:](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#pull-request-template-and-its-checklist)

- [ ] [The Eclipse Contributor Agreement is valid](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-eclipse-contributor-agreement-is-valid)
- [ ] [Code produced is complete](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-produced-is-complete)
- [ ] [Code builds without errors](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-builds-without-errors)
- [ ] [Tests are covering the bugfix](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#tests-are-covering-the-bugfix)
- [ ] [The repository devfile is up to date and works](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-repository-devfile-is-up-to-date-and-works)
- [ ] [Sections `What issues does this PR fix or reference` and `How to test this PR` completed](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#sections-what-issues-does-this-pr-fix-or-reference-and-how-to-test-this-pr-completed)
- [ ] [Relevant user documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [Relevant contributing documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [CI/CD changes implemented, documented and communicated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#cicd-changes-implemented-documented-and-communicated)

### Reviewers

Reviewers, please comment how you tested the PR when approving it.
