### PR TITLE
fix: work with Bitbucket users containing special characters in their…

### DIFF
--- a/infrastructures/infrastructure-factory/src/main/java/org/eclipse/che/api/factory/server/scm/kubernetes/KubernetesGitCredentialManager.java
+++ b/infrastructures/infrastructure-factory/src/main/java/org/eclipse/che/api/factory/server/scm/kubernetes/KubernetesGitCredentialManager.java
@@ -23,6 +23,7 @@ import static org.eclipse.che.workspace.infrastructure.kubernetes.provision.secr
 import static org.eclipse.che.workspace.infrastructure.kubernetes.provision.secret.KubernetesSecretAnnotationNames.DEV_WORKSPACE_PREFIX;
 
 import com.google.common.collect.ImmutableMap;
+import com.google.common.net.PercentEscaper;
 import io.fabric8.kubernetes.api.model.ObjectMeta;
 import io.fabric8.kubernetes.api.model.ObjectMetaBuilder;
 import io.fabric8.kubernetes.api.model.Secret;
@@ -173,10 +174,12 @@ public class KubernetesGitCredentialManager implements GitCredentialManager {
    * field.
    */
   private String getUsernameSegment(PersonalAccessToken personalAccessToken) {
+    // Special characters are not allowed in URL username segment, so we need to escape them.
+    PercentEscaper percentEscaper = new PercentEscaper("", false);
     return personalAccessToken.getScmTokenName().startsWith(OAUTH_2_PREFIX)
         ? "oauth2"
         : isNullOrEmpty(personalAccessToken.getScmOrganization())
-            ? personalAccessToken.getScmUserName()
+            ? percentEscaper.escape(personalAccessToken.getScmUserName())
             : "username";
   }
 

--- a/wsmaster/che-core-api-factory-bitbucket-server/src/main/java/org/eclipse/che/api/factory/server/bitbucket/BitbucketServerPersonalAccessTokenFetcher.java
+++ b/wsmaster/che-core-api-factory-bitbucket-server/src/main/java/org/eclipse/che/api/factory/server/bitbucket/BitbucketServerPersonalAccessTokenFetcher.java
@@ -131,8 +131,7 @@ public class BitbucketServerPersonalAccessTokenFetcher implements PersonalAccess
     }
     try {
       BitbucketPersonalAccessToken bitbucketPersonalAccessToken =
-          bitbucketServerApiClient.getPersonalAccessToken(
-              Long.valueOf(personalAccessToken.getScmTokenId()));
+          bitbucketServerApiClient.getPersonalAccessToken(personalAccessToken.getScmTokenId());
       return Optional.of(DEFAULT_TOKEN_SCOPE.equals(bitbucketPersonalAccessToken.getPermissions()));
     } catch (ScmItemNotFoundException e) {
       return Optional.of(Boolean.FALSE);
@@ -167,7 +166,7 @@ public class BitbucketServerPersonalAccessTokenFetcher implements PersonalAccess
       }
       // Token is added by OAuth. Token id is available.
       BitbucketPersonalAccessToken bitbucketPersonalAccessToken =
-          bitbucketServerApiClient.getPersonalAccessToken(Long.valueOf(params.getScmTokenId()));
+          bitbucketServerApiClient.getPersonalAccessToken(params.getScmTokenId());
       return Optional.of(
           Pair.of(
               DEFAULT_TOKEN_SCOPE.equals(bitbucketPersonalAccessToken.getPermissions())

--- a/wsmaster/che-core-api-factory-bitbucket-server/src/main/java/org/eclipse/che/api/factory/server/bitbucket/server/BitbucketPersonalAccessToken.java
+++ b/wsmaster/che-core-api-factory-bitbucket-server/src/main/java/org/eclipse/che/api/factory/server/bitbucket/server/BitbucketPersonalAccessToken.java
@@ -17,7 +17,7 @@ import java.util.Set;
 
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class BitbucketPersonalAccessToken {
-  private long id;
+  private String id;
   private long createdDate;
   private long lastAuthenticated;
   private int expiryDays;
@@ -35,7 +35,7 @@ public class BitbucketPersonalAccessToken {
   public BitbucketPersonalAccessToken() {}
 
   public BitbucketPersonalAccessToken(
-      long id,
+      String id,
       long createdDate,
       long lastAuthenticated,
       int expiryDays,
@@ -53,11 +53,11 @@ public class BitbucketPersonalAccessToken {
     this.permissions = permissions;
   }
 
-  public long getId() {
+  public String getId() {
     return id;
   }
 
-  public void setId(long id) {
+  public void setId(String id) {
     this.id = id;
   }
 
@@ -146,7 +146,7 @@ public class BitbucketPersonalAccessToken {
     if (this == o) return true;
     if (o == null || getClass() != o.getClass()) return false;
     BitbucketPersonalAccessToken that = (BitbucketPersonalAccessToken) o;
-    return id == that.id
+    return id.equals(that.id)
         && createdDate == that.createdDate
         && lastAuthenticated == that.lastAuthenticated
         && expiryDays == that.expiryDays

--- a/wsmaster/che-core-api-factory-bitbucket-server/src/main/java/org/eclipse/che/api/factory/server/bitbucket/server/BitbucketServerApiClient.java
+++ b/wsmaster/che-core-api-factory-bitbucket-server/src/main/java/org/eclipse/che/api/factory/server/bitbucket/server/BitbucketServerApiClient.java
@@ -69,7 +69,7 @@ public interface BitbucketServerApiClient {
    * @throws ScmUnauthorizedException
    * @throws ScmCommunicationException
    */
-  void deletePersonalAccessTokens(Long tokenId)
+  void deletePersonalAccessTokens(String tokenId)
       throws ScmItemNotFoundException, ScmUnauthorizedException, ScmCommunicationException;
 
   /**
@@ -103,6 +103,6 @@ public interface BitbucketServerApiClient {
    * @return - Bitbucket personal access token.
    * @throws ScmCommunicationException
    */
-  BitbucketPersonalAccessToken getPersonalAccessToken(Long tokenId)
+  BitbucketPersonalAccessToken getPersonalAccessToken(String tokenId)
       throws ScmItemNotFoundException, ScmUnauthorizedException, ScmCommunicationException;
 }

--- a/wsmaster/che-core-api-factory-bitbucket-server/src/main/java/org/eclipse/che/api/factory/server/bitbucket/server/NoopBitbucketServerApiClient.java
+++ b/wsmaster/che-core-api-factory-bitbucket-server/src/main/java/org/eclipse/che/api/factory/server/bitbucket/server/NoopBitbucketServerApiClient.java
@@ -57,7 +57,7 @@ public class NoopBitbucketServerApiClient implements BitbucketServerApiClient {
   }
 
   @Override
-  public void deletePersonalAccessTokens(Long tokenId)
+  public void deletePersonalAccessTokens(String tokenId)
       throws ScmItemNotFoundException, ScmUnauthorizedException, ScmCommunicationException {
     throw new RuntimeException(
         "The fallback noop api client cannot be used for real operation. Make sure Bitbucket OAuth1 is properly configured.");
@@ -77,7 +77,7 @@ public class NoopBitbucketServerApiClient implements BitbucketServerApiClient {
   }
 
   @Override
-  public BitbucketPersonalAccessToken getPersonalAccessToken(Long tokenId)
+  public BitbucketPersonalAccessToken getPersonalAccessToken(String tokenId)
       throws ScmItemNotFoundException, ScmUnauthorizedException, ScmCommunicationException {
     throw new RuntimeException("Invalid usage of BitbucketServerApi");
   }

--- a/wsmaster/che-core-api-factory-bitbucket-server/src/test/java/org/eclipse/che/api/factory/server/bitbucket/BitbucketServerPersonalAccessTokenFetcherTest.java
+++ b/wsmaster/che-core-api-factory-bitbucket-server/src/test/java/org/eclipse/che/api/factory/server/bitbucket/BitbucketServerPersonalAccessTokenFetcherTest.java
@@ -78,7 +78,7 @@ public class BitbucketServerPersonalAccessTokenFetcherTest {
             "User User", "user-name", 32423523, "NORMAL", true, "user-slug", "user@users.com");
     bitbucketPersonalAccessToken =
         new BitbucketPersonalAccessToken(
-            234234,
+            "234234",
             234345345,
             23534534,
             90,
@@ -88,7 +88,7 @@ public class BitbucketServerPersonalAccessTokenFetcherTest {
             ImmutableSet.of("PROJECT_WRITE", "REPO_WRITE"));
     bitbucketPersonalAccessToken2 =
         new BitbucketPersonalAccessToken(
-            3647456,
+            "3647456",
             234345345,
             23534534,
             90,
@@ -98,7 +98,7 @@ public class BitbucketServerPersonalAccessTokenFetcherTest {
             ImmutableSet.of("REPO_READ"));
     bitbucketPersonalAccessToken3 =
         new BitbucketPersonalAccessToken(
-            132423,
+            "132423",
             234345345,
             23534534,
             90,
@@ -222,7 +222,7 @@ public class BitbucketServerPersonalAccessTokenFetcherTest {
     // given
     when(personalAccessTokenParams.getScmProviderUrl()).thenReturn(someBitbucketURL);
     when(personalAccessTokenParams.getScmTokenId())
-        .thenReturn(Long.toString(bitbucketPersonalAccessToken.getId()));
+        .thenReturn(bitbucketPersonalAccessToken.getId());
     when(bitbucketServerApiClient.isConnected(eq(someBitbucketURL))).thenReturn(true);
     when(bitbucketServerApiClient.getPersonalAccessToken(eq(bitbucketPersonalAccessToken.getId())))
         .thenReturn(bitbucketPersonalAccessToken);

--- a/wsmaster/che-core-api-factory-bitbucket-server/src/test/java/org/eclipse/che/api/factory/server/bitbucket/HttpBitbucketServerApiClientTest.java
+++ b/wsmaster/che-core-api-factory-bitbucket-server/src/test/java/org/eclipse/che/api/factory/server/bitbucket/HttpBitbucketServerApiClientTest.java
@@ -122,6 +122,16 @@ public class HttpBitbucketServerApiClientTest {
                     .withHeader("Content-Type", "application/json; charset=utf-8")
                     .withBodyFile("bitbucket/rest/api/1.0/users/ksmster/response.json")));
 
+    stubFor(
+        get(urlPathEqualTo("/rest/api/1.0/users"))
+            .withHeader(HttpHeaders.AUTHORIZATION, equalTo(AUTHORIZATION_TOKEN))
+            .withQueryParam("start", equalTo("0"))
+            .withQueryParam("limit", equalTo("25"))
+            .willReturn(
+                aResponse()
+                    .withHeader("Content-Type", "application/json; charset=utf-8")
+                    .withBodyFile("bitbucket/rest/api/1.0/users/filtered/response.json")));
+
     BitbucketUser user = bitbucketServer.getUser();
     assertNotNull(user);
   }
@@ -219,6 +229,16 @@ public class HttpBitbucketServerApiClientTest {
                     .withHeader("Content-Type", "application/json; charset=utf-8")
                     .withBodyFile("bitbucket/rest/access-tokens/1.0/users/ksmster/response.json")));
 
+    stubFor(
+        get(urlPathEqualTo("/rest/api/1.0/users"))
+            .withHeader(HttpHeaders.AUTHORIZATION, equalTo(AUTHORIZATION_TOKEN))
+            .withQueryParam("start", equalTo("0"))
+            .withQueryParam("limit", equalTo("25"))
+            .willReturn(
+                aResponse()
+                    .withHeader("Content-Type", "application/json; charset=utf-8")
+                    .withBodyFile("bitbucket/rest/api/1.0/users/filtered/response.json")));
+
     List<String> page =
         bitbucketServer.getPersonalAccessTokens().stream()
             .map(BitbucketPersonalAccessToken::getName)
@@ -237,9 +257,18 @@ public class HttpBitbucketServerApiClientTest {
             .withHeader(HttpHeaders.AUTHORIZATION, equalTo(AUTHORIZATION_TOKEN))
             .withHeader(HttpHeaders.ACCEPT, equalTo(MediaType.APPLICATION_JSON))
             .withHeader(HttpHeaders.CONTENT_TYPE, equalTo(MediaType.APPLICATION_JSON))
-            .withHeader(HttpHeaders.CONTENT_LENGTH, equalTo("149"))
+            .withHeader(HttpHeaders.CONTENT_LENGTH, equalTo("152"))
             .willReturn(
                 ok().withBodyFile("bitbucket/rest/access-tokens/1.0/users/ksmster/newtoken.json")));
+    stubFor(
+        get(urlPathEqualTo("/rest/api/1.0/users"))
+            .withHeader(HttpHeaders.AUTHORIZATION, equalTo(AUTHORIZATION_TOKEN))
+            .withQueryParam("start", equalTo("0"))
+            .withQueryParam("limit", equalTo("25"))
+            .willReturn(
+                aResponse()
+                    .withHeader("Content-Type", "application/json; charset=utf-8")
+                    .withBodyFile("bitbucket/rest/api/1.0/users/filtered/response.json")));
 
     // when
     BitbucketPersonalAccessToken result =
@@ -262,8 +291,18 @@ public class HttpBitbucketServerApiClientTest {
             .withHeader(HttpHeaders.CONTENT_TYPE, equalTo(MediaType.APPLICATION_JSON))
             .willReturn(aResponse().withStatus(204)));
 
+    stubFor(
+        get(urlPathEqualTo("/rest/api/1.0/users"))
+            .withHeader(HttpHeaders.AUTHORIZATION, equalTo(AUTHORIZATION_TOKEN))
+            .withQueryParam("start", equalTo("0"))
+            .withQueryParam("limit", equalTo("25"))
+            .willReturn(
+                aResponse()
+                    .withHeader("Content-Type", "application/json; charset=utf-8")
+                    .withBodyFile("bitbucket/rest/api/1.0/users/filtered/response.json")));
+
     // when
-    bitbucketServer.deletePersonalAccessTokens(5L);
+    bitbucketServer.deletePersonalAccessTokens("5");
   }
 
   @Test
@@ -278,8 +317,18 @@ public class HttpBitbucketServerApiClientTest {
             .willReturn(
                 ok().withBodyFile("bitbucket/rest/access-tokens/1.0/users/ksmster/newtoken.json")));
 
+    stubFor(
+        get(urlPathEqualTo("/rest/api/1.0/users"))
+            .withHeader(HttpHeaders.AUTHORIZATION, equalTo(AUTHORIZATION_TOKEN))
+            .withQueryParam("start", equalTo("0"))
+            .withQueryParam("limit", equalTo("25"))
+            .willReturn(
+                aResponse()
+                    .withHeader("Content-Type", "application/json; charset=utf-8")
+                    .withBodyFile("bitbucket/rest/api/1.0/users/filtered/response.json")));
+
     // when
-    BitbucketPersonalAccessToken result = bitbucketServer.getPersonalAccessToken(5L);
+    BitbucketPersonalAccessToken result = bitbucketServer.getPersonalAccessToken("5");
     // then
     assertNotNull(result);
     assertEquals(result.getToken(), "MTU4OTEwNTMyOTA5Ohc88HcY8k7gWOzl2mP5TtdtY5Qs");
@@ -297,7 +346,18 @@ public class HttpBitbucketServerApiClientTest {
             .willReturn(notFound()));
 
     // when
-    bitbucketServer.getPersonalAccessToken(5L);
+    bitbucketServer.getPersonalAccessToken("5");
+  }
+
+  @Test(expectedExceptions = ScmUnauthorizedException.class)
+  public void shouldBeAbleToThrowScmUnauthorizedExceptionOnGetUser()
+      throws ScmCommunicationException, ScmUnauthorizedException, ScmItemNotFoundException {
+    // given
+    stubFor(
+        get(urlEqualTo("/plugins/servlet/applinks/whoami")).willReturn(aResponse().withBody("")));
+
+    // when
+    bitbucketServer.getUser();
   }
 
   @Test(expectedExceptions = ScmUnauthorizedException.class)
@@ -310,9 +370,18 @@ public class HttpBitbucketServerApiClientTest {
             .withHeader(HttpHeaders.AUTHORIZATION, equalTo(AUTHORIZATION_TOKEN))
             .withHeader(HttpHeaders.ACCEPT, equalTo(MediaType.APPLICATION_JSON))
             .willReturn(unauthorized()));
+    stubFor(
+        get(urlPathEqualTo("/rest/api/1.0/users"))
+            .withHeader(HttpHeaders.AUTHORIZATION, equalTo(AUTHORIZATION_TOKEN))
+            .withQueryParam("start", equalTo("0"))
+            .withQueryParam("limit", equalTo("25"))
+            .willReturn(
+                aResponse()
+                    .withHeader("Content-Type", "application/json; charset=utf-8")
+                    .withBodyFile("bitbucket/rest/api/1.0/users/filtered/response.json")));
 
     // when
-    bitbucketServer.getPersonalAccessToken(5L);
+    bitbucketServer.getPersonalAccessToken("5");
   }
 
   @Test(
@@ -331,7 +400,7 @@ public class HttpBitbucketServerApiClientTest {
             wireMockServer.url("/"), new NoopOAuthAuthenticator(), oAuthAPI, apiEndpoint);
 
     // when
-    localServer.getPersonalAccessToken(5L);
+    localServer.getPersonalAccessToken("5");
   }
 
   @Test
@@ -353,6 +422,16 @@ public class HttpBitbucketServerApiClientTest {
                 aResponse()
                     .withHeader("Content-Type", "application/json; charset=utf-8")
                     .withBodyFile("bitbucket/rest/api/1.0/users/ksmster/response.json")));
+
+    stubFor(
+        get(urlPathEqualTo("/rest/api/1.0/users"))
+            .withHeader(HttpHeaders.AUTHORIZATION, equalTo("Bearer token"))
+            .withQueryParam("start", equalTo("0"))
+            .withQueryParam("limit", equalTo("25"))
+            .willReturn(
+                aResponse()
+                    .withHeader("Content-Type", "application/json; charset=utf-8")
+                    .withBodyFile("bitbucket/rest/api/1.0/users/filtered/response.json")));
 
     // when
     bitbucketServer.getUser();


### PR DESCRIPTION
…s names

<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests
-->

### What does this PR do?
1. Escape special characters while creating git credentials secrets, like user@user -> user%40user
2. Use user's slug instead of user's name in BitBucket requests
3. Use string as PAT token id for BitBucket

### Screenshot/screencast of this PR
<!-- Please include a screenshot or a screencast explaining what is doing this PR -->
N/A

### What issues does this PR fix or reference?
<!-- Please include any related issue from eclipse che repository (or from another issue tracker).
     Include link to other pull requests like documentation PR from [the docs repo](https://github.com/eclipse/che-docs)
-->
https://issues.redhat.com/browse/CRW-4832

### How to test this PR?
<!-- Please explain for example :
  - The test platform (openshift, kubernetes, minikube, CodeReady Container, docker-desktop, etc)
  - Installation method: chectl / che-operator
  - steps to reproduce
 -->
1. Deploy Eclipse Che
2. Deploy BitBucket server and import certificate to Eclipse Che
3. Create a user like this `admin@admin`
4. Try to create PAT and use it
5. Try to create OAuth and use it

### PR Checklist

[As the author of this Pull Request I made sure that:](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#pull-request-template-and-its-checklist)

- [x] [The Eclipse Contributor Agreement is valid](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-eclipse-contributor-agreement-is-valid)
- [x] [Code produced is complete](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-produced-is-complete)
- [x] [Code builds without errors](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-builds-without-errors)
- [ ] [Tests are covering the bugfix](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#tests-are-covering-the-bugfix)
- [ ] [The repository devfile is up to date and works](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-repository-devfile-is-up-to-date-and-works)
- [ ] [Sections `What issues does this PR fix or reference` and `How to test this PR` completed](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#sections-what-issues-does-this-pr-fix-or-reference-and-how-to-test-this-pr-completed)
- [ ] [Relevant user documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [Relevant contributing documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [CI/CD changes implemented, documented and communicated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#cicd-changes-implemented-documented-and-communicated)

### Reviewers

Reviewers, please comment how you tested the PR when approving it.
