### PR TITLE
Do not pass oauth2 as a username to Git credentials for Bitbucket

### DIFF
--- a/wsmaster/che-core-api-auth/src/main/java/org/eclipse/che/security/oauth/EmbeddedOAuthAPI.java
+++ b/wsmaster/che-core-api-auth/src/main/java/org/eclipse/che/security/oauth/EmbeddedOAuthAPI.java
@@ -111,7 +111,9 @@ public class EmbeddedOAuthAPI implements OAuthAPI {
               EnvironmentContext.getCurrent().getSubject().getUserId(),
               null,
               null,
-              NameGenerator.generate(OAUTH_2_PREFIX, 5),
+              NameGenerator.generate(
+                  // Do not pass oauth2 as a username to Git credentials for Bitbucket
+                  "bitbucket".equals(providerName) ? providerName + "-" : OAUTH_2_PREFIX, 5),
               NameGenerator.generate("id-", 5),
               token));
     } catch (OAuthAuthenticationException e) {

--- a/wsmaster/che-core-api-auth/src/main/java/org/eclipse/che/security/oauth/EmbeddedOAuthAPI.java
+++ b/wsmaster/che-core-api-auth/src/main/java/org/eclipse/che/security/oauth/EmbeddedOAuthAPI.java
@@ -111,9 +111,7 @@ public class EmbeddedOAuthAPI implements OAuthAPI {
               EnvironmentContext.getCurrent().getSubject().getUserId(),
               null,
               null,
-              NameGenerator.generate(
-                  // Do not pass oauth2 as a username to Git credentials for Bitbucket
-                  "bitbucket".equals(providerName) ? providerName + "-" : OAUTH_2_PREFIX, 5),
+              generateTokenName(providerName),
               NameGenerator.generate("id-", 5),
               token));
     } catch (OAuthAuthenticationException e) {
@@ -135,6 +133,18 @@ public class EmbeddedOAuthAPI implements OAuthAPI {
       uri = URI.create(encodeRedirectUrl(redirectAfterLogin));
     }
     return Response.temporaryRedirect(uri).build();
+  }
+
+  /*
+   * This value is used for generating git credentials. Most of the git providers work with git
+   * credentials with OAuth token in format "ouath2:<oauth token>" but bitbucket requires username
+   * to be explicitly set: "<username>:<oauth token>, see {@link
+   * GitCredentialManager#createOrReplace}
+   * TODO: needs to be moved to the specific bitbucket implementation.
+   */
+  private String generateTokenName(String providerName) {
+    return NameGenerator.generate(
+        "bitbucket".equals(providerName) ? providerName + "-" : OAUTH_2_PREFIX, 5);
   }
 
   /**

--- a/wsmaster/che-core-api-factory/src/main/java/org/eclipse/che/api/factory/server/scm/GitCredentialManager.java
+++ b/wsmaster/che-core-api-factory/src/main/java/org/eclipse/che/api/factory/server/scm/GitCredentialManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012-2021 Red Hat, Inc.
+ * Copyright (c) 2012-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/
@@ -16,7 +16,8 @@ import org.eclipse.che.api.factory.server.scm.exception.UnsatisfiedScmPreconditi
 
 public interface GitCredentialManager {
   /**
-   * Persists PersonalAccessToken for the future usage.
+   * Propagates git credentials in format: "username:<oauth token>" if the token is Personal Access
+   * Token or "oauth2:<oauth token> if oAuth token.
    *
    * @param personalAccessToken
    * @throws UnsatisfiedScmPreconditionException - some storage preconditions aren't met.


### PR DESCRIPTION
<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests
-->

### What does this PR do?
Set `bitbucket-*****` as a token name annotation for bitbucket token secret. This is needed to pass username instead of `oauth2` for bitbucket credentials:
https://github.com/eclipse-che/che-server/blob/7dc7a6151144b1da05ed8d6991f985db055d4440/infrastructures/infrastructure-factory/src/main/java/org/eclipse/che/api/factory/server/scm/kubernetes/KubernetesGitCredentialManager.java#L169-L184

This fixes the bug when a private bitbucket.org project is not cloned.

### Screenshot/screencast of this PR
<!-- Please include a screenshot or a screencast explaining what is doing this PR -->

### What issues does this PR fix or reference?
<!-- Please include any related issue from eclipse che repository (or from another issue tracker).
     Include link to other pull requests like documentation PR from [the docs repo](https://github.com/eclipse/che-docs)
-->
https://issues.redhat.com/browse/CRW-5952

### How to test this PR?
<!-- Please explain for example :
  - The test platform (openshift, kubernetes, minikube, CodeReady Container, docker-desktop, etc)
  - Installation method: chectl / che-operator
  - steps to reproduce
 -->
1. Deploy che with the PR image: `quay.io/eclipse/che-server:pr-662
2. [Setup bitbucket.org oauth](https://eclipse.dev/che/docs/stable/administration-guide/configuring-oauth-2-for-the-bitbucket-cloud/)
3. Start a workspace from a private bitbucket.org repository.
See: the workspace starts successfully.

### PR Checklist

[As the author of this Pull Request I made sure that:](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#pull-request-template-and-its-checklist)

- [x] [The Eclipse Contributor Agreement is valid](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-eclipse-contributor-agreement-is-valid)
- [x] [Code produced is complete](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-produced-is-complete)
- [x] [Code builds without errors](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-builds-without-errors)
- [ ] [Tests are covering the bugfix](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#tests-are-covering-the-bugfix)
- [ ] [The repository devfile is up to date and works](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-repository-devfile-is-up-to-date-and-works)
- [x] [Sections `What issues does this PR fix or reference` and `How to test this PR` completed](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#sections-what-issues-does-this-pr-fix-or-reference-and-how-to-test-this-pr-completed)
- [ ] [Relevant user documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [Relevant contributing documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [CI/CD changes implemented, documented and communicated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#cicd-changes-implemented-documented-and-communicated)

### Reviewers

Reviewers, please comment how you tested the PR when approving it.
