### PR TITLE
Fix gitlab oauth token validation request

### DIFF
--- a/wsmaster/che-core-api-auth-gitlab/pom.xml
+++ b/wsmaster/che-core-api-auth-gitlab/pom.xml
@@ -36,6 +36,10 @@
             <artifactId>guice</artifactId>
         </dependency>
         <dependency>
+            <groupId>com.google.oauth-client</groupId>
+            <artifactId>google-oauth-client</artifactId>
+        </dependency>
+        <dependency>
             <groupId>jakarta.inject</groupId>
             <artifactId>jakarta.inject-api</artifactId>
         </dependency>

--- a/wsmaster/che-core-api-auth-gitlab/src/main/java/org/eclipse/che/security/oauth/GitLabOAuthAuthenticator.java
+++ b/wsmaster/che-core-api-auth-gitlab/src/main/java/org/eclipse/che/security/oauth/GitLabOAuthAuthenticator.java
@@ -11,6 +11,7 @@
  */
 package org.eclipse.che.security.oauth;
 
+import static com.google.common.base.Strings.isNullOrEmpty;
 import static java.lang.String.format;
 import static org.eclipse.che.commons.lang.StringUtils.trimEnd;
 
@@ -93,7 +94,8 @@ public class GitLabOAuthAuthenticator extends OAuthAuthenticator {
       if (token == null
           || token.getToken() == null
           || token.getToken().isEmpty()
-          || getJson(gitlabUserEndpoint, token.getToken(), GitLabUser.class) == null) {
+          || isNullOrEmpty(
+              getJson(gitlabUserEndpoint, token.getToken(), GitLabUser.class).getId())) {
         return null;
       }
     } catch (OAuthAuthenticationException e) {

--- a/wsmaster/che-core-api-auth-gitlab/src/main/java/org/eclipse/che/security/oauth/GitLabOAuthAuthenticator.java
+++ b/wsmaster/che-core-api-auth-gitlab/src/main/java/org/eclipse/che/security/oauth/GitLabOAuthAuthenticator.java
@@ -91,11 +91,11 @@ public class GitLabOAuthAuthenticator extends OAuthAuthenticator {
   public OAuthToken getToken(String userId) throws IOException {
     final OAuthToken token = super.getToken(userId);
     try {
-      if (token == null
-          || token.getToken() == null
-          || token.getToken().isEmpty()
-          || isNullOrEmpty(
-              getJson(gitlabUserEndpoint, token.getToken(), GitLabUser.class).getId())) {
+      if (token == null || token.getToken() == null || token.getToken().isEmpty()) {
+        return null;
+      }
+      GitLabUser user = getJson(gitlabUserEndpoint, token.getToken(), GitLabUser.class);
+      if (user == null || isNullOrEmpty(user.getId())) {
         return null;
       }
     } catch (OAuthAuthenticationException e) {

--- a/wsmaster/che-core-api-auth-gitlab/src/test/java/org/eclipse/che/security/oauth/GitLabAuthenticatorTest.java
+++ b/wsmaster/che-core-api-auth-gitlab/src/test/java/org/eclipse/che/security/oauth/GitLabAuthenticatorTest.java
@@ -1,0 +1,96 @@
+/*
+ * Copyright (c) 2012-2024 Red Hat, Inc.
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+package org.eclipse.che.security.oauth;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
+import static com.github.tomakehurst.wiremock.client.WireMock.equalTo;
+import static com.github.tomakehurst.wiremock.client.WireMock.get;
+import static com.github.tomakehurst.wiremock.client.WireMock.stubFor;
+import static com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo;
+import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.wireMockConfig;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNull;
+
+import com.github.tomakehurst.wiremock.WireMockServer;
+import com.github.tomakehurst.wiremock.client.WireMock;
+import com.github.tomakehurst.wiremock.common.Slf4jNotifier;
+import com.google.api.client.auth.oauth2.StoredCredential;
+import com.google.api.client.util.store.MemoryDataStoreFactory;
+import com.google.common.net.HttpHeaders;
+import java.lang.reflect.Field;
+import org.eclipse.che.api.auth.shared.dto.OAuthToken;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+public class GitLabAuthenticatorTest {
+  WireMockServer wireMockServer;
+  WireMock wireMock;
+
+  @BeforeClass
+  public void setup() {
+    wireMockServer =
+        new WireMockServer(wireMockConfig().notifier(new Slf4jNotifier(false)).dynamicPort());
+    wireMockServer.start();
+    WireMock.configureFor("localhost", wireMockServer.port());
+    wireMock = new WireMock("localhost", wireMockServer.port());
+  }
+
+  @Test
+  public void shouldGetToken() throws Exception {
+    // given
+    GitLabOAuthAuthenticator gitLabOAuthAuthenticator =
+        new GitLabOAuthAuthenticator(
+            "id", "secret", wireMockServer.url("/"), "https://che.api.com");
+    Field flowField = OAuthAuthenticator.class.getDeclaredField("flow");
+    Field credentialDataStoreField =
+        ((Class) flowField.getGenericType()).getDeclaredField("credentialDataStore");
+    credentialDataStoreField.setAccessible(true);
+    credentialDataStoreField.set(
+        flowField.get(gitLabOAuthAuthenticator),
+        new MemoryDataStoreFactory()
+            .getDataStore("test")
+            .set("userId", new StoredCredential().setAccessToken("token")));
+    stubFor(
+        get(urlEqualTo("/api/v4/user"))
+            .withHeader(HttpHeaders.AUTHORIZATION, equalTo("Bearer token"))
+            .willReturn(aResponse().withBody("{\"id\": \"testId\"}")));
+    // when
+    OAuthToken token = gitLabOAuthAuthenticator.getToken("userId");
+    // then
+    assertEquals(token.getToken(), "token");
+  }
+
+  @Test
+  public void shouldGetEmptyToken() throws Exception {
+    // given
+    GitLabOAuthAuthenticator gitLabOAuthAuthenticator =
+        new GitLabOAuthAuthenticator(
+            "id", "secret", wireMockServer.url("/"), "https://che.api.com");
+    Field flowField = OAuthAuthenticator.class.getDeclaredField("flow");
+    Field credentialDataStoreField =
+        ((Class) flowField.getGenericType()).getDeclaredField("credentialDataStore");
+    credentialDataStoreField.setAccessible(true);
+    credentialDataStoreField.set(
+        flowField.get(gitLabOAuthAuthenticator),
+        new MemoryDataStoreFactory()
+            .getDataStore("test")
+            .set("userId", new StoredCredential().setAccessToken("token")));
+    stubFor(
+        get(urlEqualTo("/api/v4/user"))
+            .withHeader(HttpHeaders.AUTHORIZATION, equalTo("Bearer token"))
+            .willReturn(aResponse().withBody("{}")));
+    // when
+    OAuthToken token = gitLabOAuthAuthenticator.getToken("userId");
+    // then
+    assertNull(token);
+  }
+}

--- a/wsmaster/che-core-api-auth/src/main/java/org/eclipse/che/security/oauth/OAuthAuthenticator.java
+++ b/wsmaster/che-core-api-auth/src/main/java/org/eclipse/che/security/oauth/OAuthAuthenticator.java
@@ -285,7 +285,8 @@ public abstract class OAuthAuthenticator {
    *     none token found for user then {@code null} will be returned, when user have expired token
    *     and it can't be refreshed then {@code null} will be returned
    * @throws IOException when error occurs during token loading
-   * @see OAuthTokenProvider#getToken(String, String)
+   * @see OAuthTokenProvider#getToken(String, String) TODO: return Optional<OAuthToken> to avoid
+   *     returning null.
    */
   public OAuthToken getToken(String userId) throws IOException {
     if (!isConfigured()) {


### PR DESCRIPTION
<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests
-->

### What does this PR do?
Rework the gitlab oauth token validation check to verify if the test response has data in the returned object.

### Screenshot/screencast of this PR
<!-- Please include a screenshot or a screencast explaining what is doing this PR -->


### What issues does this PR fix or reference?
<!-- Please include any related issue from eclipse che repository (or from another issue tracker).
     Include link to other pull requests like documentation PR from [the docs repo](https://github.com/eclipse/che-docs)
-->
https://github.com/eclipse/che/issues/22836

### How to test this PR?
<!-- Please explain for example :
  - The test platform (openshift, kubernetes, minikube, CodeReady Container, docker-desktop, etc)
  - Installation method: chectl / che-operator
  - steps to reproduce
 -->
1. Deploy che with the PR image: `quay.io/eclipse/che-server:pr-674`
2. Configure [Gitlab oauth](https://eclipse.dev/che/docs/stable/administration-guide/configuring-oauth-2-for-gitlab/).
3. Start a workspace from a Gitlab repository with a devfile.
4. Go to dashboard -> User Preferences -> Git Services tab, see: the Gitlab provider is in the `authorised` state.
5. Revoke the Gitlab authorisation.

See: the authorisation state of the Gitlab provider has changed to `unauthorised`.

### PR Checklist

[As the author of this Pull Request I made sure that:](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#pull-request-template-and-its-checklist)

- [ ] [The Eclipse Contributor Agreement is valid](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-eclipse-contributor-agreement-is-valid)
- [ ] [Code produced is complete](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-produced-is-complete)
- [ ] [Code builds without errors](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-builds-without-errors)
- [ ] [Tests are covering the bugfix](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#tests-are-covering-the-bugfix)
- [ ] [The repository devfile is up to date and works](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-repository-devfile-is-up-to-date-and-works)
- [ ] [Sections `What issues does this PR fix or reference` and `How to test this PR` completed](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#sections-what-issues-does-this-pr-fix-or-reference-and-how-to-test-this-pr-completed)
- [ ] [Relevant user documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [Relevant contributing documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [CI/CD changes implemented, documented and communicated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#cicd-changes-implemented-documented-and-communicated)

### Reviewers

Reviewers, please comment how you tested the PR when approving it.
