### PR TITLE
Encode redirect URL if needed on oauth1 callback request

### DIFF
--- a/wsmaster/che-core-api-auth/src/main/java/org/eclipse/che/security/oauth/EmbeddedOAuthAPI.java
+++ b/wsmaster/che-core-api-auth/src/main/java/org/eclipse/che/security/oauth/EmbeddedOAuthAPI.java
@@ -152,7 +152,7 @@ public class EmbeddedOAuthAPI implements OAuthAPI {
    * JSON, as a query parameter. This prevents passing unsupported characters, like '{' and '}' to
    * the {@link URI#create(String)} method.
    */
-  private String encodeRedirectUrl(String url) {
+  public static String encodeRedirectUrl(String url) {
     try {
       String query = new URL(url).getQuery();
       return url.substring(0, url.indexOf(query)) + URLEncoder.encode(query, UTF_8);

--- a/wsmaster/che-core-api-auth/src/main/java/org/eclipse/che/security/oauth1/OAuthAuthenticationService.java
+++ b/wsmaster/che-core-api-auth/src/main/java/org/eclipse/che/security/oauth1/OAuthAuthenticationService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012-2023 Red Hat, Inc.
+ * Copyright (c) 2012-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/
@@ -16,6 +16,7 @@ import static org.eclipse.che.commons.lang.UrlUtils.getParameter;
 import static org.eclipse.che.commons.lang.UrlUtils.getQueryParametersFromState;
 import static org.eclipse.che.commons.lang.UrlUtils.getRequestUrl;
 import static org.eclipse.che.commons.lang.UrlUtils.getState;
+import static org.eclipse.che.security.oauth.EmbeddedOAuthAPI.encodeRedirectUrl;
 
 import jakarta.ws.rs.GET;
 import jakarta.ws.rs.Path;
@@ -73,7 +74,14 @@ public class OAuthAuthenticationService extends Service {
     final Map<String, List<String>> parameters = getQueryParametersFromState(getState(requestUrl));
 
     final String providerName = getParameter(parameters, "oauth_provider");
-    final String redirectAfterLogin = getParameter(parameters, "redirect_after_login");
+    String redirectAfterLogin = getParameter(parameters, "redirect_after_login");
+
+    try {
+      URI.create(redirectAfterLogin);
+    } catch (IllegalArgumentException e) {
+      // the redirectUrl was decoded by the CSM provider, so we need to encode it back.
+      redirectAfterLogin = encodeRedirectUrl(redirectAfterLogin);
+    }
 
     UriBuilder redirectUriBuilder = UriBuilder.fromUri(redirectAfterLogin);
 

--- a/wsmaster/che-core-api-auth/src/main/java/org/eclipse/che/security/oauth1/OAuthAuthenticationService.java
+++ b/wsmaster/che-core-api-auth/src/main/java/org/eclipse/che/security/oauth1/OAuthAuthenticationService.java
@@ -16,7 +16,7 @@ import static org.eclipse.che.commons.lang.UrlUtils.getParameter;
 import static org.eclipse.che.commons.lang.UrlUtils.getQueryParametersFromState;
 import static org.eclipse.che.commons.lang.UrlUtils.getRequestUrl;
 import static org.eclipse.che.commons.lang.UrlUtils.getState;
-import static org.eclipse.che.security.oauth.EmbeddedOAuthAPI.encodeRedirectUrl;
+import static org.eclipse.che.security.oauth.EmbeddedOAuthAPI.getRedirectAfterLoginUrl;
 
 import jakarta.ws.rs.GET;
 import jakarta.ws.rs.Path;
@@ -74,14 +74,7 @@ public class OAuthAuthenticationService extends Service {
     final Map<String, List<String>> parameters = getQueryParametersFromState(getState(requestUrl));
 
     final String providerName = getParameter(parameters, "oauth_provider");
-    String redirectAfterLogin = getParameter(parameters, "redirect_after_login");
-
-    try {
-      URI.create(redirectAfterLogin);
-    } catch (IllegalArgumentException e) {
-      // the redirectUrl was decoded by the CSM provider, so we need to encode it back.
-      redirectAfterLogin = encodeRedirectUrl(redirectAfterLogin);
-    }
+    final String redirectAfterLogin = getRedirectAfterLoginUrl(parameters);
 
     UriBuilder redirectUriBuilder = UriBuilder.fromUri(redirectAfterLogin);
 


### PR DESCRIPTION
<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests
-->

### What does this PR do?
The latest BItBucket Server decodes the callback url so that causes `IllegalArgumentException` error. Catch the error and decode the redirect url.

A cherry-pick from the PR to main: https://github.com/eclipse-che/che-server/pull/663
### Screenshot/screencast of this PR
<!-- Please include a screenshot or a screencast explaining what is doing this PR -->


### What issues does this PR fix or reference?
<!-- Please include any related issue from eclipse che repository (or from another issue tracker).
     Include link to other pull requests like documentation PR from [the docs repo](https://github.com/eclipse/che-docs)
-->
https://issues.redhat.com/browse/CRW-5663

### How to test this PR?
<!-- Please explain for example :
  - The test platform (openshift, kubernetes, minikube, CodeReady Container, docker-desktop, etc)
  - Installation method: chectl / che-operator
  - steps to reproduce
 -->
1. Deploy che with the PR image: `quay.io/eclipse/che-server:pr-`
2. Configure [oauth1 for BitBucket Server](https://eclipse.dev/che/docs/stable/administration-guide/configuring-oauth-1-for-a-bitbucket-server/) instance.
3. Create a workspace from the BitBucket Server repository, accept the oauth agreement.
4. Stop the workspace and revoke the agreement from the oauth application.
5. Start the workspace and accept the agreement again.

### PR Checklist

[As the author of this Pull Request I made sure that:](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#pull-request-template-and-its-checklist)

- [ ] [The Eclipse Contributor Agreement is valid](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-eclipse-contributor-agreement-is-valid)
- [ ] [Code produced is complete](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-produced-is-complete)
- [ ] [Code builds without errors](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-builds-without-errors)
- [ ] [Tests are covering the bugfix](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#tests-are-covering-the-bugfix)
- [ ] [The repository devfile is up to date and works](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-repository-devfile-is-up-to-date-and-works)
- [ ] [Sections `What issues does this PR fix or reference` and `How to test this PR` completed](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#sections-what-issues-does-this-pr-fix-or-reference-and-how-to-test-this-pr-completed)
- [ ] [Relevant user documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [Relevant contributing documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [CI/CD changes implemented, documented and communicated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#cicd-changes-implemented-documented-and-communicated)

### Reviewers

Reviewers, please comment how you tested the PR when approving it.
