### PR TITLE
Support raw devfile urls without yaml extension

### DIFF
--- a/wsmaster/che-core-api-factory/src/main/java/org/eclipse/che/api/factory/server/RawDevfileUrlFactoryParameterResolver.java
+++ b/wsmaster/che-core-api-factory/src/main/java/org/eclipse/che/api/factory/server/RawDevfileUrlFactoryParameterResolver.java
@@ -77,7 +77,9 @@ public class RawDevfileUrlFactoryParameterResolver extends BaseFactoryParameterR
       String fetch = urlFetcher.fetch(requestURL);
       devfileParser.parseYaml(fetch);
       return true;
-    } catch (IOException | DevfileFormatException e) {
+    } catch (IOException e) {
+      return false;
+    } catch (DevfileFormatException e) {
       return !e.getMessage().startsWith("Cannot construct instance of");
     }
   }

--- a/wsmaster/che-core-api-factory/src/main/java/org/eclipse/che/api/factory/server/RawDevfileUrlFactoryParameterResolver.java
+++ b/wsmaster/che-core-api-factory/src/main/java/org/eclipse/che/api/factory/server/RawDevfileUrlFactoryParameterResolver.java
@@ -16,6 +16,7 @@ import static java.lang.String.format;
 import static org.eclipse.che.api.factory.server.FactoryResolverPriority.HIGHEST;
 import static org.eclipse.che.api.factory.shared.Constants.URL_PARAMETER_NAME;
 
+import com.fasterxml.jackson.databind.JsonNode;
 import jakarta.validation.constraints.NotNull;
 import java.io.IOException;
 import java.net.MalformedURLException;
@@ -69,18 +70,16 @@ public class RawDevfileUrlFactoryParameterResolver extends BaseFactoryParameterR
   @Override
   public boolean accept(Map<String, String> factoryParameters) {
     String url = factoryParameters.get(URL_PARAMETER_NAME);
-    return !isNullOrEmpty(url) && (PATTERN.matcher(url).matches() || containsDevfile(url));
+    return !isNullOrEmpty(url) && (PATTERN.matcher(url).matches() || containsYaml(url));
   }
 
-  private boolean containsDevfile(String requestURL) {
+  private boolean containsYaml(String requestURL) {
     try {
       String fetch = urlFetcher.fetch(requestURL);
-      devfileParser.parseYaml(fetch);
-      return true;
-    } catch (IOException e) {
+      JsonNode parsedYaml = devfileParser.parseYamlRaw(fetch);
+      return !parsedYaml.isEmpty();
+    } catch (IOException | DevfileFormatException e) {
       return false;
-    } catch (DevfileFormatException e) {
-      return !e.getMessage().startsWith("Cannot construct instance of");
     }
   }
 

--- a/wsmaster/che-core-api-factory/src/main/java/org/eclipse/che/api/factory/server/RawDevfileUrlFactoryParameterResolver.java
+++ b/wsmaster/che-core-api-factory/src/main/java/org/eclipse/che/api/factory/server/RawDevfileUrlFactoryParameterResolver.java
@@ -69,7 +69,7 @@ public class RawDevfileUrlFactoryParameterResolver extends BaseFactoryParameterR
   @Override
   public boolean accept(Map<String, String> factoryParameters) {
     String url = factoryParameters.get(URL_PARAMETER_NAME);
-    return !isNullOrEmpty(url) && PATTERN.matcher(url).matches() || containsDevfile(url);
+    return !isNullOrEmpty(url) && (PATTERN.matcher(url).matches() || containsDevfile(url));
   }
 
   private boolean containsDevfile(String requestURL) {

--- a/wsmaster/che-core-api-factory/src/test/java/org/eclipse/che/api/factory/server/RawDevfileUrlFactoryParameterResolverTest.java
+++ b/wsmaster/che-core-api-factory/src/test/java/org/eclipse/che/api/factory/server/RawDevfileUrlFactoryParameterResolverTest.java
@@ -169,6 +169,22 @@ public class RawDevfileUrlFactoryParameterResolverTest {
     assertTrue(result);
   }
 
+  @Test(dataProvider = "devfileUrlsWithoutExtension")
+  public void shouldAcceptRawDevfileUrlWithoutExtension(String url) throws Exception {
+    // given
+    JsonNode jsonNode = mock(JsonNode.class);
+    when(urlFetcher.fetch(eq(url))).thenReturn(DEVFILE);
+    when(devfileParser.parseYamlRaw(eq(DEVFILE))).thenReturn(jsonNode);
+    when(jsonNode.isEmpty()).thenReturn(false);
+
+    // when
+    boolean result =
+        rawDevfileUrlFactoryParameterResolver.accept(singletonMap(URL_PARAMETER_NAME, url));
+
+    // then
+    assertTrue(result);
+  }
+
   @Test
   public void shouldAcceptRawDevfileUrlWithYaml() throws Exception {
     // given
@@ -238,12 +254,15 @@ public class RawDevfileUrlFactoryParameterResolverTest {
       "https://host/path/.devfile.yaml",
       "https://host/path/any-name.yaml",
       "https://host/path/any-name.yml",
-      "https://host/path/any-name",
       "https://host/path/devfile.yaml?token=TOKEN123",
       "https://host/path/.devfile.yaml?token=TOKEN123",
       "https://host/path/any-name.yaml?token=TOKEN123",
-      "https://host/path/any-name.yml?token=TOKEN123",
-      "https://host/path/any-name?token=TOKEN123"
+      "https://host/path/any-name.yml?token=TOKEN123"
     };
+  }
+
+  @DataProvider(name = "devfileUrlsWithoutExtension")
+  private Object[] devfileUrlsWithoutExtension() {
+    return new String[] {"https://host/path/any-name", "https://host/path/any-name?token=TOKEN123"};
   }
 }

--- a/wsmaster/che-core-api-factory/src/test/java/org/eclipse/che/api/factory/server/RawDevfileUrlFactoryParameterResolverTest.java
+++ b/wsmaster/che-core-api-factory/src/test/java/org/eclipse/che/api/factory/server/RawDevfileUrlFactoryParameterResolverTest.java
@@ -30,6 +30,7 @@ import static org.testng.Assert.fail;
 import static org.testng.AssertJUnit.assertEquals;
 import static org.testng.AssertJUnit.assertTrue;
 
+import java.io.FileNotFoundException;
 import java.util.HashMap;
 import java.util.Map;
 import org.eclipse.che.api.core.BadRequestException;
@@ -185,12 +186,27 @@ public class RawDevfileUrlFactoryParameterResolverTest {
   }
 
   @Test
-  public void shouldNotAcceptGitRepositoryUrl() throws Exception {
+  public void shouldNotAcceptPublicGitRepositoryUrl() throws Exception {
     // given
     String gitRepositoryUrl = "https://host/user/repo.git";
     when(urlFetcher.fetch(eq(gitRepositoryUrl))).thenReturn("unsupported content");
     when(devfileParser.parseYaml(eq("unsupported content")))
         .thenThrow(new DevfileFormatException("Cannot construct instance of ..."));
+
+    // when
+    boolean result =
+        rawDevfileUrlFactoryParameterResolver.accept(
+            singletonMap(URL_PARAMETER_NAME, gitRepositoryUrl));
+
+    // then
+    assertFalse(result);
+  }
+
+  @Test
+  public void shouldNotAcceptPrivateGitRepositoryUrl() throws Exception {
+    // given
+    String gitRepositoryUrl = "https://host/user/private-repo.git";
+    when(urlFetcher.fetch(eq(gitRepositoryUrl))).thenThrow(new FileNotFoundException());
 
     // when
     boolean result =

--- a/wsmaster/che-core-api-factory/src/test/java/org/eclipse/che/api/factory/server/RawDevfileUrlFactoryParameterResolverTest.java
+++ b/wsmaster/che-core-api-factory/src/test/java/org/eclipse/che/api/factory/server/RawDevfileUrlFactoryParameterResolverTest.java
@@ -30,6 +30,7 @@ import static org.testng.Assert.fail;
 import static org.testng.AssertJUnit.assertEquals;
 import static org.testng.AssertJUnit.assertTrue;
 
+import com.fasterxml.jackson.databind.JsonNode;
 import java.io.FileNotFoundException;
 import java.util.HashMap;
 import java.util.Map;
@@ -40,7 +41,6 @@ import org.eclipse.che.api.workspace.server.devfile.DevfileParser;
 import org.eclipse.che.api.workspace.server.devfile.DevfileVersionDetector;
 import org.eclipse.che.api.workspace.server.devfile.URLFetcher;
 import org.eclipse.che.api.workspace.server.devfile.URLFileContentProvider;
-import org.eclipse.che.api.workspace.server.devfile.exception.DevfileFormatException;
 import org.eclipse.che.api.workspace.server.devfile.validator.ComponentIntegrityValidator;
 import org.eclipse.che.api.workspace.server.devfile.validator.ComponentIntegrityValidator.NoopComponentIntegrityValidator;
 import org.eclipse.che.api.workspace.server.devfile.validator.DevfileIntegrityValidator;
@@ -170,12 +170,13 @@ public class RawDevfileUrlFactoryParameterResolverTest {
   }
 
   @Test
-  public void shouldAcceptRawDevfileUrlWithUnrecognizedDevfile() throws Exception {
+  public void shouldAcceptRawDevfileUrlWithYaml() throws Exception {
     // given
+    JsonNode jsonNode = mock(JsonNode.class);
     String url = "https://host/path/devfile";
     when(urlFetcher.fetch(eq(url))).thenReturn(DEVFILE);
-    when(devfileParser.parseYaml(eq(DEVFILE)))
-        .thenThrow(new DevfileFormatException("Unrecognized field \"schemaVersion\""));
+    when(devfileParser.parseYamlRaw(eq(DEVFILE))).thenReturn(jsonNode);
+    when(jsonNode.isEmpty()).thenReturn(false);
 
     // when
     boolean result =
@@ -188,10 +189,11 @@ public class RawDevfileUrlFactoryParameterResolverTest {
   @Test
   public void shouldNotAcceptPublicGitRepositoryUrl() throws Exception {
     // given
+    JsonNode jsonNode = mock(JsonNode.class);
     String gitRepositoryUrl = "https://host/user/repo.git";
     when(urlFetcher.fetch(eq(gitRepositoryUrl))).thenReturn("unsupported content");
-    when(devfileParser.parseYaml(eq("unsupported content")))
-        .thenThrow(new DevfileFormatException("Cannot construct instance of ..."));
+    when(devfileParser.parseYamlRaw(eq("unsupported content"))).thenReturn(jsonNode);
+    when(jsonNode.isEmpty()).thenReturn(true);
 
     // when
     boolean result =


### PR DESCRIPTION
<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests
-->

### What does this PR do?
On handling raw devfile urls, request content by the url, and check if the content is a devfile. If yes treat the url as a raw devfile url.

### Screenshot/screencast of this PR
<!-- Please include a screenshot or a screencast explaining what is doing this PR -->


### What issues does this PR fix or reference?
<!-- Please include any related issue from eclipse che repository (or from another issue tracker).
     Include link to other pull requests like documentation PR from [the docs repo](https://github.com/eclipse/che-docs)
-->
fixes https://github.com/eclipse-che/che/issues/22937


### How to test this PR?
<!-- Please explain for example :
  - The test platform (openshift, kubernetes, minikube, CodeReady Container, docker-desktop, etc)
  - Installation method: chectl / che-operator
  - steps to reproduce
 -->
1. Deploy che with the PR image: `quay.io/eclipse/che-server:pr-683`
2. Start a workspace from a raw devfile url without `yaml` extension, e.g. `https://raw.githubusercontent.com/vinokurig/test/master/parent`

See: workspace starts successfully.

### PR Checklist

[As the author of this Pull Request I made sure that:](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#pull-request-template-and-its-checklist)

- [ ] [The Eclipse Contributor Agreement is valid](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-eclipse-contributor-agreement-is-valid)
- [ ] [Code produced is complete](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-produced-is-complete)
- [ ] [Code builds without errors](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-builds-without-errors)
- [ ] [Tests are covering the bugfix](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#tests-are-covering-the-bugfix)
- [ ] [The repository devfile is up to date and works](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-repository-devfile-is-up-to-date-and-works)
- [ ] [Sections `What issues does this PR fix or reference` and `How to test this PR` completed](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#sections-what-issues-does-this-pr-fix-or-reference-and-how-to-test-this-pr-completed)
- [ ] [Relevant user documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [Relevant contributing documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [CI/CD changes implemented, documented and communicated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#cicd-changes-implemented-documented-and-communicated)

### Reviewers

Reviewers, please comment how you tested the PR when approving it.
