### PR TITLE
Move installation of oc client from Dockerfile to common.sh in OpenShift CI jobs

### DIFF
--- a/.ci/openshift-ci/Dockerfile
+++ b/.ci/openshift-ci/Dockerfile
@@ -32,9 +32,7 @@ RUN set -x && dnf install -y -q --allowerasing --nobest nodejs-devel nodejs-libs
     curl -LO https://storage.googleapis.com/kubernetes-release/release/$(curl -s https://storage.googleapis.com/kubernetes-release/release/stable.txt)/bin/linux/amd64/kubectl && \
     chmod +x ./kubectl && \
     mv ./kubectl /usr/local/bin && \
-    bash <(curl -sL https://www.eclipse.org/che/chectl/) --channel=next && \
-    curl -v https://mirror.openshift.com/pub/openshift-v4/clients/ocp/latest-4.14/openshift-client-linux.tar.gz | tar xvzf - -C /usr/local/bin/ oc && \
-    chmod ug+x /usr/local/bin/oc
+    bash <(curl -sL https://www.eclipse.org/che/chectl/) --channel=next
 
 SHELL ["/bin/bash", "-c"]
 

--- a/.ci/openshift-ci/common.sh
+++ b/.ci/openshift-ci/common.sh
@@ -490,6 +490,7 @@ testCloneGitRepoProjectShouldExists() {
 setupTestEnvironment() {
   OCP_USER_NAME=$1
 
+  installOcClient
   provisionOpenShiftOAuthUser
   createCustomResourcesFile
   deployChe
@@ -502,6 +503,7 @@ setupTestEnvironmentOAuthFlow() {
   APPLICATION_ID=$2
   APPLICATION_SECRET=$3
 
+  installOcClient
   provisionOpenShiftOAuthUser
   configureGitSelfSignedCertificate
   createCustomResourcesFile
@@ -509,4 +511,10 @@ setupTestEnvironmentOAuthFlow() {
   deployChe
   createOAuthApplicationGitLabServer ${ADMIN_ACCESS_TOKEN} ${APPLICATION_NAME}
   setupOAuthSecret ${APPLICATION_ID} ${APPLICATION_SECRET}
+}
+
+installOcClient() {
+  set -x
+  curl https://mirror.openshift.com/pub/openshift-v4/clients/ocp/latest-4.14/openshift-client-linux.tar.gz | tar xvzf - -C /usr/local/bin/ oc && \
+  chmod ug+x /usr/local/bin/oc
 }


### PR DESCRIPTION
### What does this PR do?
PR works around OpenShift CI job error "DockerBuildFailed: Dockerfile build strategy has failed." after switching to new cluster profile "che-aws":
e.g. https://storage.googleapis.com/test-platform-results/pr-logs/pull/eclipse-che_che-server/643/pull-ci-eclipse-che-che-server-main-v14-bitbucket-no-pat-oauth-flow-ssh-url/1747605397394427904/build-log.txt
```
+ curl https://mirror.openshift.com/pub/openshift-v4/clients/ocp/latest-4.12/openshift-client-linux.tar.gz
+ tar xvzf - -C /usr/local/bin/ oc
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed

  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0

gzip: stdin: unexpected end of file
tar: Child returned status 1
tar: Error is not recoverable: exiting now
```

### Screenshot/screencast of this PR


### What issues does this PR fix or reference?
https://issues.redhat.com/browse/CRW-5370


### How to test this PR?
Look at OpenShift CI job execution results in PR

### PR Checklist

[As the author of this Pull Request I made sure that:](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#pull-request-template-and-its-checklist)

- [ ] [The Eclipse Contributor Agreement is valid](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-eclipse-contributor-agreement-is-valid)
- [ ] [Code produced is complete](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-produced-is-complete)
- [ ] [Code builds without errors](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-builds-without-errors)
- [ ] [Tests are covering the bugfix](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#tests-are-covering-the-bugfix)
- [ ] [The repository devfile is up to date and works](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-repository-devfile-is-up-to-date-and-works)
- [ ] [Sections `What issues does this PR fix or reference` and `How to test this PR` completed](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#sections-what-issues-does-this-pr-fix-or-reference-and-how-to-test-this-pr-completed)
- [ ] [Relevant user documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [Relevant contributing documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [CI/CD changes implemented, documented and communicated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#cicd-changes-implemented-documented-and-communicated)

### Reviewers

Reviewers, please comment how you tested the PR when approving it.
