### PR TITLE
Explicitly set Bitbucket Server provider name, fix GitHub url parser

### DIFF
--- a/wsmaster/che-core-api-auth-bitbucket/src/main/java/org/eclipse/che/security/oauth/BitbucketOAuthAuthenticator.java
+++ b/wsmaster/che-core-api-auth-bitbucket/src/main/java/org/eclipse/che/security/oauth/BitbucketOAuthAuthenticator.java
@@ -30,6 +30,8 @@ public class BitbucketOAuthAuthenticator extends OAuthAuthenticator {
   private final String bitbucketEndpoint;
 
   private static final String BITBUCKET_CLOUD_ENDPOINT = "https://bitbucket.org";
+  private static final String BITBUCKET_NAME = "bitbucket";
+  private static final String BITBUCKET_SERVER_NAME = "bitbucket-server";
 
   public BitbucketOAuthAuthenticator(
       String bitbucketEndpoint,
@@ -54,7 +56,10 @@ public class BitbucketOAuthAuthenticator extends OAuthAuthenticator {
 
   @Override
   public final String getOAuthProvider() {
-    return BITBUCKET_CLOUD_ENDPOINT.equals(bitbucketEndpoint) ? "bitbucket" : "bitbucket-server";
+    // Bitbucket Cloud and Bitbucket Server have different provider names.
+    return BITBUCKET_CLOUD_ENDPOINT.equals(bitbucketEndpoint)
+        ? BITBUCKET_NAME
+        : BITBUCKET_SERVER_NAME;
   }
 
   @Override

--- a/wsmaster/che-core-api-auth-bitbucket/src/main/java/org/eclipse/che/security/oauth/BitbucketOAuthAuthenticator.java
+++ b/wsmaster/che-core-api-auth-bitbucket/src/main/java/org/eclipse/che/security/oauth/BitbucketOAuthAuthenticator.java
@@ -29,6 +29,8 @@ import org.eclipse.che.api.auth.shared.dto.OAuthToken;
 public class BitbucketOAuthAuthenticator extends OAuthAuthenticator {
   private final String bitbucketEndpoint;
 
+  private static final String BITBUCKET_CLOUD_ENDPOINT = "https://bitbucket.org";
+
   public BitbucketOAuthAuthenticator(
       String bitbucketEndpoint,
       String clientId,
@@ -52,7 +54,7 @@ public class BitbucketOAuthAuthenticator extends OAuthAuthenticator {
 
   @Override
   public final String getOAuthProvider() {
-    return "bitbucket";
+    return BITBUCKET_CLOUD_ENDPOINT.equals(bitbucketEndpoint) ? "bitbucket" : "bitbucket-server";
   }
 
   @Override
@@ -76,7 +78,7 @@ public class BitbucketOAuthAuthenticator extends OAuthAuthenticator {
    * @return Bitbucket Cloud or Server API request URL
    */
   private String getTestRequestUrl() {
-    return "https://bitbucket.org".equals(bitbucketEndpoint)
+    return BITBUCKET_CLOUD_ENDPOINT.equals(bitbucketEndpoint)
         ? "https://api.bitbucket.org/2.0/user"
         : bitbucketEndpoint + "/plugins/servlet/applinks/whoami";
   }

--- a/wsmaster/che-core-api-factory-bitbucket-server/src/main/java/org/eclipse/che/api/factory/server/bitbucket/HttpBitbucketServerApiClient.java
+++ b/wsmaster/che-core-api-factory-bitbucket-server/src/main/java/org/eclipse/che/api/factory/server/bitbucket/HttpBitbucketServerApiClient.java
@@ -421,7 +421,7 @@ public class HttpBitbucketServerApiClient implements BitbucketServerApiClient {
 
   private @Nullable String getToken() throws ScmUnauthorizedException {
     try {
-      OAuthToken token = oAuthAPI.getToken("bitbucket");
+      OAuthToken token = oAuthAPI.getToken("bitbucket-server");
       return token.getToken();
     } catch (NotFoundException
         | ServerException
@@ -459,7 +459,7 @@ public class HttpBitbucketServerApiClient implements BitbucketServerApiClient {
         "bitbucket",
         authenticator instanceof NoopOAuthAuthenticator ? "2.0" : "1.0",
         authenticator instanceof NoopOAuthAuthenticator
-            ? apiEndpoint + "/oauth/authenticate?oauth_provider=bitbucket&scope=ADMIN_WRITE"
+            ? apiEndpoint + "/oauth/authenticate?oauth_provider=bitbucket-server&scope=ADMIN_WRITE"
             : authenticator.getLocalAuthenticateUrl());
   }
 }

--- a/wsmaster/che-core-api-factory-bitbucket-server/src/test/java/org/eclipse/che/api/factory/server/bitbucket/HttpBitbucketServerApiClientTest.java
+++ b/wsmaster/che-core-api-factory-bitbucket-server/src/test/java/org/eclipse/che/api/factory/server/bitbucket/HttpBitbucketServerApiClientTest.java
@@ -394,7 +394,7 @@ public class HttpBitbucketServerApiClientTest {
           NotFoundException, BadRequestException {
 
     // given
-    when(oAuthAPI.getToken(eq("bitbucket"))).thenReturn(mock(OAuthToken.class));
+    when(oAuthAPI.getToken(eq("bitbucket-server"))).thenReturn(mock(OAuthToken.class));
     HttpBitbucketServerApiClient localServer =
         new HttpBitbucketServerApiClient(
             wireMockServer.url("/"), new NoopOAuthAuthenticator(), oAuthAPI, apiEndpoint);
@@ -411,7 +411,7 @@ public class HttpBitbucketServerApiClientTest {
     // given
     OAuthToken token = mock(OAuthToken.class);
     when(token.getToken()).thenReturn("token");
-    when(oAuthAPI.getToken(eq("bitbucket"))).thenReturn(token);
+    when(oAuthAPI.getToken(eq("bitbucket-server"))).thenReturn(token);
     bitbucketServer =
         new HttpBitbucketServerApiClient(
             wireMockServer.url("/"), new NoopOAuthAuthenticator(), oAuthAPI, apiEndpoint);
@@ -437,6 +437,6 @@ public class HttpBitbucketServerApiClientTest {
     bitbucketServer.getUser();
 
     // then
-    verify(oAuthAPI, times(2)).getToken(eq("bitbucket"));
+    verify(oAuthAPI, times(2)).getToken(eq("bitbucket-server"));
   }
 }

--- a/wsmaster/che-core-api-factory-github-common/src/main/java/org/eclipse/che/api/factory/server/github/AbstractGithubURLParser.java
+++ b/wsmaster/che-core-api-factory-github-common/src/main/java/org/eclipse/che/api/factory/server/github/AbstractGithubURLParser.java
@@ -63,6 +63,7 @@ public abstract class AbstractGithubURLParser {
   private final boolean disableSubdomainIsolation;
 
   private final String providerName;
+  private final String endpoint;
 
   /** Constructor used for testing only. */
   AbstractGithubURLParser(
@@ -78,8 +79,7 @@ public abstract class AbstractGithubURLParser {
     this.disableSubdomainIsolation = disableSubdomainIsolation;
     this.providerName = providerName;
 
-    String endpoint =
-        isNullOrEmpty(oauthEndpoint) ? GITHUB_SAAS_ENDPOINT : trimEnd(oauthEndpoint, '/');
+    endpoint = isNullOrEmpty(oauthEndpoint) ? GITHUB_SAAS_ENDPOINT : trimEnd(oauthEndpoint, '/');
 
     this.githubPattern = compile(format(githubPatternTemplate, endpoint));
     this.githubSSHPattern =
@@ -93,8 +93,8 @@ public abstract class AbstractGithubURLParser {
         // If the GitHub URL is not configured, try to find it in a manually added user namespace
         // token.
         || isUserTokenPresent(trimmedUrl)
-        // Try to call an API request to see if the URL matches GitHub.
-        || isApiRequestRelevant(trimmedUrl);
+        // Try to call an API request to see if the URL matches self-hosted GitHub Enterprise.
+        || (!GITHUB_SAAS_ENDPOINT.equals(endpoint) && isApiRequestRelevant(trimmedUrl));
   }
 
   private boolean isUserTokenPresent(String repositoryUrl) {

--- a/wsmaster/che-core-api-factory-github-common/src/main/java/org/eclipse/che/api/factory/server/github/AbstractGithubURLParser.java
+++ b/wsmaster/che-core-api-factory-github-common/src/main/java/org/eclipse/che/api/factory/server/github/AbstractGithubURLParser.java
@@ -86,17 +86,24 @@ public abstract class AbstractGithubURLParser {
         compile(format(githubSSHPatternTemplate, URI.create(endpoint).getHost()));
   }
 
+  // Check if the given URL is a valid GitHub URL.
   public boolean isValid(@NotNull String url) {
     String trimmedUrl = trimEnd(url, '/');
-    return githubPattern.matcher(trimmedUrl).matches()
+    return
+    // Check if the given URL matches the GitHub URL patterns. It works if OAuth is configured and
+    // GitHub server URL is known or the repository URL points to GitHub SaaS (https://github.com).
+    githubPattern.matcher(trimmedUrl).matches()
         || githubSSHPattern.matcher(trimmedUrl).matches()
-        // If the GitHub URL is not configured, try to find it in a manually added user namespace
-        // token.
+        // Check whether PAT is configured for the GitHub server URL. It is sufficient to confirm
+        // that the URL is a valid GitHub URL.
         || isUserTokenPresent(trimmedUrl)
-        // Try to call an API request to see if the URL matches self-hosted GitHub Enterprise.
+        // Check if the given URL is a valid GitHub URL by reaching the endpoint of the GitHub
+        // server and analysing the response. This query basically only needs to be performed if the
+        // specified repository URL does not point to GitHub SaaS.
         || (!GITHUB_SAAS_ENDPOINT.equals(endpoint) && isApiRequestRelevant(trimmedUrl));
   }
 
+  // Try to find the given url in a manually added user namespace token secret.
   private boolean isUserTokenPresent(String repositoryUrl) {
     Optional<String> serverUrlOptional = getServerUrl(repositoryUrl);
     if (serverUrlOptional.isPresent()) {
@@ -115,6 +122,7 @@ public abstract class AbstractGithubURLParser {
     return false;
   }
 
+  // Try to call an API request to see if the given url matches self-hosted GitHub Enterprise.
   private boolean isApiRequestRelevant(String repositoryUrl) {
     Optional<String> serverUrlOptional = getServerUrl(repositoryUrl);
     if (serverUrlOptional.isPresent()) {


### PR DESCRIPTION
<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests
-->

### What does this PR do?
* Return 'bitbucket-server' on oauth list request if the provider is Bitbucket server. If the provider is Bitbucket SAAS, return `bitbucket`.
* Do not test GitHub repository urls with user request if the url is a GitHub SAAS url.

### Screenshot/screencast of this PR
<!-- Please include a screenshot or a screencast explaining what is doing this PR -->


### What issues does this PR fix or reference?
<!-- Please include any related issue from eclipse che repository (or from another issue tracker).
     Include link to other pull requests like documentation PR from [the docs repo](https://github.com/eclipse/che-docs)
-->
https://github.com/eclipse-che/che/issues/22971

### How to test this PR?
<!-- Please explain for example :
  - The test platform (openshift, kubernetes, minikube, CodeReady Container, docker-desktop, etc)
  - Installation method: chectl / che-operator
  - steps to reproduce
 -->
1. Deploy che with the PR image: `quay.io/eclipse/che-server:pr-689`
2. Configure BitBucket server oauth2.
3. Call `<che-endpoint/api/oauth> api request, see: the provider name is `bitbucket-server`
4. Re-configure the oauth secret to BitBucket SAAS.
5. Call `<che-endpoint/api/oauth> api request, see: the provider name is `bitbucket`

### PR Checklist

[As the author of this Pull Request I made sure that:](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#pull-request-template-and-its-checklist)

- [ ] [The Eclipse Contributor Agreement is valid](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-eclipse-contributor-agreement-is-valid)
- [ ] [Code produced is complete](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-produced-is-complete)
- [ ] [Code builds without errors](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-builds-without-errors)
- [ ] [Tests are covering the bugfix](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#tests-are-covering-the-bugfix)
- [ ] [The repository devfile is up to date and works](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-repository-devfile-is-up-to-date-and-works)
- [ ] [Sections `What issues does this PR fix or reference` and `How to test this PR` completed](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#sections-what-issues-does-this-pr-fix-or-reference-and-how-to-test-this-pr-completed)
- [ ] [Relevant user documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [Relevant contributing documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [CI/CD changes implemented, documented and communicated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#cicd-changes-implemented-documented-and-communicated)

### Reviewers

Reviewers, please comment how you tested the PR when approving it.
