### PR TITLE
Fix syntax error in Dockerfile of OpenShift CI jobs

### DIFF
--- a/.ci/openshift-ci/Dockerfile
+++ b/.ci/openshift-ci/Dockerfile
@@ -15,6 +15,8 @@ FROM registry.ci.openshift.org/openshift/release:golang-1.18
 # hadolint ignore=DL3002
 USER 0
 
+SHELL ["/bin/bash", "-c"]
+
 # Install yq, kubectl, chectl cli used by olm/olm.sh script.
 # hadolint ignore=DL3041
 # Install yq, kubectl, chectl cli.
@@ -25,5 +27,3 @@ RUN yum install --assumeyes -d1 psmisc python3-pip  httpd-tools nodejs && \
     chmod +x ./kubectl && \
     mv ./kubectl /usr/local/bin && \
     bash <(curl -sL https://www.eclipse.org/che/chectl/) --channel=next
-
-SHELL ["/bin/bash", "-c"]


### PR DESCRIPTION
### What does this PR do?
Fix syntax error in Dockerfile of OpenShift CI jobs 
https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/eclipse-che_che-server/634/pull-ci-eclipse-che-che-server-main-v14-bitbucket-no-pat-oauth-flow-raw-devfile-url/1748288359341494272
```
STEP 4/7: RUN yum install --assumeyes -d1 psmisc python3-pip  httpd-tools nodejs &&     pip3 install --upgrade setuptools &&     pip3 install yq &&     curl -LO https://storage.googleapis.com/kubernetes-release/release/$(curl -s https://storage.googleapis.com/kubernetes-release/release/stable.txt)/bin/linux/amd64/kubectl &&     chmod +x ./kubectl &&     mv ./kubectl /usr/local/bin &&     bash <(curl -sL https://www.eclipse.org/che/chectl/) --channel=next
/bin/sh: -c: line 0: syntax error near unexpected token `('
/bin/sh: -c: line 0: `yum install --assumeyes -d1 psmisc python3-pip  httpd-tools nodejs &&     pip3 install --upgrade setuptools &&     pip3 install yq &&     curl -LO https://storage.googleapis.com/kubernetes-release/release/$(curl -s https://storage.googleapis.com/kubernetes-release/release/stable.txt)/bin/linux/amd64/kubectl &&     chmod +x ./kubectl &&     mv ./kubectl /usr/local/bin &&     bash <(curl -sL https://www.eclipse.org/che/chectl/) --channel=next'
error: build error: building at STEP "RUN yum install --assumeyes -d1 psmisc python3-pip  httpd-tools nodejs &&     pip3 install --upgrade setuptools &&     pip3 install yq &&     curl -LO https://storage.googleapis.com/kubernetes-release/release/$(curl -s https://storage.googleapis.com/kubernetes-release/release/stable.txt)/bin/linux/amd64/kubectl &&     chmod +x ./kubectl &&     mv ./kubectl /usr/local/bin &&     bash <(curl -sL https://www.eclipse.org/che/chectl/) --channel=next": while running runtime: exit status 1
```

### Screenshot/screencast of this PR


### What issues does this PR fix or reference?
https://issues.redhat.com/browse/CRW-5370

### How to test this PR?
Look at OpenShift CI job execution results in PR

### PR Checklist

[As the author of this Pull Request I made sure that:](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#pull-request-template-and-its-checklist)

- [ ] [The Eclipse Contributor Agreement is valid](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-eclipse-contributor-agreement-is-valid)
- [ ] [Code produced is complete](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-produced-is-complete)
- [ ] [Code builds without errors](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-builds-without-errors)
- [ ] [Tests are covering the bugfix](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#tests-are-covering-the-bugfix)
- [ ] [The repository devfile is up to date and works](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-repository-devfile-is-up-to-date-and-works)
- [ ] [Sections `What issues does this PR fix or reference` and `How to test this PR` completed](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#sections-what-issues-does-this-pr-fix-or-reference-and-how-to-test-this-pr-completed)
- [ ] [Relevant user documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [Relevant contributing documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [CI/CD changes implemented, documented and communicated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#cicd-changes-implemented-documented-and-communicated)

### Reviewers

Reviewers, please comment how you tested the PR when approving it.
