### PR TITLE
Avoid using token in testcase

### DIFF
--- a/wsmaster/che-core-api-factory-bitbucket-server/src/test/java/org/eclipse/che/api/factory/server/bitbucket/HttpBitbucketServerApiClientTest.java
+++ b/wsmaster/che-core-api-factory-bitbucket-server/src/test/java/org/eclipse/che/api/factory/server/bitbucket/HttpBitbucketServerApiClientTest.java
@@ -331,7 +331,7 @@ public class HttpBitbucketServerApiClientTest {
     BitbucketPersonalAccessToken result = bitbucketServer.getPersonalAccessToken("5", "token");
     // then
     assertNotNull(result);
-    assertEquals(result.getToken(), "MTU4OTEwNTMyOTA5Ohc88HcY8k7gWOzl2mP5TtdtY5Qs");
+    assertEquals(result.getToken(), "xxxx");
   }
 
   @Test(expectedExceptions = ScmItemNotFoundException.class)

--- a/wsmaster/che-core-api-factory-bitbucket-server/src/test/resources/__files/bitbucket/rest/access-tokens/1.0/users/ksmster/newtoken.json
+++ b/wsmaster/che-core-api-factory-bitbucket-server/src/test/resources/__files/bitbucket/rest/access-tokens/1.0/users/ksmster/newtoken.json
@@ -23,5 +23,5 @@
       ]
     }
   },
-  "token": "MTU4OTEwNTMyOTA5Ohc88HcY8k7gWOzl2mP5TtdtY5Qs"
+  "token": "xxxx"
 }


### PR DESCRIPTION
This PR is triggered by a security alert wrt a token used in a test case.

I updated the testcase to use a dummy value instead.