### PR TITLE
[DO NOT MERGE] Delete personal access tokens without provider name annotation

### DIFF
--- a/infrastructures/infrastructure-factory/src/main/java/org/eclipse/che/api/factory/server/scm/kubernetes/KubernetesPersonalAccessTokenManager.java
+++ b/infrastructures/infrastructure-factory/src/main/java/org/eclipse/che/api/factory/server/scm/kubernetes/KubernetesPersonalAccessTokenManager.java
@@ -71,8 +71,14 @@ public class KubernetesPersonalAccessTokenManager implements PersonalAccessToken
   public static final String ANNOTATION_SCM_ORGANIZATION = "che.eclipse.org/scm-organization";
   public static final String ANNOTATION_SCM_PERSONAL_ACCESS_TOKEN_ID =
       "che.eclipse.org/scm-personal-access-token-id";
+  public static final String ANNOTATION_SCM_PERSONAL_ACCESS_TOKEN_IS_OAUTH =
+      "che.eclipse.org/scm-personal-access-token-is-oauth";
+
+  @Deprecated
+  // This annotation is deprecated and will be removed in the future.
   public static final String ANNOTATION_SCM_PERSONAL_ACCESS_TOKEN_NAME =
       "che.eclipse.org/scm-personal-access-token-name";
+
   public static final String ANNOTATION_SCM_URL = "che.eclipse.org/scm-url";
   public static final String TOKEN_DATA_FIELD = "token";
 
@@ -112,9 +118,6 @@ public class KubernetesPersonalAccessTokenManager implements PersonalAccessToken
                       .put(
                           ANNOTATION_SCM_PERSONAL_ACCESS_TOKEN_ID,
                           personalAccessToken.getScmTokenId())
-                      .put(
-                          ANNOTATION_SCM_PERSONAL_ACCESS_TOKEN_NAME,
-                          personalAccessToken.getScmTokenName())
                       .build())
               .withLabels(SECRET_LABELS)
               .build();
@@ -214,7 +217,9 @@ public class KubernetesPersonalAccessTokenManager implements PersonalAccessToken
               PersonalAccessToken personalAccessToken =
                   new PersonalAccessToken(
                       personalAccessTokenParams.getScmProviderUrl(),
-                      getScmProviderName(personalAccessTokenParams),
+                      getScmProviderName(
+                          personalAccessTokenParams.getScmProviderName(),
+                          personalAccessTokenParams.getScmTokenName()),
                       secretAnnotations.get(ANNOTATION_CHE_USERID),
                       personalAccessTokenParams.getOrganization(),
                       scmUsername.get(),
@@ -273,13 +278,12 @@ public class KubernetesPersonalAccessTokenManager implements PersonalAccessToken
    * This is used to support back compatibility with the old token secrets, which do not have the
    * 'che.eclipse.org/scm-provider-name' annotation.
    *
-   * @param params the parameters of the personal access token
+   * @param providerName the name of the SCM provider
+   * @param tokenName the name of the token
    * @return the name of the SCM provider
    */
-  private String getScmProviderName(PersonalAccessTokenParams params) {
-    return isNullOrEmpty(params.getScmProviderName())
-        ? params.getScmTokenName()
-        : params.getScmProviderName();
+  private String getScmProviderName(@Nullable String providerName, String tokenName) {
+    return isNullOrEmpty(providerName) ? tokenName : providerName;
   }
 
   private boolean deleteSecretIfMisconfigured(Secret secret) throws InfrastructureException {
@@ -289,8 +293,8 @@ public class KubernetesPersonalAccessTokenManager implements PersonalAccessToken
     LOG.debug("SCM server URL: {}", configuredScmServerUrl);
     String configuredCheUserId = secretAnnotations.get(ANNOTATION_CHE_USERID);
     LOG.debug("Che user ID: {}", configuredCheUserId);
-    String configuredOAuthProviderName =
-        secretAnnotations.get(ANNOTATION_SCM_PERSONAL_ACCESS_TOKEN_NAME);
+    String providerName = secretAnnotations.get(ANNOTATION_SCM_PROVIDER_NAME);
+    String configuredOAuthProviderName = getScmProviderName(providerName, getTokenName(secret));
     LOG.debug("OAuth provider name: {}", configuredOAuthProviderName);
 
     // if any of the required annotations is missing, the secret is not valid
@@ -309,24 +313,42 @@ public class KubernetesPersonalAccessTokenManager implements PersonalAccessToken
     return false;
   }
 
+  /**
+   * Returns the token name. If the token name is not set, the name of the secret in format:
+   * personal-access-token-<token-name> is used. This is used to support back compatibility with the
+   * old token secrets, which do not have the 'che.eclipse.org/scm-provider-name' annotation, but
+   * have the deprecated 'che.eclipse.org/scm-personal-access-token-name' annotation.
+   *
+   * @param secret the secret
+   * @return the token name
+   */
+  private String getTokenName(Secret secret) {
+    String tokenName =
+        secret.getMetadata().getAnnotations().get(ANNOTATION_SCM_PERSONAL_ACCESS_TOKEN_NAME);
+    String secretName = secret.getMetadata().getName();
+    return isNullOrEmpty(tokenName)
+        ? secretName.substring(secretName.lastIndexOf("-") + 1)
+        : tokenName;
+  }
+
   private PersonalAccessTokenParams secret2PersonalAccessTokenParams(Secret secret) {
     Map<String, String> secretAnnotations = secret.getMetadata().getAnnotations();
 
     String token = new String(Base64.getDecoder().decode(secret.getData().get("token"))).trim();
-    String configuredOAuthTokenName =
-        secretAnnotations.get(ANNOTATION_SCM_PERSONAL_ACCESS_TOKEN_NAME);
     String configuredTokenId = secretAnnotations.get(ANNOTATION_SCM_PERSONAL_ACCESS_TOKEN_ID);
     String configuredScmOrganization = secretAnnotations.get(ANNOTATION_SCM_ORGANIZATION);
     String configuredScmServerUrl = secretAnnotations.get(ANNOTATION_SCM_URL);
     String configuredScmProviderName = secretAnnotations.get(ANNOTATION_SCM_PROVIDER_NAME);
+    String configuredIsOauth = secretAnnotations.get(ANNOTATION_SCM_PERSONAL_ACCESS_TOKEN_IS_OAUTH);
 
     return new PersonalAccessTokenParams(
         trimEnd(configuredScmServerUrl, '/'),
         configuredScmProviderName,
-        configuredOAuthTokenName,
+        getTokenName(secret),
         configuredTokenId,
         token,
-        configuredScmOrganization);
+        configuredScmOrganization,
+        Boolean.parseBoolean(configuredIsOauth));
   }
 
   private boolean isSecretMatchesSearchCriteria(
@@ -337,8 +359,8 @@ public class KubernetesPersonalAccessTokenManager implements PersonalAccessToken
     Map<String, String> secretAnnotations = secret.getMetadata().getAnnotations();
     String configuredScmServerUrl = secretAnnotations.get(ANNOTATION_SCM_URL);
     String configuredCheUserId = secretAnnotations.get(ANNOTATION_CHE_USERID);
-    String configuredOAuthProviderName =
-        secretAnnotations.get(ANNOTATION_SCM_PERSONAL_ACCESS_TOKEN_NAME);
+    String providerName = secretAnnotations.get(ANNOTATION_SCM_PROVIDER_NAME);
+    String configuredOAuthProviderName = getScmProviderName(providerName, getTokenName(secret));
 
     return (configuredCheUserId.equals(cheUser.getUserId()))
         && (oAuthProviderName == null || oAuthProviderName.equals(configuredOAuthProviderName))
@@ -391,8 +413,7 @@ public class KubernetesPersonalAccessTokenManager implements PersonalAccessToken
 
   @Override
   public void storeGitCredentials(String scmServerUrl)
-      throws UnsatisfiedScmPreconditionException, ScmConfigurationPersistenceException,
-          ScmCommunicationException, ScmUnauthorizedException {
+      throws UnsatisfiedScmPreconditionException, ScmConfigurationPersistenceException {
     Subject subject = EnvironmentContext.getCurrent().getSubject();
     Optional<PersonalAccessToken> tokenOptional = get(subject, scmServerUrl);
     if (tokenOptional.isPresent()) {

--- a/wsmaster/che-core-api-factory-azure-devops/src/main/java/org/eclipse/che/api/factory/server/azure/devops/AzureDevOpsPersonalAccessTokenFetcher.java
+++ b/wsmaster/che-core-api-factory-azure-devops/src/main/java/org/eclipse/che/api/factory/server/azure/devops/AzureDevOpsPersonalAccessTokenFetcher.java
@@ -108,7 +108,8 @@ public class AzureDevOpsPersonalAccessTokenFetcher implements PersonalAccessToke
                   tokenName,
                   tokenId,
                   oAuthToken.getToken(),
-                  null));
+                  null,
+                  true));
       if (valid.isEmpty()) {
         throw buildScmUnauthorizedException(cheSubject);
       } else if (!valid.get().first) {

--- a/wsmaster/che-core-api-factory-bitbucket/src/main/java/org/eclipse/che/api/factory/server/bitbucket/BitbucketPersonalAccessTokenFetcher.java
+++ b/wsmaster/che-core-api-factory-bitbucket/src/main/java/org/eclipse/che/api/factory/server/bitbucket/BitbucketPersonalAccessTokenFetcher.java
@@ -117,7 +117,8 @@ public class BitbucketPersonalAccessTokenFetcher implements PersonalAccessTokenF
                   tokenName,
                   tokenId,
                   oAuthToken.getToken(),
-                  null));
+                  null,
+                  true));
       if (valid.isEmpty()) {
         throw buildScmUnauthorizedException(cheSubject);
       } else if (!valid.get().first) {

--- a/wsmaster/che-core-api-factory-bitbucket/src/test/java/org/eclipse/che/api/factory/server/bitbucket/BitbucketPersonalAccessTokenFetcherTest.java
+++ b/wsmaster/che-core-api-factory-bitbucket/src/test/java/org/eclipse/che/api/factory/server/bitbucket/BitbucketPersonalAccessTokenFetcherTest.java
@@ -92,7 +92,8 @@ public class BitbucketPersonalAccessTokenFetcherTest {
             "scmTokenName",
             "scmTokenId",
             bitbucketOauthToken,
-            null);
+            null,
+            true);
     assertTrue(
         bitbucketPersonalAccessTokenFetcher.isValid(personalAccessTokenParams).isEmpty(),
         "Should not validate SCM server with trailing /");
@@ -175,7 +176,8 @@ public class BitbucketPersonalAccessTokenFetcherTest {
             "params-name",
             "tid-23434",
             bitbucketOauthToken,
-            null);
+            null,
+            true);
 
     Optional<Pair<Boolean, String>> valid = bitbucketPersonalAccessTokenFetcher.isValid(params);
     assertTrue(valid.isPresent());
@@ -202,7 +204,8 @@ public class BitbucketPersonalAccessTokenFetcherTest {
             OAUTH_2_PREFIX + "-params-name",
             "tid-23434",
             bitbucketOauthToken,
-            null);
+            null,
+            true);
 
     Optional<Pair<Boolean, String>> valid = bitbucketPersonalAccessTokenFetcher.isValid(params);
     assertTrue(valid.isPresent());
@@ -220,7 +223,8 @@ public class BitbucketPersonalAccessTokenFetcherTest {
             OAUTH_2_PREFIX + "-token-name",
             "tid-23434",
             bitbucketOauthToken,
-            null);
+            null,
+            true);
 
     assertFalse(bitbucketPersonalAccessTokenFetcher.isValid(params).isPresent());
   }

--- a/wsmaster/che-core-api-factory-github-common/src/main/java/org/eclipse/che/api/factory/server/github/AbstractGithubPersonalAccessTokenFetcher.java
+++ b/wsmaster/che-core-api-factory-github-common/src/main/java/org/eclipse/che/api/factory/server/github/AbstractGithubPersonalAccessTokenFetcher.java
@@ -156,7 +156,8 @@ public abstract class AbstractGithubPersonalAccessTokenFetcher
                   tokenName,
                   tokenId,
                   oAuthToken.getToken(),
-                  null));
+                  null,
+                  true));
       if (valid.isEmpty()) {
         throw buildScmUnauthorizedException(cheSubject);
       } else if (!valid.get().first) {
@@ -227,7 +228,7 @@ public abstract class AbstractGithubPersonalAccessTokenFetcher
       // The url from the token has the same url as the api client, no need to create a new one.
       apiClient = githubApiClient;
     } else {
-      if (OAUTH_PROVIDER_NAME.equals(params.getScmTokenName())) {
+      if (OAUTH_PROVIDER_NAME.equals(params.getScmProviderName())) {
         apiClient = new GithubApiClient(params.getScmProviderUrl());
       } else {
         LOG.debug("not a  valid url {} for current fetcher ", params.getScmProviderUrl());
@@ -235,7 +236,7 @@ public abstract class AbstractGithubPersonalAccessTokenFetcher
       }
     }
     try {
-      if (params.getScmTokenName() != null && params.getScmTokenName().startsWith(OAUTH_2_PREFIX)) {
+      if (params.isOauthToken()) {
         Pair<String, String[]> pair = apiClient.getTokenScopes(params.getToken());
         return Optional.of(
             Pair.of(

--- a/wsmaster/che-core-api-factory-github/src/test/java/org/eclipse/che/api/factory/server/github/GithubPersonalAccessTokenFetcherTest.java
+++ b/wsmaster/che-core-api-factory-github/src/test/java/org/eclipse/che/api/factory/server/github/GithubPersonalAccessTokenFetcherTest.java
@@ -96,7 +96,8 @@ public class GithubPersonalAccessTokenFetcherTest {
             "scmTokenName",
             "scmTokenId",
             githubOauthToken,
-            null);
+            null,
+            true);
     assertTrue(
         githubPATFetcher.isValid(personalAccessTokenParams).isEmpty(),
         "Should not validate SCM server with trailing /");
@@ -218,7 +219,13 @@ public class GithubPersonalAccessTokenFetcherTest {
 
     PersonalAccessTokenParams params =
         new PersonalAccessTokenParams(
-            wireMockServer.url("/"), "provider", "token-name", "tid-23434", githubOauthToken, null);
+            wireMockServer.url("/"),
+            "provider",
+            "token-name",
+            "tid-23434",
+            githubOauthToken,
+            null,
+            true);
 
     Optional<Pair<Boolean, String>> valid = githubPATFetcher.isValid(params);
     assertTrue(valid.isPresent());
@@ -245,7 +252,8 @@ public class GithubPersonalAccessTokenFetcherTest {
             OAUTH_2_PREFIX + "-params-name",
             "tid-23434",
             githubOauthToken,
-            null);
+            null,
+            true);
 
     Optional<Pair<Boolean, String>> valid = githubPATFetcher.isValid(params);
     assertTrue(valid.isPresent());
@@ -263,7 +271,8 @@ public class GithubPersonalAccessTokenFetcherTest {
             OAUTH_2_PREFIX + "-token-name",
             "tid-23434",
             githubOauthToken,
-            null);
+            null,
+            true);
 
     assertFalse(githubPATFetcher.isValid(params).isPresent());
   }

--- a/wsmaster/che-core-api-factory-gitlab/src/main/java/org/eclipse/che/api/factory/server/gitlab/GitlabOAuthTokenFetcher.java
+++ b/wsmaster/che-core-api-factory-gitlab/src/main/java/org/eclipse/che/api/factory/server/gitlab/GitlabOAuthTokenFetcher.java
@@ -131,7 +131,8 @@ public class GitlabOAuthTokenFetcher implements PersonalAccessTokenFetcher {
                   tokenName,
                   tokenId,
                   oAuthToken.getToken(),
-                  null));
+                  null,
+                  true));
       if (valid.isEmpty()) {
         throw buildScmUnauthorizedException(cheSubject);
       } else if (!valid.get().first) {

--- a/wsmaster/che-core-api-factory-gitlab/src/test/java/org/eclipse/che/api/factory/server/gitlab/GitlabOAuthTokenFetcherTest.java
+++ b/wsmaster/che-core-api-factory-gitlab/src/test/java/org/eclipse/che/api/factory/server/gitlab/GitlabOAuthTokenFetcherTest.java
@@ -184,7 +184,8 @@ public class GitlabOAuthTokenFetcherTest {
             "oauth2-token-name",
             "tid-23434",
             "token123",
-            null);
+            null,
+            true);
 
     Optional<Pair<Boolean, String>> valid = oAuthTokenFetcher.isValid(params);
 

--- a/wsmaster/che-core-api-factory/src/main/java/org/eclipse/che/api/factory/server/scm/PersonalAccessTokenParams.java
+++ b/wsmaster/che-core-api-factory/src/main/java/org/eclipse/che/api/factory/server/scm/PersonalAccessTokenParams.java
@@ -20,19 +20,23 @@ public class PersonalAccessTokenParams {
   private final String token;
   private final String organization;
 
+  private final boolean isOauthToken;
+
   public PersonalAccessTokenParams(
       String scmProviderUrl,
       String scmProviderName,
       String scmTokenName,
       String scmTokenId,
       String token,
-      String organization) {
+      String organization,
+      boolean isOauthToken) {
     this.scmProviderUrl = scmProviderUrl;
     this.scmProviderName = scmProviderName;
     this.scmTokenName = scmTokenName;
     this.scmTokenId = scmTokenId;
     this.token = token;
     this.organization = organization;
+    this.isOauthToken = isOauthToken;
   }
 
   public String getScmProviderUrl() {
@@ -49,6 +53,10 @@ public class PersonalAccessTokenParams {
   @Deprecated
   public String getScmTokenName() {
     return scmTokenName;
+  }
+
+  public boolean isOauthToken() {
+    return isOauthToken;
   }
 
   public String getScmTokenId() {


### PR DESCRIPTION
<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests
-->

### What does this PR do?
Check a personal access token to have the `che.eclipse.org/scm-provider-name` annotation instead of the deprecated `che.eclipse.org/scm-personal-access-token-name`. All token secrets that were created before the 7.84 version, will be removed. A new secret with the new annotation will be created on workspace create/start. 

### Screenshot/screencast of this PR
<!-- Please include a screenshot or a screencast explaining what is doing this PR -->


### What issues does this PR fix or reference?
<!-- Please include any related issue from eclipse che repository (or from another issue tracker).
     Include link to other pull requests like documentation PR from [the docs repo](https://github.com/eclipse/che-docs)
-->
https://issues.redhat.com/browse/CRW-6301

### How to test this PR?
<!-- Please explain for example :
  - The test platform (openshift, kubernetes, minikube, CodeReady Container, docker-desktop, etc)
  - Installation method: chectl / che-operator
  - steps to reproduce
 -->
1. Deploy che from the PR image: `quay.io/eclipse/che-server:pr-685`.
2. Setup [GitHub oauth](https://eclipse.dev/che/docs/stable/administration-guide/configuring-oauth-2-for-github/).
3. Start a workspace from the GitHub repository with a devfile.
4. Go to the Che Dashboard -> User Preference -> Personal Access Tokens tab, see: a token is added to the list.
5. Go to Openshift console Workloads -> Secrets and find the `personal-access-token-...` secret.
6. Open the secret's YAML and remove the `che.eclipse.org/scm-provider-name` annotation.
7. Go to the Che Dashboard -> User Preference -> Personal Access Tokens tab (refresh the page if needed), see: the token item is removed.
8. Delete the previously created workspace and start a new one from the same repository url.
9. Go to the Che Dashboard -> User Preference -> Personal Access Tokens tab, see: a new token is added to the list.

### PR Checklist

[As the author of this Pull Request I made sure that:](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#pull-request-template-and-its-checklist)

- [x] [The Eclipse Contributor Agreement is valid](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-eclipse-contributor-agreement-is-valid)
- [x] [Code produced is complete](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-produced-is-complete)
- [x] [Code builds without errors](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-builds-without-errors)
- [x] [Tests are covering the bugfix](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#tests-are-covering-the-bugfix)
- [ ] [The repository devfile is up to date and works](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-repository-devfile-is-up-to-date-and-works)
- [x] [Sections `What issues does this PR fix or reference` and `How to test this PR` completed](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#sections-what-issues-does-this-pr-fix-or-reference-and-how-to-test-this-pr-completed)
- [ ] [Relevant user documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [Relevant contributing documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [CI/CD changes implemented, documented and communicated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#cicd-changes-implemented-documented-and-communicated)

### Reviewers

Reviewers, please comment how you tested the PR when approving it.
