### PR TITLE
Handle SSL handshake exception on SCM callback step

### DIFF
--- a/wsmaster/che-core-api-auth/src/main/java/org/eclipse/che/security/oauth/EmbeddedOAuthAPI.java
+++ b/wsmaster/che-core-api-auth/src/main/java/org/eclipse/che/security/oauth/EmbeddedOAuthAPI.java
@@ -119,7 +119,9 @@ public class EmbeddedOAuthAPI implements OAuthAPI {
               token));
     } catch (OAuthAuthenticationException e) {
       return Response.temporaryRedirect(
-              URI.create(getRedirectAfterLoginUrl(params, "access_denied")))
+              URI.create(
+                  getParameter(params, "redirect_after_login")
+                      + String.format("&%s=access_denied", ERROR_QUERY_NAME)))
           .build();
     } catch (UnsatisfiedScmPreconditionException | ScmConfigurationPersistenceException e) {
       // Skip exception, the token will be stored in the next request.

--- a/wsmaster/che-core-api-auth/src/main/java/org/eclipse/che/security/oauth/EmbeddedOAuthAPI.java
+++ b/wsmaster/che-core-api-auth/src/main/java/org/eclipse/che/security/oauth/EmbeddedOAuthAPI.java
@@ -18,6 +18,7 @@ import static org.eclipse.che.api.factory.server.scm.PersonalAccessTokenFetcher.
 import static org.eclipse.che.commons.lang.UrlUtils.*;
 import static org.eclipse.che.commons.lang.UrlUtils.getParameter;
 import static org.eclipse.che.dto.server.DtoFactory.newDto;
+import static org.eclipse.che.security.oauth.OAuthAuthenticator.SSL_ERROR_CODE;
 import static org.eclipse.che.security.oauth1.OAuthAuthenticationService.ERROR_QUERY_NAME;
 
 import jakarta.servlet.http.HttpServletRequest;
@@ -124,9 +125,13 @@ public class EmbeddedOAuthAPI implements OAuthAPI {
       // Skip exception, the token will be stored in the next request.
       LOG.error(e.getMessage(), e);
     } catch (ScmCommunicationException e) {
-      return Response.temporaryRedirect(
-              URI.create(getRedirectAfterLoginUrl(params, "ssl_exception")))
-          .build();
+      if (e.getStatusCode() == SSL_ERROR_CODE) {
+        return Response.temporaryRedirect(
+                URI.create(getRedirectAfterLoginUrl(params, "ssl_exception")))
+            .build();
+      } else {
+        LOG.error(e.getMessage(), e);
+      }
     }
     return Response.temporaryRedirect(URI.create(getRedirectAfterLoginUrl(params, null))).build();
   }

--- a/wsmaster/che-core-api-auth/src/main/java/org/eclipse/che/security/oauth/OAuthAuthenticator.java
+++ b/wsmaster/che-core-api-auth/src/main/java/org/eclipse/che/security/oauth/OAuthAuthenticator.java
@@ -46,6 +46,7 @@ import org.slf4j.LoggerFactory;
 /** Authentication service which allow get access token from OAuth provider site. */
 public abstract class OAuthAuthenticator {
   protected static final String AUTHENTICATOR_IS_NOT_CONFIGURED = "Authenticator is not configured";
+  protected static final int SSL_ERROR_CODE = 495;
 
   private static final Logger LOG = LoggerFactory.getLogger(OAuthAuthenticator.class);
 
@@ -179,6 +180,7 @@ public abstract class OAuthAuthenticator {
    * @return access token
    * @throws OAuthAuthenticationException if authentication failed or <code>requestUrl</code> does
    *     not contain required parameters, e.g. 'code'
+   * @throws ScmCommunicationException if communication with SCM failed
    */
   public String callback(URL requestUrl, List<String> scopes)
       throws OAuthAuthenticationException, ScmCommunicationException {
@@ -209,7 +211,7 @@ public abstract class OAuthAuthenticator {
     } catch (IOException ioe) {
       if (ioe instanceof SSLHandshakeException) {
         throw new ScmCommunicationException(
-            "SSL handshake failed. Please contact your administrator.");
+            "SSL handshake failed. Please contact your administrator.", SSL_ERROR_CODE);
       }
       throw new OAuthAuthenticationException(ioe.getMessage());
     }

--- a/wsmaster/che-core-api-auth/src/main/java/org/eclipse/che/security/oauth1/OAuthAuthenticationService.java
+++ b/wsmaster/che-core-api-auth/src/main/java/org/eclipse/che/security/oauth1/OAuthAuthenticationService.java
@@ -74,7 +74,7 @@ public class OAuthAuthenticationService extends Service {
     final Map<String, List<String>> parameters = getQueryParametersFromState(getState(requestUrl));
 
     final String providerName = getParameter(parameters, "oauth_provider");
-    final String redirectAfterLogin = getRedirectAfterLoginUrl(parameters);
+    final String redirectAfterLogin = getRedirectAfterLoginUrl(parameters, null);
 
     UriBuilder redirectUriBuilder = UriBuilder.fromUri(redirectAfterLogin);
 

--- a/wsmaster/che-core-api-auth/src/test/java/org/eclipse/che/security/oauth/EmbeddedOAuthAPITest.java
+++ b/wsmaster/che-core-api-auth/src/test/java/org/eclipse/che/security/oauth/EmbeddedOAuthAPITest.java
@@ -38,6 +38,7 @@ import org.eclipse.che.api.auth.shared.dto.OAuthToken;
 import org.eclipse.che.api.core.NotFoundException;
 import org.eclipse.che.api.factory.server.scm.PersonalAccessToken;
 import org.eclipse.che.api.factory.server.scm.PersonalAccessTokenManager;
+import org.eclipse.che.api.factory.server.scm.exception.ScmCommunicationException;
 import org.eclipse.che.security.oauth.shared.dto.OAuthAuthenticatorDescriptor;
 import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
@@ -114,6 +115,30 @@ public class EmbeddedOAuthAPITest {
     assertEquals(
         callback.getLocation().toString(),
         "http://eclipse.che?quary%3Dparam%26error_code%3Daccess_denied");
+  }
+
+  @Test
+  public void shouldAddSslErrorCode() throws Exception {
+    // given
+    UriInfo uriInfo = mock(UriInfo.class);
+    OAuthAuthenticator authenticator = mock(OAuthAuthenticator.class);
+    when(authenticator.callback(any(URL.class), anyList()))
+        .thenThrow(new ScmCommunicationException(""));
+    when(uriInfo.getRequestUri())
+        .thenReturn(
+            new URI(
+                "http://eclipse.che?state=oauth_provider"
+                    + encode(
+                        "=github&redirect_after_login=https://redirecturl.com?params=", UTF_8)));
+    when(oauth2Providers.getAuthenticator("github")).thenReturn(authenticator);
+
+    // when
+    Response callback = embeddedOAuthAPI.callback(uriInfo, singletonList("ssl_exception"));
+
+    // then
+    assertEquals(
+        callback.getLocation().toString(),
+        "https://redirecturl.com?params=&error_code=ssl_exception");
   }
 
   @Test

--- a/wsmaster/che-core-api-auth/src/test/java/org/eclipse/che/security/oauth/EmbeddedOAuthAPITest.java
+++ b/wsmaster/che-core-api-auth/src/test/java/org/eclipse/che/security/oauth/EmbeddedOAuthAPITest.java
@@ -17,6 +17,7 @@ import static java.util.Collections.emptyList;
 import static java.util.Collections.singletonList;
 import static org.eclipse.che.api.factory.server.scm.PersonalAccessTokenFetcher.OAUTH_2_PREFIX;
 import static org.eclipse.che.dto.server.DtoFactory.newDto;
+import static org.eclipse.che.security.oauth.OAuthAuthenticator.SSL_ERROR_CODE;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyList;
 import static org.mockito.ArgumentMatchers.anyString;
@@ -123,7 +124,7 @@ public class EmbeddedOAuthAPITest {
     UriInfo uriInfo = mock(UriInfo.class);
     OAuthAuthenticator authenticator = mock(OAuthAuthenticator.class);
     when(authenticator.callback(any(URL.class), anyList()))
-        .thenThrow(new ScmCommunicationException(""));
+        .thenThrow(new ScmCommunicationException("", SSL_ERROR_CODE));
     when(uriInfo.getRequestUri())
         .thenReturn(
             new URI(


### PR DESCRIPTION
<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests
-->

### What does this PR do?
Intercept the SSLHandshakeException and pass the `ssl_exception` error code when redirecting to dashboard on oAuth callback call.

### Screenshot/screencast of this PR
<!-- Please include a screenshot or a screencast explaining what is doing this PR -->


### What issues does this PR fix or reference?
<!-- Please include any related issue from eclipse che repository (or from another issue tracker).
     Include link to other pull requests like documentation PR from [the docs repo](https://github.com/eclipse/che-docs)
-->
https://issues.redhat.com/browse/CRW-6940

### How to test this PR?
<!-- Please explain for example :
  - The test platform (openshift, kubernetes, minikube, CodeReady Container, docker-desktop, etc)
  - Installation method: chectl / che-operator
  - steps to reproduce
 -->
1. Deploy Che from the pull request image: `quay.io/eclipse/che-server:pr-710`
2. Apply the related dashboard image: `quay.io/eclipse/che-dashboard:pr-1171`
3. Configure oAuth for a self hosted git provider that uses self signed certificate e.g. https://gh.crw-qe.com/
4. Start a workspace from the provider's repository with a devfile.

See: A notification appears in the dashboard side:
![screenshot-eclipse-che apps rosa tnx7p-xgwvy-6er z6p6 p3 openshiftapps com-2024 08 20-15_02_22](https://github.com/user-attachments/assets/e991205c-1a68-4265-8531-fa674e86208d)


### PR Checklist

[As the author of this Pull Request I made sure that:](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#pull-request-template-and-its-checklist)

- [ ] [The Eclipse Contributor Agreement is valid](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-eclipse-contributor-agreement-is-valid)
- [ ] [Code produced is complete](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-produced-is-complete)
- [ ] [Code builds without errors](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-builds-without-errors)
- [ ] [Tests are covering the bugfix](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#tests-are-covering-the-bugfix)
- [ ] [The repository devfile is up to date and works](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-repository-devfile-is-up-to-date-and-works)
- [ ] [Sections `What issues does this PR fix or reference` and `How to test this PR` completed](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#sections-what-issues-does-this-pr-fix-or-reference-and-how-to-test-this-pr-completed)
- [ ] [Relevant user documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [Relevant contributing documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [CI/CD changes implemented, documented and communicated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#cicd-changes-implemented-documented-and-communicated)

### Reviewers

Reviewers, please comment how you tested the PR when approving it.
