### PR TITLE
Return oauth1 providers on registered oauth providers list request

### DIFF
--- a/infrastructures/infrastructure-factory/src/main/java/org/eclipse/che/api/factory/server/scm/kubernetes/KubernetesAuthorisationRequestManager.java
+++ b/infrastructures/infrastructure-factory/src/main/java/org/eclipse/che/api/factory/server/scm/kubernetes/KubernetesAuthorisationRequestManager.java
@@ -90,7 +90,10 @@ public class KubernetesAuthorisationRequestManager implements AuthorisationReque
     Map<String, List<String>> params = getQueryParametersFromState(getState(requestUrl));
     errorValues = errorValues == null ? uriInfo.getQueryParameters().get("error") : errorValues;
     if (errorValues != null && errorValues.contains("access_denied")) {
-      store(getParameter(params, "oauth_provider"));
+      String oauthProvider = getParameter(params, "oauth_provider");
+      if (!isNullOrEmpty(oauthProvider)) {
+        store(oauthProvider);
+      }
     }
   }
 

--- a/wsmaster/che-core-api-auth-bitbucket/src/main/java/org/eclipse/che/security/oauth1/BitbucketServerOAuthAuthenticator.java
+++ b/wsmaster/che-core-api-auth-bitbucket/src/main/java/org/eclipse/che/security/oauth1/BitbucketServerOAuthAuthenticator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012-2021 Red Hat, Inc.
+ * Copyright (c) 2012-2023 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/
@@ -21,6 +21,7 @@ import com.google.inject.Singleton;
 @Singleton
 public class BitbucketServerOAuthAuthenticator extends OAuthAuthenticator {
   public static final String AUTHENTICATOR_NAME = "bitbucket-server";
+  private final String bitbucketEndpoint;
   private final String apiEndpoint;
 
   public BitbucketServerOAuthAuthenticator(
@@ -33,6 +34,7 @@ public class BitbucketServerOAuthAuthenticator extends OAuthAuthenticator {
         apiEndpoint + "/oauth/1.0/callback",
         null,
         privateKey);
+    this.bitbucketEndpoint = bitbucketEndpoint;
     this.apiEndpoint = apiEndpoint;
   }
 
@@ -47,5 +49,10 @@ public class BitbucketServerOAuthAuthenticator extends OAuthAuthenticator {
         + "/oauth/1.0/authenticate?oauth_provider="
         + AUTHENTICATOR_NAME
         + "&request_method=POST&signature_method=rsa";
+  }
+
+  @Override
+  public String getEndpointUrl() {
+    return bitbucketEndpoint;
   }
 }

--- a/wsmaster/che-core-api-auth-bitbucket/src/main/java/org/eclipse/che/security/oauth1/NoopOAuthAuthenticator.java
+++ b/wsmaster/che-core-api-auth-bitbucket/src/main/java/org/eclipse/che/security/oauth1/NoopOAuthAuthenticator.java
@@ -51,4 +51,9 @@ public class NoopOAuthAuthenticator extends OAuthAuthenticator {
   public String getLocalAuthenticateUrl() {
     return "Noop URL";
   }
+
+  @Override
+  public String getEndpointUrl() {
+    return "Noop URL";
+  }
 }

--- a/wsmaster/che-core-api-auth/src/main/java/org/eclipse/che/security/oauth1/OAuthAuthenticator.java
+++ b/wsmaster/che-core-api-auth/src/main/java/org/eclipse/che/security/oauth1/OAuthAuthenticator.java
@@ -244,6 +244,13 @@ public abstract class OAuthAuthenticator {
   public abstract String getLocalAuthenticateUrl();
 
   /**
+   * Get endpoint URL.
+   *
+   * @return provider's endpoint URL
+   */
+  public abstract String getEndpointUrl();
+
+  /**
    * Compute the Authorization header to sign the OAuth 1 request.
    *
    * @param userId the user id.

--- a/wsmaster/che-core-api-auth/src/main/java/org/eclipse/che/security/oauth1/OAuthAuthenticatorProvider.java
+++ b/wsmaster/che-core-api-auth/src/main/java/org/eclipse/che/security/oauth1/OAuthAuthenticatorProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012-2018 Red Hat, Inc.
+ * Copyright (c) 2012-2023 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/
@@ -10,6 +10,8 @@
  *   Red Hat, Inc. - initial API and implementation
  */
 package org.eclipse.che.security.oauth1;
+
+import static java.util.stream.Collectors.toUnmodifiableSet;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -43,5 +45,16 @@ public class OAuthAuthenticatorProvider {
    */
   public OAuthAuthenticator getAuthenticator(String oauthProviderName) {
     return oAuthAuthenticators.get(oauthProviderName);
+  }
+
+  /**
+   * Gets registered OAuth1 provider names
+   *
+   * @return set of registered OAuth1 provider names
+   */
+  public Set<String> getRegisteredProviderNames() {
+    return oAuthAuthenticators.keySet().stream()
+        .filter(key -> !"Noop".equals(key))
+        .collect(toUnmodifiableSet());
   }
 }

--- a/wsmaster/che-core-api-auth/src/test/java/org/eclipse/che/security/oauth1/OAuthAuthenticatorTest.java
+++ b/wsmaster/che-core-api-auth/src/test/java/org/eclipse/che/security/oauth1/OAuthAuthenticatorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012-2021 Red Hat, Inc.
+ * Copyright (c) 2012-2023 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/
@@ -60,6 +60,11 @@ public class OAuthAuthenticatorTest {
 
           @Override
           public String getLocalAuthenticateUrl() {
+            return null;
+          }
+
+          @Override
+          public String getEndpointUrl() {
             return null;
           }
         };


### PR DESCRIPTION
<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests
-->

### What does this PR do?
Add the list of oauth1 providers to the list of registered oauth2 providers on get registered oauth providers API request.

### Screenshot/screencast of this PR
<!-- Please include a screenshot or a screencast explaining what is doing this PR -->


### What issues does this PR fix or reference?
<!-- Please include any related issue from eclipse che repository (or from another issue tracker).
     Include link to other pull requests like documentation PR from [the docs repo](https://github.com/eclipse/che-docs)
-->
https://github.com/eclipse/che/issues/22723

### How to test this PR?
<!-- Please explain for example :
  - The test platform (openshift, kubernetes, minikube, CodeReady Container, docker-desktop, etc)
  - Installation method: chectl / che-operator
  - steps to reproduce
 -->
1. Deploy che from the PR image: `quay.io/eclipse/che-server:pr-624`
2. Register Bitbucket Server oauth1 provider.
3. Open `https://<che-endpoint url>/api/oauth` in a new browser tab.

See: The oauth1 provider is listed in the response JSON.

### PR Checklist

[As the author of this Pull Request I made sure that:](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#pull-request-template-and-its-checklist)

- [ ] [The Eclipse Contributor Agreement is valid](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-eclipse-contributor-agreement-is-valid)
- [ ] [Code produced is complete](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-produced-is-complete)
- [ ] [Code builds without errors](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-builds-without-errors)
- [ ] [Tests are covering the bugfix](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#tests-are-covering-the-bugfix)
- [ ] [The repository devfile is up to date and works](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-repository-devfile-is-up-to-date-and-works)
- [ ] [Sections `What issues does this PR fix or reference` and `How to test this PR` completed](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#sections-what-issues-does-this-pr-fix-or-reference-and-how-to-test-this-pr-completed)
- [ ] [Relevant user documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [Relevant contributing documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [CI/CD changes implemented, documented and communicated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#cicd-changes-implemented-documented-and-communicated)

### Reviewers

Reviewers, please comment how you tested the PR when approving it.
