### PR TITLE
Add provider name annotation to PAT secret

### DIFF
--- a/infrastructures/infrastructure-factory/src/test/java/org/eclipse/che/api/factory/server/scm/kubernetes/KubernetesGitCredentialManagerTest.java
+++ b/infrastructures/infrastructure-factory/src/test/java/org/eclipse/che/api/factory/server/scm/kubernetes/KubernetesGitCredentialManagerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012-2023 Red Hat, Inc.
+ * Copyright (c) 2012-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/
@@ -92,7 +92,13 @@ public class KubernetesGitCredentialManagerTest {
 
     PersonalAccessToken token =
         new PersonalAccessToken(
-            "https://bitbucket.com", "cheUser", "username", "token-name", "tid-23434", "token123");
+            "https://bitbucket.com",
+            "provider",
+            "cheUser",
+            "username",
+            "token-name",
+            "tid-23434",
+            "token123");
 
     // when
     kubernetesGitCredentialManager.createOrReplace(token);
@@ -174,6 +180,7 @@ public class KubernetesGitCredentialManagerTest {
     PersonalAccessToken token =
         new PersonalAccessToken(
             "https://bitbucket.com",
+            "provider",
             "cheUser",
             "username",
             "oauth2-token-name",
@@ -199,6 +206,7 @@ public class KubernetesGitCredentialManagerTest {
     PersonalAccessToken token =
         new PersonalAccessToken(
             "https://bitbucket.com:5648",
+            "provider",
             "cheUser",
             "username",
             "token-name",

--- a/infrastructures/infrastructure-factory/src/test/java/org/eclipse/che/api/factory/server/scm/kubernetes/KubernetesPersonalAccessTokenManagerTest.java
+++ b/infrastructures/infrastructure-factory/src/test/java/org/eclipse/che/api/factory/server/scm/kubernetes/KubernetesPersonalAccessTokenManagerTest.java
@@ -139,7 +139,13 @@ public class KubernetesPersonalAccessTokenManagerTest {
 
     PersonalAccessToken token =
         new PersonalAccessToken(
-            "https://bitbucket.com", "cheUser", "username", "token-name", "tid-24", "token123");
+            "https://bitbucket.com",
+            "provider",
+            "cheUser",
+            "username",
+            "token-name",
+            "tid-24",
+            "token123");
 
     // when
     personalAccessTokenManager.store(token);

--- a/wsmaster/che-core-api-auth/src/main/java/org/eclipse/che/security/oauth/EmbeddedOAuthAPI.java
+++ b/wsmaster/che-core-api-auth/src/main/java/org/eclipse/che/security/oauth/EmbeddedOAuthAPI.java
@@ -108,6 +108,7 @@ public class EmbeddedOAuthAPI implements OAuthAPI {
       personalAccessTokenManager.store(
           new PersonalAccessToken(
               oauth.getEndpointUrl(),
+              providerName,
               EnvironmentContext.getCurrent().getSubject().getUserId(),
               null,
               null,

--- a/wsmaster/che-core-api-auth/src/test/java/org/eclipse/che/security/oauth/EmbeddedOAuthAPITest.java
+++ b/wsmaster/che-core-api-auth/src/test/java/org/eclipse/che/security/oauth/EmbeddedOAuthAPITest.java
@@ -165,6 +165,7 @@ public class EmbeddedOAuthAPITest {
     verify(personalAccessTokenManager).store(tokenCapture.capture());
     PersonalAccessToken token = tokenCapture.getValue();
     assertEquals(token.getScmProviderUrl(), "http://eclipse.che");
+    assertEquals(token.getScmProviderName(), "bitbucket");
     assertEquals(token.getCheUserId(), "0000-00-0000");
     assertTrue(token.getScmTokenId().startsWith("id-"));
     assertTrue(token.getScmTokenName().startsWith("bitbucket-"));

--- a/wsmaster/che-core-api-factory-azure-devops/src/main/java/org/eclipse/che/api/factory/server/azure/devops/AzureDevOpsPersonalAccessTokenFetcher.java
+++ b/wsmaster/che-core-api-factory-azure-devops/src/main/java/org/eclipse/che/api/factory/server/azure/devops/AzureDevOpsPersonalAccessTokenFetcher.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012-2023 Red Hat, Inc.
+ * Copyright (c) 2012-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/
@@ -49,6 +49,7 @@ public class AzureDevOpsPersonalAccessTokenFetcher implements PersonalAccessToke
 
   private static final Logger LOG =
       LoggerFactory.getLogger(AzureDevOpsPersonalAccessTokenFetcher.class);
+  private static final String OAUTH_PROVIDER_NAME = "azure-devops";
   private final String cheApiEndpoint;
   private final String azureDevOpsScmApiEndpoint;
   private final OAuthAPI oAuthAPI;
@@ -87,7 +88,12 @@ public class AzureDevOpsPersonalAccessTokenFetcher implements PersonalAccessToke
       Optional<Pair<Boolean, String>> valid =
           isValid(
               new PersonalAccessTokenParams(
-                  scmServerUrl, tokenName, tokenId, oAuthToken.getToken(), null));
+                  scmServerUrl,
+                  OAUTH_PROVIDER_NAME,
+                  tokenName,
+                  tokenId,
+                  oAuthToken.getToken(),
+                  null));
       if (valid.isEmpty()) {
         throw buildScmUnauthorizedException(cheSubject);
       } else if (!valid.get().first) {
@@ -97,6 +103,7 @@ public class AzureDevOpsPersonalAccessTokenFetcher implements PersonalAccessToke
       }
       return new PersonalAccessToken(
           scmServerUrl,
+          OAUTH_PROVIDER_NAME,
           cheSubject.getUserId(),
           valid.get().second,
           tokenName,

--- a/wsmaster/che-core-api-factory-bitbucket-server/src/main/java/org/eclipse/che/api/factory/server/bitbucket/BitbucketServerPersonalAccessTokenFetcher.java
+++ b/wsmaster/che-core-api-factory-bitbucket-server/src/main/java/org/eclipse/che/api/factory/server/bitbucket/BitbucketServerPersonalAccessTokenFetcher.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012-2023 Red Hat, Inc.
+ * Copyright (c) 2012-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/
@@ -51,6 +51,8 @@ public class BitbucketServerPersonalAccessTokenFetcher implements PersonalAccess
   private static final Logger LOG =
       LoggerFactory.getLogger(BitbucketServerPersonalAccessTokenFetcher.class);
 
+  private static final String OAUTH_PROVIDER_NAME = "bitbucket-server";
+
   private static final String TOKEN_NAME_TEMPLATE = "che-token-<%s>-<%s>";
   public static final Set<String> DEFAULT_TOKEN_SCOPE =
       ImmutableSet.of("PROJECT_WRITE", "REPO_WRITE");
@@ -96,6 +98,7 @@ public class BitbucketServerPersonalAccessTokenFetcher implements PersonalAccess
       LOG.debug("Token created = {} for {}", token.getId(), token.getUser());
       return new PersonalAccessToken(
           scmServerUrl,
+          OAUTH_PROVIDER_NAME,
           EnvironmentContext.getCurrent().getSubject().getUserId(),
           user.getName(),
           user.getSlug(),

--- a/wsmaster/che-core-api-factory-bitbucket-server/src/test/java/org/eclipse/che/api/factory/server/bitbucket/BitbucketServerAuthorizingFileContentProviderTest.java
+++ b/wsmaster/che-core-api-factory-bitbucket-server/src/test/java/org/eclipse/che/api/factory/server/bitbucket/BitbucketServerAuthorizingFileContentProviderTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012-2023 Red Hat, Inc.
+ * Copyright (c) 2012-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/
@@ -43,7 +43,7 @@ public class BitbucketServerAuthorizingFileContentProviderTest {
             url, urlFetcher, personalAccessTokenManager);
 
     PersonalAccessToken token =
-        new PersonalAccessToken(TEST_SCHEME + "://" + TEST_HOSTNAME, "user1", "token");
+        new PersonalAccessToken(TEST_SCHEME + "://" + TEST_HOSTNAME, "provider", "user1", "token");
     when(personalAccessTokenManager.getAndStore(anyString())).thenReturn(token);
 
     String fileURL = "https://foo.bar/scm/repo/.devfile";
@@ -64,7 +64,7 @@ public class BitbucketServerAuthorizingFileContentProviderTest {
             url, urlFetcher, personalAccessTokenManager);
 
     PersonalAccessToken token =
-        new PersonalAccessToken(TEST_SCHEME + "://" + TEST_HOSTNAME, "user1", "token");
+        new PersonalAccessToken(TEST_SCHEME + "://" + TEST_HOSTNAME, "provider", "user1", "token");
     when(personalAccessTokenManager.getAndStore(eq(TEST_SCHEME + "://" + TEST_HOSTNAME)))
         .thenReturn(token);
 
@@ -95,7 +95,7 @@ public class BitbucketServerAuthorizingFileContentProviderTest {
         new BitbucketServerAuthorizingFileContentProvider(
             url, urlFetcher, personalAccessTokenManager);
     PersonalAccessToken token =
-        new PersonalAccessToken(TEST_SCHEME + "://" + TEST_HOSTNAME, "user1", "token");
+        new PersonalAccessToken(TEST_SCHEME + "://" + TEST_HOSTNAME, "provider", "user1", "token");
     when(personalAccessTokenManager.getAndStore(anyString())).thenReturn(token);
 
     // when

--- a/wsmaster/che-core-api-factory-bitbucket-server/src/test/java/org/eclipse/che/api/factory/server/bitbucket/BitbucketServerScmFileResolverTest.java
+++ b/wsmaster/che-core-api-factory-bitbucket-server/src/test/java/org/eclipse/che/api/factory/server/bitbucket/BitbucketServerScmFileResolverTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012-2023 Red Hat, Inc.
+ * Copyright (c) 2012-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/
@@ -74,7 +74,7 @@ public class BitbucketServerScmFileResolverTest {
     final String rawContent = "raw_content";
     final String filename = "devfile.yaml";
     when(personalAccessTokenManager.getAndStore(anyString()))
-        .thenReturn(new PersonalAccessToken(SCM_URL, "root", "token123"));
+        .thenReturn(new PersonalAccessToken(SCM_URL, "provider", "root", "token123"));
 
     when(urlFetcher.fetch(anyString(), eq("Bearer token123"))).thenReturn(rawContent);
 

--- a/wsmaster/che-core-api-factory-bitbucket/src/main/java/org/eclipse/che/api/factory/server/bitbucket/BitbucketPersonalAccessTokenFetcher.java
+++ b/wsmaster/che-core-api-factory-bitbucket/src/main/java/org/eclipse/che/api/factory/server/bitbucket/BitbucketPersonalAccessTokenFetcher.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012-2023 Red Hat, Inc.
+ * Copyright (c) 2012-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/
@@ -97,7 +97,12 @@ public class BitbucketPersonalAccessTokenFetcher implements PersonalAccessTokenF
       Optional<Pair<Boolean, String>> valid =
           isValid(
               new PersonalAccessTokenParams(
-                  scmServerUrl, tokenName, tokenId, oAuthToken.getToken(), null));
+                  scmServerUrl,
+                  OAUTH_PROVIDER_NAME,
+                  tokenName,
+                  tokenId,
+                  oAuthToken.getToken(),
+                  null));
       if (valid.isEmpty()) {
         throw buildScmUnauthorizedException(cheSubject);
       } else if (!valid.get().first) {
@@ -109,6 +114,7 @@ public class BitbucketPersonalAccessTokenFetcher implements PersonalAccessTokenF
       }
       return new PersonalAccessToken(
           scmServerUrl,
+          OAUTH_PROVIDER_NAME,
           cheSubject.getUserId(),
           valid.get().second,
           tokenName,

--- a/wsmaster/che-core-api-factory-bitbucket/src/test/java/org/eclipse/che/api/factory/server/bitbucket/BitbucketAuthorizingFileContentProviderTest.java
+++ b/wsmaster/che-core-api-factory-bitbucket/src/test/java/org/eclipse/che/api/factory/server/bitbucket/BitbucketAuthorizingFileContentProviderTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012-2023 Red Hat, Inc.
+ * Copyright (c) 2012-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/
@@ -82,7 +82,8 @@ public class BitbucketAuthorizingFileContentProviderTest {
     // given
     URLFetcher urlFetcher = Mockito.mock(URLFetcher.class);
     String url = "https://bitbucket.org/workspace/repository/raw/HEAD/devfile.yaml";
-    PersonalAccessToken personalAccessToken = new PersonalAccessToken(url, "che", "my-token");
+    PersonalAccessToken personalAccessToken =
+        new PersonalAccessToken(url, "provider", "che", "my-token");
     when(personalAccessTokenManager.getAndStore(anyString())).thenReturn(personalAccessToken);
     when(bitbucketApiClient.getFileContent(
             eq("workspace"), eq("repository"), eq("HEAD"), eq("devfile.yaml"), eq("my-token")))

--- a/wsmaster/che-core-api-factory-bitbucket/src/test/java/org/eclipse/che/api/factory/server/bitbucket/BitbucketPersonalAccessTokenFetcherTest.java
+++ b/wsmaster/che-core-api-factory-bitbucket/src/test/java/org/eclipse/che/api/factory/server/bitbucket/BitbucketPersonalAccessTokenFetcherTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012-2023 Red Hat, Inc.
+ * Copyright (c) 2012-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/
@@ -87,7 +87,12 @@ public class BitbucketPersonalAccessTokenFetcherTest {
                     .withBodyFile("bitbucket/rest/user/response.json")));
     PersonalAccessTokenParams personalAccessTokenParams =
         new PersonalAccessTokenParams(
-            "https://bitbucket.org/", "scmTokenName", "scmTokenId", bitbucketOauthToken, null);
+            "https://bitbucket.org/",
+            "provider",
+            "scmTokenName",
+            "scmTokenId",
+            bitbucketOauthToken,
+            null);
     assertTrue(
         bitbucketPersonalAccessTokenFetcher.isValid(personalAccessTokenParams).isEmpty(),
         "Should not validate SCM server with trailing /");
@@ -165,7 +170,12 @@ public class BitbucketPersonalAccessTokenFetcherTest {
 
     PersonalAccessTokenParams params =
         new PersonalAccessTokenParams(
-            "https://bitbucket.org", "params-name", "tid-23434", bitbucketOauthToken, null);
+            "https://bitbucket.org",
+            "provider",
+            "params-name",
+            "tid-23434",
+            bitbucketOauthToken,
+            null);
 
     Optional<Pair<Boolean, String>> valid = bitbucketPersonalAccessTokenFetcher.isValid(params);
     assertTrue(valid.isPresent());
@@ -188,6 +198,7 @@ public class BitbucketPersonalAccessTokenFetcherTest {
     PersonalAccessTokenParams params =
         new PersonalAccessTokenParams(
             "https://bitbucket.org",
+            "provider",
             OAUTH_2_PREFIX + "-params-name",
             "tid-23434",
             bitbucketOauthToken,
@@ -205,6 +216,7 @@ public class BitbucketPersonalAccessTokenFetcherTest {
     PersonalAccessTokenParams params =
         new PersonalAccessTokenParams(
             "https://bitbucket.org",
+            "provider",
             OAUTH_2_PREFIX + "-token-name",
             "tid-23434",
             bitbucketOauthToken,

--- a/wsmaster/che-core-api-factory-bitbucket/src/test/java/org/eclipse/che/api/factory/server/bitbucket/BitbucketScmFileResolverTest.java
+++ b/wsmaster/che-core-api-factory-bitbucket/src/test/java/org/eclipse/che/api/factory/server/bitbucket/BitbucketScmFileResolverTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012-2023 Red Hat, Inc.
+ * Copyright (c) 2012-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/
@@ -75,7 +75,7 @@ public class BitbucketScmFileResolverTest {
     when(bitbucketApiClient.getFileContent(
             eq("test"), eq("repo"), eq("HEAD"), eq("devfile.yaml"), eq("my-token")))
         .thenReturn(rawContent);
-    var personalAccessToken = new PersonalAccessToken("foo", "che", "my-token");
+    var personalAccessToken = new PersonalAccessToken("foo", "provider", "che", "my-token");
     when(personalAccessTokenManager.getAndStore(anyString())).thenReturn(personalAccessToken);
 
     String content =

--- a/wsmaster/che-core-api-factory-github-common/src/main/java/org/eclipse/che/api/factory/server/github/AbstractGithubPersonalAccessTokenFetcher.java
+++ b/wsmaster/che-core-api-factory-github-common/src/main/java/org/eclipse/che/api/factory/server/github/AbstractGithubPersonalAccessTokenFetcher.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012-2023 Red Hat, Inc.
+ * Copyright (c) 2012-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/
@@ -37,6 +37,7 @@ public abstract class AbstractGithubPersonalAccessTokenFetcher
 
   private static final Logger LOG =
       LoggerFactory.getLogger(AbstractGithubPersonalAccessTokenFetcher.class);
+  private static final String OAUTH_PROVIDER_NAME = "github";
   private final String apiEndpoint;
   private final OAuthAPI oAuthAPI;
 
@@ -140,7 +141,12 @@ public abstract class AbstractGithubPersonalAccessTokenFetcher
       Optional<Pair<Boolean, String>> valid =
           isValid(
               new PersonalAccessTokenParams(
-                  scmServerUrl, tokenName, tokenId, oAuthToken.getToken(), null));
+                  scmServerUrl,
+                  OAUTH_PROVIDER_NAME,
+                  tokenName,
+                  tokenId,
+                  oAuthToken.getToken(),
+                  null));
       if (valid.isEmpty()) {
         throw buildScmUnauthorizedException(cheSubject);
       } else if (!valid.get().first) {
@@ -150,6 +156,7 @@ public abstract class AbstractGithubPersonalAccessTokenFetcher
       }
       return new PersonalAccessToken(
           scmServerUrl,
+          OAUTH_PROVIDER_NAME,
           cheSubject.getUserId(),
           valid.get().second,
           tokenName,
@@ -210,7 +217,7 @@ public abstract class AbstractGithubPersonalAccessTokenFetcher
       // The url from the token has the same url as the api client, no need to create a new one.
       apiClient = githubApiClient;
     } else {
-      if ("github".equals(params.getScmTokenName())) {
+      if (OAUTH_PROVIDER_NAME.equals(params.getScmTokenName())) {
         apiClient = new GithubApiClient(params.getScmProviderUrl());
       } else {
         LOG.debug("not a  valid url {} for current fetcher ", params.getScmProviderUrl());

--- a/wsmaster/che-core-api-factory-github-common/src/main/java/org/eclipse/che/api/factory/server/github/AbstractGithubPersonalAccessTokenFetcher.java
+++ b/wsmaster/che-core-api-factory-github-common/src/main/java/org/eclipse/che/api/factory/server/github/AbstractGithubPersonalAccessTokenFetcher.java
@@ -142,9 +142,7 @@ public abstract class AbstractGithubPersonalAccessTokenFetcher
           isValid(
               new PersonalAccessTokenParams(
                   scmServerUrl,
-                  providerName.equals(OAUTH_PROVIDER_NAME)
-                      ? OAUTH_PROVIDER_NAME
-                      : OAUTH_PROVIDER_NAME + "-second",
+                  OAUTH_PROVIDER_NAME,
                   tokenName,
                   tokenId,
                   oAuthToken.getToken(),

--- a/wsmaster/che-core-api-factory-github-common/src/main/java/org/eclipse/che/api/factory/server/github/AbstractGithubPersonalAccessTokenFetcher.java
+++ b/wsmaster/che-core-api-factory-github-common/src/main/java/org/eclipse/che/api/factory/server/github/AbstractGithubPersonalAccessTokenFetcher.java
@@ -142,7 +142,9 @@ public abstract class AbstractGithubPersonalAccessTokenFetcher
           isValid(
               new PersonalAccessTokenParams(
                   scmServerUrl,
-                  OAUTH_PROVIDER_NAME,
+                  providerName.equals(OAUTH_PROVIDER_NAME)
+                      ? OAUTH_PROVIDER_NAME
+                      : OAUTH_PROVIDER_NAME + "-second",
                   tokenName,
                   tokenId,
                   oAuthToken.getToken(),

--- a/wsmaster/che-core-api-factory-github-common/src/main/java/org/eclipse/che/api/factory/server/github/AbstractGithubPersonalAccessTokenFetcher.java
+++ b/wsmaster/che-core-api-factory-github-common/src/main/java/org/eclipse/che/api/factory/server/github/AbstractGithubPersonalAccessTokenFetcher.java
@@ -142,6 +142,9 @@ public abstract class AbstractGithubPersonalAccessTokenFetcher
           isValid(
               new PersonalAccessTokenParams(
                   scmServerUrl,
+                  // Despite the fact that we may have two GitHub oauth providers, we always set
+                  // "github" to the token provider name. The specific GitHub oauth provider
+                  // references to the specific token by the url parameter.
                   OAUTH_PROVIDER_NAME,
                   tokenName,
                   tokenId,

--- a/wsmaster/che-core-api-factory-github/src/test/java/org/eclipse/che/api/factory/server/github/GithubAuthorizingFileContentProviderTest.java
+++ b/wsmaster/che-core-api-factory-github/src/test/java/org/eclipse/che/api/factory/server/github/GithubAuthorizingFileContentProviderTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012-2023 Red Hat, Inc.
+ * Copyright (c) 2012-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/
@@ -56,7 +56,7 @@ public class GithubAuthorizingFileContentProviderTest {
         new GithubAuthorizingFileContentProvider(githubUrl, urlFetcher, personalAccessTokenManager);
 
     when(personalAccessTokenManager.getAndStore(anyString()))
-        .thenReturn(new PersonalAccessToken("foo", "che", "my-token"));
+        .thenReturn(new PersonalAccessToken("foo", "provider", "che", "my-token"));
 
     fileContentProvider.fetchContent("devfile.yaml");
 
@@ -84,7 +84,7 @@ public class GithubAuthorizingFileContentProviderTest {
         new GithubAuthorizingFileContentProvider(githubUrl, urlFetcher, personalAccessTokenManager);
 
     when(personalAccessTokenManager.getAndStore(anyString()))
-        .thenReturn(new PersonalAccessToken(raw_url, "che", "my-token"));
+        .thenReturn(new PersonalAccessToken(raw_url, "provider", "che", "my-token"));
 
     fileContentProvider.fetchContent(raw_url);
     verify(urlFetcher).fetch(eq(raw_url), eq("token my-token"));
@@ -145,7 +145,7 @@ public class GithubAuthorizingFileContentProviderTest {
             .withServerUrl("https://github.com");
     FileContentProvider fileContentProvider =
         new GithubAuthorizingFileContentProvider(githubUrl, urlFetcher, personalAccessTokenManager);
-    var personalAccessToken = new PersonalAccessToken(raw_url, "che", "my-token");
+    var personalAccessToken = new PersonalAccessToken(raw_url, "provider", "che", "my-token");
     when(personalAccessTokenManager.getAndStore(anyString())).thenReturn(personalAccessToken);
 
     fileContentProvider.fetchContent(raw_url);

--- a/wsmaster/che-core-api-factory-github/src/test/java/org/eclipse/che/api/factory/server/github/GithubPersonalAccessTokenFetcherTest.java
+++ b/wsmaster/che-core-api-factory-github/src/test/java/org/eclipse/che/api/factory/server/github/GithubPersonalAccessTokenFetcherTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012-2023 Red Hat, Inc.
+ * Copyright (c) 2012-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/
@@ -91,7 +91,12 @@ public class GithubPersonalAccessTokenFetcherTest {
                     .withBodyFile("github/rest/user/response.json")));
     PersonalAccessTokenParams personalAccessTokenParams =
         new PersonalAccessTokenParams(
-            "https://github.com/", "scmTokenName", "scmTokenId", githubOauthToken, null);
+            "https://github.com/",
+            "provider",
+            "scmTokenName",
+            "scmTokenId",
+            githubOauthToken,
+            null);
     assertTrue(
         githubPATFetcher.isValid(personalAccessTokenParams).isEmpty(),
         "Should not validate SCM server with trailing /");
@@ -213,7 +218,7 @@ public class GithubPersonalAccessTokenFetcherTest {
 
     PersonalAccessTokenParams params =
         new PersonalAccessTokenParams(
-            wireMockServer.url("/"), "token-name", "tid-23434", githubOauthToken, null);
+            wireMockServer.url("/"), "provider", "token-name", "tid-23434", githubOauthToken, null);
 
     Optional<Pair<Boolean, String>> valid = githubPATFetcher.isValid(params);
     assertTrue(valid.isPresent());
@@ -236,6 +241,7 @@ public class GithubPersonalAccessTokenFetcherTest {
     PersonalAccessTokenParams params =
         new PersonalAccessTokenParams(
             wireMockServer.url("/"),
+            "provider",
             OAUTH_2_PREFIX + "-params-name",
             "tid-23434",
             githubOauthToken,
@@ -253,6 +259,7 @@ public class GithubPersonalAccessTokenFetcherTest {
     PersonalAccessTokenParams params =
         new PersonalAccessTokenParams(
             wireMockServer.url("/"),
+            "provider",
             OAUTH_2_PREFIX + "-token-name",
             "tid-23434",
             githubOauthToken,

--- a/wsmaster/che-core-api-factory-github/src/test/java/org/eclipse/che/api/factory/server/github/GithubScmFileResolverTest.java
+++ b/wsmaster/che-core-api-factory-github/src/test/java/org/eclipse/che/api/factory/server/github/GithubScmFileResolverTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012-2023 Red Hat, Inc.
+ * Copyright (c) 2012-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/
@@ -88,7 +88,7 @@ public class GithubScmFileResolverTest {
 
     lenient()
         .when(personalAccessTokenManager.getAndStore(anyString()))
-        .thenReturn(new PersonalAccessToken("foo", "che", "my-token"));
+        .thenReturn(new PersonalAccessToken("foo", "provider", "che", "my-token"));
 
     when(githubApiClient.isConnected(eq("https://github.com"))).thenReturn(true);
     when(githubApiClient.getLatestCommit(anyString(), anyString(), anyString(), any()))

--- a/wsmaster/che-core-api-factory-gitlab/src/main/java/org/eclipse/che/api/factory/server/gitlab/GitlabOAuthTokenFetcher.java
+++ b/wsmaster/che-core-api-factory-gitlab/src/main/java/org/eclipse/che/api/factory/server/gitlab/GitlabOAuthTokenFetcher.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012-2023 Red Hat, Inc.
+ * Copyright (c) 2012-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/
@@ -111,7 +111,12 @@ public class GitlabOAuthTokenFetcher implements PersonalAccessTokenFetcher {
       Optional<Pair<Boolean, String>> valid =
           isValid(
               new PersonalAccessTokenParams(
-                  scmServerUrl, tokenName, tokenId, oAuthToken.getToken(), null));
+                  scmServerUrl,
+                  OAUTH_PROVIDER_NAME,
+                  tokenName,
+                  tokenId,
+                  oAuthToken.getToken(),
+                  null));
       if (valid.isEmpty()) {
         throw buildScmUnauthorizedException(cheSubject);
       } else if (!valid.get().first) {
@@ -121,6 +126,7 @@ public class GitlabOAuthTokenFetcher implements PersonalAccessTokenFetcher {
       }
       return new PersonalAccessToken(
           scmServerUrl,
+          OAUTH_PROVIDER_NAME,
           cheSubject.getUserId(),
           valid.get().second,
           tokenName,

--- a/wsmaster/che-core-api-factory-gitlab/src/test/java/org/eclipse/che/api/factory/server/gitlab/GitlabAuthorizingFileContentProviderTest.java
+++ b/wsmaster/che-core-api-factory-gitlab/src/test/java/org/eclipse/che/api/factory/server/gitlab/GitlabAuthorizingFileContentProviderTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012-2023 Red Hat, Inc.
+ * Copyright (c) 2012-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/
@@ -35,7 +35,7 @@ public class GitlabAuthorizingFileContentProviderTest {
     GitlabUrl gitlabUrl = new GitlabUrl().withHostName("gitlab.net").withSubGroups("eclipse/che");
     FileContentProvider fileContentProvider =
         new GitlabAuthorizingFileContentProvider(gitlabUrl, urlFetcher, personalAccessTokenManager);
-    var personalAccessToken = new PersonalAccessToken("foo", "che", "my-token");
+    var personalAccessToken = new PersonalAccessToken("foo", "provider", "che", "my-token");
     when(personalAccessTokenManager.getAndStore(anyString())).thenReturn(personalAccessToken);
     fileContentProvider.fetchContent("devfile.yaml");
     verify(urlFetcher)
@@ -53,7 +53,7 @@ public class GitlabAuthorizingFileContentProviderTest {
         new GitlabAuthorizingFileContentProvider(gitlabUrl, urlFetcher, personalAccessTokenManager);
     String url =
         "https://gitlab.net/api/v4/projects/eclipse%2Fche/repository/files/devfile.yaml/raw";
-    var personalAccessToken = new PersonalAccessToken(url, "che", "my-token");
+    var personalAccessToken = new PersonalAccessToken(url, "provider", "che", "my-token");
     when(personalAccessTokenManager.getAndStore(anyString())).thenReturn(personalAccessToken);
 
     fileContentProvider.fetchContent(url);

--- a/wsmaster/che-core-api-factory-gitlab/src/test/java/org/eclipse/che/api/factory/server/gitlab/GitlabOAuthTokenFetcherTest.java
+++ b/wsmaster/che-core-api-factory-gitlab/src/test/java/org/eclipse/che/api/factory/server/gitlab/GitlabOAuthTokenFetcherTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012-2023 Red Hat, Inc.
+ * Copyright (c) 2012-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/
@@ -179,7 +179,12 @@ public class GitlabOAuthTokenFetcherTest {
 
     PersonalAccessTokenParams params =
         new PersonalAccessTokenParams(
-            wireMockServer.baseUrl(), "oauth2-token-name", "tid-23434", "token123", null);
+            wireMockServer.baseUrl(),
+            "provider",
+            "oauth2-token-name",
+            "tid-23434",
+            "token123",
+            null);
 
     Optional<Pair<Boolean, String>> valid = oAuthTokenFetcher.isValid(params);
 

--- a/wsmaster/che-core-api-factory-gitlab/src/test/java/org/eclipse/che/api/factory/server/gitlab/GitlabScmFileResolverTest.java
+++ b/wsmaster/che-core-api-factory-gitlab/src/test/java/org/eclipse/che/api/factory/server/gitlab/GitlabScmFileResolverTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012-2023 Red Hat, Inc.
+ * Copyright (c) 2012-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/
@@ -73,7 +73,7 @@ public class GitlabScmFileResolverTest {
     final String rawContent = "raw_content";
     final String filename = "devfile.yaml";
     when(personalAccessTokenManager.getAndStore(any(String.class)))
-        .thenReturn(new PersonalAccessToken(SCM_URL, "root", "token123"));
+        .thenReturn(new PersonalAccessToken(SCM_URL, "provider", "root", "token123"));
 
     when(urlFetcher.fetch(anyString(), eq("Bearer token123"))).thenReturn(rawContent);
 

--- a/wsmaster/che-core-api-factory/src/main/java/org/eclipse/che/api/factory/server/scm/PersonalAccessToken.java
+++ b/wsmaster/che-core-api-factory/src/main/java/org/eclipse/che/api/factory/server/scm/PersonalAccessToken.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012-2023 Red Hat, Inc.
+ * Copyright (c) 2012-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/
@@ -22,6 +22,7 @@ import org.eclipse.che.commons.env.EnvironmentContext;
 public class PersonalAccessToken {
 
   private final String scmProviderUrl;
+  private final String scmProviderName;
   private final String scmUserName;
   /** Organization that user belongs to. Can be null if user is not a member of any organization. */
   @Nullable private final String scmOrganization;
@@ -33,6 +34,7 @@ public class PersonalAccessToken {
 
   public PersonalAccessToken(
       String scmProviderUrl,
+      String scmProviderName,
       String cheUserId,
       String scmOrganization,
       String scmUserName,
@@ -41,6 +43,7 @@ public class PersonalAccessToken {
       String token) {
     this.scmProviderUrl = scmProviderUrl;
     this.scmOrganization = scmOrganization;
+    this.scmProviderName = scmProviderName;
     this.scmUserName = scmUserName;
     this.scmTokenName = scmTokenName;
     this.scmTokenId = scmTokenId;
@@ -50,17 +53,28 @@ public class PersonalAccessToken {
 
   public PersonalAccessToken(
       String scmProviderUrl,
+      String scmProviderName,
       String cheUserId,
       String scmUserName,
       String scmTokenName,
       String scmTokenId,
       String token) {
-    this(scmProviderUrl, cheUserId, null, scmUserName, scmTokenName, scmTokenId, token);
-  }
-
-  public PersonalAccessToken(String scmProviderUrl, String scmUserName, String token) {
     this(
         scmProviderUrl,
+        scmProviderName,
+        cheUserId,
+        null,
+        scmUserName,
+        scmTokenName,
+        scmTokenId,
+        token);
+  }
+
+  public PersonalAccessToken(
+      String scmProviderUrl, String scmProviderName, String scmUserName, String token) {
+    this(
+        scmProviderUrl,
+        scmProviderName,
         EnvironmentContext.getCurrent().getSubject().getUserId(),
         null,
         scmUserName,
@@ -104,6 +118,7 @@ public class PersonalAccessToken {
     if (o == null || getClass() != o.getClass()) return false;
     PersonalAccessToken that = (PersonalAccessToken) o;
     return Objects.equal(scmProviderUrl, that.scmProviderUrl)
+        && Objects.equal(scmProviderName, that.scmProviderName)
         && Objects.equal(scmUserName, that.scmUserName)
         && Objects.equal(scmOrganization, that.scmOrganization)
         && Objects.equal(scmTokenName, that.scmTokenName)
@@ -124,6 +139,9 @@ public class PersonalAccessToken {
         + "scmProviderUrl='"
         + scmProviderUrl
         + '\''
+        + "scmProviderName='"
+        + scmProviderName
+        + '\''
         + ", scmUserName='"
         + scmUserName
         + '\''
@@ -142,5 +160,9 @@ public class PersonalAccessToken {
         + ", cheUserId='"
         + cheUserId
         + '}';
+  }
+
+  public String getScmProviderName() {
+    return scmProviderName;
   }
 }

--- a/wsmaster/che-core-api-factory/src/main/java/org/eclipse/che/api/factory/server/scm/PersonalAccessTokenParams.java
+++ b/wsmaster/che-core-api-factory/src/main/java/org/eclipse/che/api/factory/server/scm/PersonalAccessTokenParams.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012-2023 Red Hat, Inc.
+ * Copyright (c) 2012-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/
@@ -14,6 +14,7 @@ package org.eclipse.che.api.factory.server.scm;
 /** An object to hold parameters for creating a personal access token. */
 public class PersonalAccessTokenParams {
   private final String scmProviderUrl;
+  private final String scmProviderName;
   private final String scmTokenName;
   private final String scmTokenId;
   private final String token;
@@ -21,11 +22,13 @@ public class PersonalAccessTokenParams {
 
   public PersonalAccessTokenParams(
       String scmProviderUrl,
+      String scmProviderName,
       String scmTokenName,
       String scmTokenId,
       String token,
       String organization) {
     this.scmProviderUrl = scmProviderUrl;
+    this.scmProviderName = scmProviderName;
     this.scmTokenName = scmTokenName;
     this.scmTokenId = scmTokenId;
     this.token = token;
@@ -50,5 +53,9 @@ public class PersonalAccessTokenParams {
 
   public String getOrganization() {
     return organization;
+  }
+
+  public String getScmProviderName() {
+    return scmProviderName;
   }
 }

--- a/wsmaster/che-core-api-factory/src/main/java/org/eclipse/che/api/factory/server/scm/PersonalAccessTokenParams.java
+++ b/wsmaster/che-core-api-factory/src/main/java/org/eclipse/che/api/factory/server/scm/PersonalAccessTokenParams.java
@@ -39,6 +39,14 @@ public class PersonalAccessTokenParams {
     return scmProviderUrl;
   }
 
+  /**
+   * This method returns the provider name if the token is a Personal Access Token, and the token
+   * name in format oauth2-<random string from 5 chars> if the token is an oauth token. Deprecated:
+   * We need to add a new method to distinguish oauth tokens from personal access tokens.
+   *
+   * @return token name
+   */
+  @Deprecated
   public String getScmTokenName() {
     return scmTokenName;
   }


### PR DESCRIPTION
<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests
-->

### What does this PR do?
Add `che.eclipse.org/scm-provider-name` annotation to Personal Access Token secret.

### Screenshot/screencast of this PR
<!-- Please include a screenshot or a screencast explaining what is doing this PR -->


### What issues does this PR fix or reference?
<!-- Please include any related issue from eclipse che repository (or from another issue tracker).
     Include link to other pull requests like documentation PR from [the docs repo](https://github.com/eclipse/che-docs)
-->
https://github.com/eclipse/che/issues/22802

### How to test this PR?
<!-- Please explain for example :
  - The test platform (openshift, kubernetes, minikube, CodeReady Container, docker-desktop, etc)
  - Installation method: chectl / che-operator
  - steps to reproduce
 -->
1. Deploy che with the PR image: `quay.io/eclipse/che-server:pr-670`
2. Apply the related dashboard image: `quay.io/eclipse/che-dashboard:pr-1075`
3. Setup [GitHub oauth](https://eclipse.dev/che/docs/stable/administration-guide/configuring-oauth-2-for-github/)
4. Start a workspace from a GitHub repository with a devfile, consent the authorisation request. 
5. Go to dashboard -> User Preferences -> Personal Access Tokens tab.

See: The provider value is `github`:
![screenshot-eclipse-che apps 7a178e4601d963f19462 hypershift aws-2 ci openshift [org-2024](https://issues.redhat.com//browse/org-2024) 03 18-15_59_44](https://github.com/eclipse-che/che-server/assets/7668752/8f861750-9795-4b13-9212-ad4847b303c7)


### PR Checklist

[As the author of this Pull Request I made sure that:](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#pull-request-template-and-its-checklist)

- [ ] [The Eclipse Contributor Agreement is valid](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-eclipse-contributor-agreement-is-valid)
- [ ] [Code produced is complete](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-produced-is-complete)
- [ ] [Code builds without errors](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-builds-without-errors)
- [ ] [Tests are covering the bugfix](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#tests-are-covering-the-bugfix)
- [ ] [The repository devfile is up to date and works](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-repository-devfile-is-up-to-date-and-works)
- [ ] [Sections `What issues does this PR fix or reference` and `How to test this PR` completed](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#sections-what-issues-does-this-pr-fix-or-reference-and-how-to-test-this-pr-completed)
- [ ] [Relevant user documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [Relevant contributing documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [CI/CD changes implemented, documented and communicated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#cicd-changes-implemented-documented-and-communicated)

### Reviewers

Reviewers, please comment how you tested the PR when approving it.
