### PR TITLE
Rework the Bitbucket Server oauth token validation

### DIFF
--- a/wsmaster/che-core-api-factory-bitbucket-server/src/main/java/org/eclipse/che/api/factory/server/bitbucket/BitbucketServerPersonalAccessTokenFetcher.java
+++ b/wsmaster/che-core-api-factory-bitbucket-server/src/main/java/org/eclipse/che/api/factory/server/bitbucket/BitbucketServerPersonalAccessTokenFetcher.java
@@ -100,7 +100,7 @@ public class BitbucketServerPersonalAccessTokenFetcher implements PersonalAccess
           scmServerUrl,
           OAUTH_PROVIDER_NAME,
           EnvironmentContext.getCurrent().getSubject().getUserId(),
-          user.getName(),
+          null,
           user.getSlug(),
           token.getName(),
           valueOf(token.getId()),

--- a/wsmaster/che-core-api-factory-bitbucket-server/src/main/java/org/eclipse/che/api/factory/server/bitbucket/BitbucketServerPersonalAccessTokenFetcher.java
+++ b/wsmaster/che-core-api-factory-bitbucket-server/src/main/java/org/eclipse/che/api/factory/server/bitbucket/BitbucketServerPersonalAccessTokenFetcher.java
@@ -134,7 +134,8 @@ public class BitbucketServerPersonalAccessTokenFetcher implements PersonalAccess
     }
     try {
       BitbucketPersonalAccessToken bitbucketPersonalAccessToken =
-          bitbucketServerApiClient.getPersonalAccessToken(personalAccessToken.getScmTokenId());
+          bitbucketServerApiClient.getPersonalAccessToken(
+              personalAccessToken.getScmTokenId(), personalAccessToken.getToken());
       return Optional.of(DEFAULT_TOKEN_SCOPE.equals(bitbucketPersonalAccessToken.getPermissions()));
     } catch (ScmItemNotFoundException e) {
       return Optional.of(Boolean.FALSE);
@@ -169,7 +170,8 @@ public class BitbucketServerPersonalAccessTokenFetcher implements PersonalAccess
       }
       // Token is added by OAuth. Token id is available.
       BitbucketPersonalAccessToken bitbucketPersonalAccessToken =
-          bitbucketServerApiClient.getPersonalAccessToken(params.getScmTokenId());
+          bitbucketServerApiClient.getPersonalAccessToken(
+              params.getScmTokenId(), params.getToken());
       return Optional.of(
           Pair.of(
               DEFAULT_TOKEN_SCOPE.equals(bitbucketPersonalAccessToken.getPermissions())

--- a/wsmaster/che-core-api-factory-bitbucket-server/src/main/java/org/eclipse/che/api/factory/server/bitbucket/BitbucketServerPersonalAccessTokenFetcher.java
+++ b/wsmaster/che-core-api-factory-bitbucket-server/src/main/java/org/eclipse/che/api/factory/server/bitbucket/BitbucketServerPersonalAccessTokenFetcher.java
@@ -111,31 +111,34 @@ public class BitbucketServerPersonalAccessTokenFetcher implements PersonalAccess
   }
 
   @Override
-  public Optional<Boolean> isValid(PersonalAccessToken personalAccessToken)
+  public Optional<Boolean> isValid(PersonalAccessToken accessToken)
       throws ScmCommunicationException, ScmUnauthorizedException {
-    if (!bitbucketServerApiClient.isConnected(personalAccessToken.getScmProviderUrl())) {
+    if (!bitbucketServerApiClient.isConnected(accessToken.getScmProviderUrl())) {
       // If BitBucket oAuth is not configured check the manually added user namespace token.
       HttpBitbucketServerApiClient apiClient =
           new HttpBitbucketServerApiClient(
-              personalAccessToken.getScmProviderUrl(),
+              accessToken.getScmProviderUrl(),
               new NoopOAuthAuthenticator(),
               oAuthAPI,
               apiEndpoint.toString());
       try {
-        apiClient.getUser(personalAccessToken.getToken());
+        apiClient.getUser(accessToken.getToken());
         return Optional.of(Boolean.TRUE);
       } catch (ScmItemNotFoundException
           | ScmUnauthorizedException
           | ScmCommunicationException exception) {
-        LOG.debug(
-            "not a valid url {} for current fetcher ", personalAccessToken.getScmProviderUrl());
+        LOG.debug("not a valid url {} for current fetcher ", accessToken.getScmProviderUrl());
         return Optional.empty();
       }
     }
     try {
       BitbucketPersonalAccessToken bitbucketPersonalAccessToken =
           bitbucketServerApiClient.getPersonalAccessToken(
-              personalAccessToken.getScmTokenId(), personalAccessToken.getToken());
+              accessToken.getScmTokenId(),
+              // Pass oauth token to fetch personal access token
+              // TODO: rename the PersonalAccessToken interface to more generic name, so both OAuth
+              // and personal access token implementations would be suitable.
+              accessToken.getToken());
       return Optional.of(DEFAULT_TOKEN_SCOPE.equals(bitbucketPersonalAccessToken.getPermissions()));
     } catch (ScmItemNotFoundException e) {
       return Optional.of(Boolean.FALSE);

--- a/wsmaster/che-core-api-factory-bitbucket-server/src/main/java/org/eclipse/che/api/factory/server/bitbucket/server/BitbucketServerApiClient.java
+++ b/wsmaster/che-core-api-factory-bitbucket-server/src/main/java/org/eclipse/che/api/factory/server/bitbucket/server/BitbucketServerApiClient.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012-2023 Red Hat, Inc.
+ * Copyright (c) 2012-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/
@@ -100,9 +100,10 @@ public interface BitbucketServerApiClient {
 
   /**
    * @param tokenId - bitbucket personal access token id.
+   * @param oauthToken - bitbucket oauth token.
    * @return - Bitbucket personal access token.
    * @throws ScmCommunicationException
    */
-  BitbucketPersonalAccessToken getPersonalAccessToken(String tokenId)
+  BitbucketPersonalAccessToken getPersonalAccessToken(String tokenId, String oauthToken)
       throws ScmItemNotFoundException, ScmUnauthorizedException, ScmCommunicationException;
 }

--- a/wsmaster/che-core-api-factory-bitbucket-server/src/main/java/org/eclipse/che/api/factory/server/bitbucket/server/NoopBitbucketServerApiClient.java
+++ b/wsmaster/che-core-api-factory-bitbucket-server/src/main/java/org/eclipse/che/api/factory/server/bitbucket/server/NoopBitbucketServerApiClient.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012-2023 Red Hat, Inc.
+ * Copyright (c) 2012-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/
@@ -77,7 +77,7 @@ public class NoopBitbucketServerApiClient implements BitbucketServerApiClient {
   }
 
   @Override
-  public BitbucketPersonalAccessToken getPersonalAccessToken(String tokenId)
+  public BitbucketPersonalAccessToken getPersonalAccessToken(String tokenId, String oauthToken)
       throws ScmItemNotFoundException, ScmUnauthorizedException, ScmCommunicationException {
     throw new RuntimeException("Invalid usage of BitbucketServerApi");
   }

--- a/wsmaster/che-core-api-factory-bitbucket-server/src/test/java/org/eclipse/che/api/factory/server/bitbucket/BitbucketServerPersonalAccessTokenFetcherTest.java
+++ b/wsmaster/che-core-api-factory-bitbucket-server/src/test/java/org/eclipse/che/api/factory/server/bitbucket/BitbucketServerPersonalAccessTokenFetcherTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012-2023 Red Hat, Inc.
+ * Copyright (c) 2012-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/
@@ -221,10 +221,12 @@ public class BitbucketServerPersonalAccessTokenFetcherTest {
       throws ScmUnauthorizedException, ScmCommunicationException, ScmItemNotFoundException {
     // given
     when(personalAccessTokenParams.getScmProviderUrl()).thenReturn(someBitbucketURL);
+    when(personalAccessTokenParams.getToken()).thenReturn(bitbucketPersonalAccessToken.getToken());
     when(personalAccessTokenParams.getScmTokenId())
         .thenReturn(bitbucketPersonalAccessToken.getId());
     when(bitbucketServerApiClient.isConnected(eq(someBitbucketURL))).thenReturn(true);
-    when(bitbucketServerApiClient.getPersonalAccessToken(eq(bitbucketPersonalAccessToken.getId())))
+    when(bitbucketServerApiClient.getPersonalAccessToken(
+            eq(bitbucketPersonalAccessToken.getId()), eq(bitbucketPersonalAccessToken.getToken())))
         .thenReturn(bitbucketPersonalAccessToken);
     // when
     Optional<Pair<Boolean, String>> result = fetcher.isValid(personalAccessTokenParams);

--- a/wsmaster/che-core-api-factory-bitbucket-server/src/test/java/org/eclipse/che/api/factory/server/bitbucket/BitbucketServerPersonalAccessTokenFetcherTest.java
+++ b/wsmaster/che-core-api-factory-bitbucket-server/src/test/java/org/eclipse/che/api/factory/server/bitbucket/BitbucketServerPersonalAccessTokenFetcherTest.java
@@ -156,7 +156,7 @@ public class BitbucketServerPersonalAccessTokenFetcherTest {
     assertNotNull(result);
     assertEquals(result.getScmProviderUrl(), someBitbucketURL);
     assertEquals(result.getCheUserId(), subject.getUserId());
-    assertEquals(result.getScmOrganization(), bitbucketUser.getName());
+    assertNull(result.getScmOrganization(), bitbucketUser.getName());
     assertEquals(result.getScmTokenId(), valueOf(bitbucketPersonalAccessToken.getId()));
     assertEquals(result.getToken(), bitbucketPersonalAccessToken.getToken());
   }

--- a/wsmaster/che-core-api-factory-bitbucket-server/src/test/java/org/eclipse/che/api/factory/server/bitbucket/HttpBitbucketServerApiClientTest.java
+++ b/wsmaster/che-core-api-factory-bitbucket-server/src/test/java/org/eclipse/che/api/factory/server/bitbucket/HttpBitbucketServerApiClientTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012-2023 Red Hat, Inc.
+ * Copyright (c) 2012-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/
@@ -312,14 +312,14 @@ public class HttpBitbucketServerApiClientTest {
     // given
     stubFor(
         get(urlPathEqualTo("/rest/access-tokens/1.0/users/ksmster/5"))
-            .withHeader(HttpHeaders.AUTHORIZATION, equalTo(AUTHORIZATION_TOKEN))
+            .withHeader(HttpHeaders.AUTHORIZATION, equalTo("Bearer token"))
             .withHeader(HttpHeaders.ACCEPT, equalTo(MediaType.APPLICATION_JSON))
             .willReturn(
                 ok().withBodyFile("bitbucket/rest/access-tokens/1.0/users/ksmster/newtoken.json")));
 
     stubFor(
         get(urlPathEqualTo("/rest/api/1.0/users"))
-            .withHeader(HttpHeaders.AUTHORIZATION, equalTo(AUTHORIZATION_TOKEN))
+            .withHeader(HttpHeaders.AUTHORIZATION, equalTo("Bearer token"))
             .withQueryParam("start", equalTo("0"))
             .withQueryParam("limit", equalTo("25"))
             .willReturn(
@@ -328,7 +328,7 @@ public class HttpBitbucketServerApiClientTest {
                     .withBodyFile("bitbucket/rest/api/1.0/users/filtered/response.json")));
 
     // when
-    BitbucketPersonalAccessToken result = bitbucketServer.getPersonalAccessToken("5");
+    BitbucketPersonalAccessToken result = bitbucketServer.getPersonalAccessToken("5", "token");
     // then
     assertNotNull(result);
     assertEquals(result.getToken(), "MTU4OTEwNTMyOTA5Ohc88HcY8k7gWOzl2mP5TtdtY5Qs");
@@ -346,7 +346,7 @@ public class HttpBitbucketServerApiClientTest {
             .willReturn(notFound()));
 
     // when
-    bitbucketServer.getPersonalAccessToken("5");
+    bitbucketServer.getPersonalAccessToken("5", "token");
   }
 
   @Test(expectedExceptions = ScmUnauthorizedException.class)
@@ -361,18 +361,18 @@ public class HttpBitbucketServerApiClientTest {
   }
 
   @Test(expectedExceptions = ScmUnauthorizedException.class)
-  public void shouldBeAbleToThrowScmUnauthorizedExceptionOnGePAT()
+  public void shouldBeAbleToThrowScmUnauthorizedExceptionOnGetPAT()
       throws ScmCommunicationException, ScmUnauthorizedException, ScmItemNotFoundException {
 
     // given
     stubFor(
         get(urlPathEqualTo("/rest/access-tokens/1.0/users/ksmster/5"))
-            .withHeader(HttpHeaders.AUTHORIZATION, equalTo(AUTHORIZATION_TOKEN))
+            .withHeader(HttpHeaders.AUTHORIZATION, equalTo("Bearer token"))
             .withHeader(HttpHeaders.ACCEPT, equalTo(MediaType.APPLICATION_JSON))
             .willReturn(unauthorized()));
     stubFor(
         get(urlPathEqualTo("/rest/api/1.0/users"))
-            .withHeader(HttpHeaders.AUTHORIZATION, equalTo(AUTHORIZATION_TOKEN))
+            .withHeader(HttpHeaders.AUTHORIZATION, equalTo("Bearer token"))
             .withQueryParam("start", equalTo("0"))
             .withQueryParam("limit", equalTo("25"))
             .willReturn(
@@ -381,7 +381,7 @@ public class HttpBitbucketServerApiClientTest {
                     .withBodyFile("bitbucket/rest/api/1.0/users/filtered/response.json")));
 
     // when
-    bitbucketServer.getPersonalAccessToken("5");
+    bitbucketServer.getPersonalAccessToken("5", "token");
   }
 
   @Test(
@@ -400,7 +400,7 @@ public class HttpBitbucketServerApiClientTest {
             wireMockServer.url("/"), new NoopOAuthAuthenticator(), oAuthAPI, apiEndpoint);
 
     // when
-    localServer.getPersonalAccessToken("5");
+    localServer.getUser();
   }
 
   @Test


### PR DESCRIPTION
<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests
-->

### What does this PR do?
* Change the validation API request to get current user request. The `/rest/api/1.0/application-properties` request is irrelevant as it does not require a token.
* Pass oath token to the `getPersonalAccessToken()` API request in order to avoid circular `getToken()` request.
### Screenshot/screencast of this PR
<!-- Please include a screenshot or a screencast explaining what is doing this PR -->


### What issues does this PR fix or reference?
<!-- Please include any related issue from eclipse che repository (or from another issue tracker).
     Include link to other pull requests like documentation PR from [the docs repo](https://github.com/eclipse/che-docs)
-->
fixes https://github.com/eclipse/che/issues/22836

### How to test this PR?
<!-- Please explain for example :
  - The test platform (openshift, kubernetes, minikube, CodeReady Container, docker-desktop, etc)
  - Installation method: chectl / che-operator
  - steps to reproduce
 -->
1. Deploy che with the PR image: `quay.io/eclipse/che-server:pr-673`
2. Setup a Bitbucket-Server instance.
3. Configure [oauth2](https://eclipse.dev/che/docs/stable/administration-guide/configuring-oauth-2-for-a-bitbucket-server/) for the Bitbucket-Server instance.
4. Start a workspace from a repository with a devfile from the Bitbucket-Server, consent the authorisation request.
5. Go to dashboard -> User Preferences -> Git Services and see that the provider has `Authorised` state.
6. Go to the Bitbucket-Server user account page and revoke the authorisation.
7. Go back to the Git Services tab, refresh the page.

See: The provider's authorisation state is `Unauthorised`.

### PR Checklist

[As the author of this Pull Request I made sure that:](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#pull-request-template-and-its-checklist)

- [ ] [The Eclipse Contributor Agreement is valid](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-eclipse-contributor-agreement-is-valid)
- [ ] [Code produced is complete](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-produced-is-complete)
- [ ] [Code builds without errors](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-builds-without-errors)
- [ ] [Tests are covering the bugfix](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#tests-are-covering-the-bugfix)
- [ ] [The repository devfile is up to date and works](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-repository-devfile-is-up-to-date-and-works)
- [ ] [Sections `What issues does this PR fix or reference` and `How to test this PR` completed](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#sections-what-issues-does-this-pr-fix-or-reference-and-how-to-test-this-pr-completed)
- [ ] [Relevant user documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [Relevant contributing documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [CI/CD changes implemented, documented and communicated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#cicd-changes-implemented-documented-and-communicated)

### Reviewers

Reviewers, please comment how you tested the PR when approving it.
