### PR TITLE
Respect the ScmComunicationException on token validation step

### DIFF
--- a/infrastructures/infrastructure-factory/src/main/java/org/eclipse/che/api/factory/server/scm/kubernetes/KubernetesPersonalAccessTokenManager.java
+++ b/infrastructures/infrastructure-factory/src/main/java/org/eclipse/che/api/factory/server/scm/kubernetes/KubernetesPersonalAccessTokenManager.java
@@ -152,7 +152,7 @@ public class KubernetesPersonalAccessTokenManager implements PersonalAccessToken
 
   @Override
   public Optional<PersonalAccessToken> get(Subject cheUser, String scmServerUrl)
-      throws ScmConfigurationPersistenceException {
+      throws ScmConfigurationPersistenceException, ScmCommunicationException {
     return doGetPersonalAccessTokens(cheUser, null, scmServerUrl).stream().findFirst();
   }
 
@@ -174,13 +174,13 @@ public class KubernetesPersonalAccessTokenManager implements PersonalAccessToken
   @Override
   public Optional<PersonalAccessToken> get(
       Subject cheUser, String oAuthProviderName, @Nullable String scmServerUrl)
-      throws ScmConfigurationPersistenceException {
+      throws ScmConfigurationPersistenceException, ScmCommunicationException {
     return doGetPersonalAccessTokens(cheUser, oAuthProviderName, scmServerUrl).stream().findFirst();
   }
 
   private List<PersonalAccessToken> doGetPersonalAccessTokens(
       Subject cheUser, @Nullable String oAuthProviderName, @Nullable String scmServerUrl)
-      throws ScmConfigurationPersistenceException {
+      throws ScmConfigurationPersistenceException, ScmCommunicationException {
     List<PersonalAccessToken> result = new ArrayList<>();
     try {
       LOG.debug(
@@ -358,7 +358,8 @@ public class KubernetesPersonalAccessTokenManager implements PersonalAccessToken
   }
 
   private void removePreviousTokensIfPresent(Subject subject, String scmServerUrl)
-      throws ScmConfigurationPersistenceException, UnsatisfiedScmPreconditionException {
+      throws ScmConfigurationPersistenceException, UnsatisfiedScmPreconditionException,
+          ScmCommunicationException {
     List<PersonalAccessToken> personalAccessTokens =
         doGetPersonalAccessTokens(subject, null, scmServerUrl);
     for (int i = 1; i < personalAccessTokens.size(); i++) {

--- a/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/namespace/configurator/CredentialsSecretConfigurator.java
+++ b/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/namespace/configurator/CredentialsSecretConfigurator.java
@@ -25,6 +25,8 @@ import org.eclipse.che.api.factory.server.scm.exception.UnsatisfiedScmPreconditi
 import org.eclipse.che.api.workspace.server.spi.InfrastructureException;
 import org.eclipse.che.api.workspace.server.spi.NamespaceResolutionContext;
 import org.eclipse.che.workspace.infrastructure.kubernetes.CheServerKubernetesClientFactory;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * This {@link NamespaceConfigurator} ensures that Secret {@link
@@ -44,6 +46,8 @@ public class CredentialsSecretConfigurator implements NamespaceConfigurator {
   private static final String ANNOTATION_SCM_URL = "che.eclipse.org/scm-url";
   private static final String MERGED_GIT_CREDENTIALS_SECRET_NAME =
       "devworkspace-merged-git-credentials";
+
+  private static final Logger LOG = LoggerFactory.getLogger(CredentialsSecretConfigurator.class);
 
   @Inject
   public CredentialsSecretConfigurator(
@@ -79,7 +83,7 @@ public class CredentialsSecretConfigurator implements NamespaceConfigurator {
                   | ScmConfigurationPersistenceException
                   | UnsatisfiedScmPreconditionException
                   | ScmUnauthorizedException e) {
-                throw new RuntimeException(e);
+                LOG.error(e.getMessage(), e);
               }
             });
   }

--- a/wsmaster/che-core-api-auth/src/main/java/org/eclipse/che/security/oauth/EmbeddedOAuthAPI.java
+++ b/wsmaster/che-core-api-auth/src/main/java/org/eclipse/che/security/oauth/EmbeddedOAuthAPI.java
@@ -43,6 +43,7 @@ import org.eclipse.che.api.core.rest.shared.dto.LinkParameter;
 import org.eclipse.che.api.core.util.LinksHelper;
 import org.eclipse.che.api.factory.server.scm.PersonalAccessToken;
 import org.eclipse.che.api.factory.server.scm.PersonalAccessTokenManager;
+import org.eclipse.che.api.factory.server.scm.exception.ScmCommunicationException;
 import org.eclipse.che.api.factory.server.scm.exception.ScmConfigurationPersistenceException;
 import org.eclipse.che.api.factory.server.scm.exception.UnsatisfiedScmPreconditionException;
 import org.eclipse.che.commons.annotation.Nullable;
@@ -237,7 +238,7 @@ public class EmbeddedOAuthAPI implements OAuthAPI {
           if (tokenOptional.isPresent()) {
             return newDto(OAuthToken.class).withToken(tokenOptional.get().getToken());
           }
-        } catch (ScmConfigurationPersistenceException e) {
+        } catch (ScmConfigurationPersistenceException | ScmCommunicationException e) {
           throw new RuntimeException(e);
         }
       }

--- a/wsmaster/che-core-api-factory-azure-devops/src/main/java/org/eclipse/che/api/factory/server/azure/devops/AzureDevOpsApiClient.java
+++ b/wsmaster/che-core-api-factory-azure-devops/src/main/java/org/eclipse/che/api/factory/server/azure/devops/AzureDevOpsApiClient.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012-2023 Red Hat, Inc.
+ * Copyright (c) 2012-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/wsmaster/che-core-api-factory-azure-devops/src/main/java/org/eclipse/che/api/factory/server/azure/devops/AzureDevOpsApiClient.java
+++ b/wsmaster/che-core-api-factory-azure-devops/src/main/java/org/eclipse/che/api/factory/server/azure/devops/AzureDevOpsApiClient.java
@@ -147,7 +147,9 @@ public class AzureDevOpsApiClient {
             throw new ScmItemNotFoundException(body);
           default:
             throw new ScmCommunicationException(
-                "Unexpected status code " + response.statusCode() + " " + response.toString());
+                "Unexpected status code " + response.statusCode() + " " + response,
+                response.statusCode(),
+                "azure-devops");
         }
       }
     } catch (IOException | InterruptedException | UncheckedIOException e) {

--- a/wsmaster/che-core-api-factory-azure-devops/src/main/java/org/eclipse/che/api/factory/server/azure/devops/AzureDevOpsPersonalAccessTokenFetcher.java
+++ b/wsmaster/che-core-api-factory-azure-devops/src/main/java/org/eclipse/che/api/factory/server/azure/devops/AzureDevOpsPersonalAccessTokenFetcher.java
@@ -169,7 +169,8 @@ public class AzureDevOpsPersonalAccessTokenFetcher implements PersonalAccessToke
   }
 
   @Override
-  public Optional<Pair<Boolean, String>> isValid(PersonalAccessTokenParams params) {
+  public Optional<Pair<Boolean, String>> isValid(PersonalAccessTokenParams params)
+      throws ScmCommunicationException {
     if (!isValidScmServerUrl(params.getScmProviderUrl())) {
       LOG.debug("not a valid url {} for current fetcher ", params.getScmProviderUrl());
       return Optional.empty();
@@ -183,7 +184,7 @@ public class AzureDevOpsPersonalAccessTokenFetcher implements PersonalAccessToke
         user = azureDevOpsApiClient.getUserWithPAT(params.getToken(), params.getOrganization());
       }
       return Optional.of(Pair.of(Boolean.TRUE, user.getEmailAddress()));
-    } catch (ScmItemNotFoundException | ScmCommunicationException | ScmBadRequestException e) {
+    } catch (ScmItemNotFoundException | ScmBadRequestException e) {
       return Optional.empty();
     }
   }

--- a/wsmaster/che-core-api-factory-bitbucket-server/src/main/java/org/eclipse/che/api/factory/server/bitbucket/BitbucketServerPersonalAccessTokenFetcher.java
+++ b/wsmaster/che-core-api-factory-bitbucket-server/src/main/java/org/eclipse/che/api/factory/server/bitbucket/BitbucketServerPersonalAccessTokenFetcher.java
@@ -158,7 +158,8 @@ public class BitbucketServerPersonalAccessTokenFetcher implements PersonalAccess
   }
 
   @Override
-  public Optional<Pair<Boolean, String>> isValid(PersonalAccessTokenParams params) {
+  public Optional<Pair<Boolean, String>> isValid(PersonalAccessTokenParams params)
+      throws ScmCommunicationException {
     if (!bitbucketServerApiClient.isConnected(params.getScmProviderUrl())) {
       // If BitBucket oAuth is not configured check the manually added user namespace token.
       HttpBitbucketServerApiClient apiClient =
@@ -180,7 +181,7 @@ public class BitbucketServerPersonalAccessTokenFetcher implements PersonalAccess
     try {
       BitbucketUser user = bitbucketServerApiClient.getUser(params.getToken());
       return Optional.of(Pair.of(Boolean.TRUE, user.getName()));
-    } catch (ScmItemNotFoundException | ScmUnauthorizedException | ScmCommunicationException e) {
+    } catch (ScmItemNotFoundException | ScmUnauthorizedException e) {
       return Optional.empty();
     }
   }

--- a/wsmaster/che-core-api-factory-bitbucket-server/src/main/java/org/eclipse/che/api/factory/server/bitbucket/BitbucketServerURLParser.java
+++ b/wsmaster/che-core-api-factory-bitbucket-server/src/main/java/org/eclipse/che/api/factory/server/bitbucket/BitbucketServerURLParser.java
@@ -96,7 +96,7 @@ public class BitbucketServerURLParser {
         Optional<PersonalAccessToken> token =
             personalAccessTokenManager.get(EnvironmentContext.getCurrent().getSubject(), serverUrl);
         return token.isPresent() && token.get().getScmTokenName().equals(OAUTH_PROVIDER_NAME);
-      } catch (ScmConfigurationPersistenceException exception) {
+      } catch (ScmConfigurationPersistenceException | ScmCommunicationException exception) {
         return false;
       }
     }

--- a/wsmaster/che-core-api-factory-bitbucket-server/src/main/java/org/eclipse/che/api/factory/server/bitbucket/HttpBitbucketServerApiClient.java
+++ b/wsmaster/che-core-api-factory-bitbucket-server/src/main/java/org/eclipse/che/api/factory/server/bitbucket/HttpBitbucketServerApiClient.java
@@ -411,7 +411,9 @@ public class HttpBitbucketServerApiClient implements BitbucketServerApiClient {
             throw new ScmItemNotFoundException(body);
           default:
             throw new ScmCommunicationException(
-                "Unexpected status code " + response.statusCode() + " " + response.toString());
+                "Unexpected status code " + response.statusCode() + " " + response,
+                response.statusCode(),
+                "bitbucket");
         }
       }
     } catch (IOException | InterruptedException | UncheckedIOException e) {

--- a/wsmaster/che-core-api-factory-bitbucket/src/main/java/org/eclipse/che/api/factory/server/bitbucket/BitbucketApiClient.java
+++ b/wsmaster/che-core-api-factory-bitbucket/src/main/java/org/eclipse/che/api/factory/server/bitbucket/BitbucketApiClient.java
@@ -239,11 +239,13 @@ public class BitbucketApiClient {
             throw new ScmUnauthorizedException(body, "bitbucket", "v2", "");
           default:
             throw new ScmCommunicationException(
-                "Unexpected status code " + response.statusCode() + " " + response.toString());
+                "Unexpected status code " + response.statusCode() + " " + response,
+                response.statusCode(),
+                "bitbucket");
         }
       }
     } catch (IOException | InterruptedException | UncheckedIOException e) {
-      throw new ScmCommunicationException(e.getMessage(), e);
+      throw new ScmCommunicationException(e.getMessage(), e, "bitbucket");
     }
   }
 

--- a/wsmaster/che-core-api-factory-bitbucket/src/main/java/org/eclipse/che/api/factory/server/bitbucket/BitbucketApiClient.java
+++ b/wsmaster/che-core-api-factory-bitbucket/src/main/java/org/eclipse/che/api/factory/server/bitbucket/BitbucketApiClient.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012-2023 Red Hat, Inc.
+ * Copyright (c) 2012-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/
@@ -15,6 +15,7 @@ import static java.net.HttpURLConnection.HTTP_BAD_REQUEST;
 import static java.net.HttpURLConnection.HTTP_NOT_FOUND;
 import static java.net.HttpURLConnection.HTTP_NO_CONTENT;
 import static java.net.HttpURLConnection.HTTP_OK;
+import static java.net.HttpURLConnection.HTTP_UNAUTHORIZED;
 import static java.time.Duration.ofSeconds;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -37,6 +38,7 @@ import java.util.function.Function;
 import org.eclipse.che.api.factory.server.scm.exception.ScmBadRequestException;
 import org.eclipse.che.api.factory.server.scm.exception.ScmCommunicationException;
 import org.eclipse.che.api.factory.server.scm.exception.ScmItemNotFoundException;
+import org.eclipse.che.api.factory.server.scm.exception.ScmUnauthorizedException;
 import org.eclipse.che.commons.lang.Pair;
 import org.eclipse.che.commons.lang.concurrent.LoggingUncaughtExceptionHandler;
 import org.slf4j.Logger;
@@ -100,7 +102,8 @@ public class BitbucketApiClient {
    * @throws ScmBadRequestException
    */
   public BitbucketUser getUser(String authenticationToken)
-      throws ScmItemNotFoundException, ScmCommunicationException, ScmBadRequestException {
+      throws ScmItemNotFoundException, ScmCommunicationException, ScmBadRequestException,
+          ScmUnauthorizedException {
     final URI uri = apiServerUrl.resolve("user");
     HttpRequest request = buildBitbucketApiRequest(uri, authenticationToken);
     LOG.trace("executeRequest={}", request);
@@ -120,7 +123,8 @@ public class BitbucketApiClient {
 
   public String getFileContent(
       String workspace, String repository, String source, String path, String authenticationToken)
-      throws ScmItemNotFoundException, ScmCommunicationException, ScmBadRequestException {
+      throws ScmItemNotFoundException, ScmCommunicationException, ScmBadRequestException,
+          ScmUnauthorizedException {
     final URI uri =
         apiServerUrl.resolve(
             String.format("repositories/%s/%s/src/%s/%s", workspace, repository, source, path));
@@ -148,7 +152,8 @@ public class BitbucketApiClient {
    * @throws ScmBadRequestException
    */
   public BitbucketUserEmail getEmail(String authenticationToken)
-      throws ScmItemNotFoundException, ScmCommunicationException, ScmBadRequestException {
+      throws ScmItemNotFoundException, ScmCommunicationException, ScmBadRequestException,
+          ScmUnauthorizedException {
     final URI uri = apiServerUrl.resolve("user/emails");
     HttpRequest request = buildBitbucketApiRequest(uri, authenticationToken);
     LOG.trace("executeRequest={}", request);
@@ -174,7 +179,8 @@ public class BitbucketApiClient {
    *     scopes.
    */
   public Pair<String, String[]> getTokenScopes(String authenticationToken)
-      throws ScmItemNotFoundException, ScmCommunicationException, ScmBadRequestException {
+      throws ScmItemNotFoundException, ScmCommunicationException, ScmBadRequestException,
+          ScmUnauthorizedException {
     final URI uri = apiServerUrl.resolve("user");
     HttpRequest request = buildBitbucketApiRequest(uri, authenticationToken);
     LOG.trace("executeRequest={}", request);
@@ -212,7 +218,8 @@ public class BitbucketApiClient {
       HttpClient httpClient,
       HttpRequest request,
       Function<HttpResponse<InputStream>, T> responseConverter)
-      throws ScmBadRequestException, ScmItemNotFoundException, ScmCommunicationException {
+      throws ScmBadRequestException, ScmItemNotFoundException, ScmCommunicationException,
+          ScmUnauthorizedException {
     try {
       HttpResponse<InputStream> response =
           httpClient.send(request, HttpResponse.BodyHandlers.ofInputStream());
@@ -228,6 +235,8 @@ public class BitbucketApiClient {
             throw new ScmBadRequestException(body);
           case HTTP_NOT_FOUND:
             throw new ScmItemNotFoundException(body);
+          case HTTP_UNAUTHORIZED:
+            throw new ScmUnauthorizedException(body, "github", "v1", "");
           default:
             throw new ScmCommunicationException(
                 "Unexpected status code " + response.statusCode() + " " + response.toString());

--- a/wsmaster/che-core-api-factory-bitbucket/src/main/java/org/eclipse/che/api/factory/server/bitbucket/BitbucketApiClient.java
+++ b/wsmaster/che-core-api-factory-bitbucket/src/main/java/org/eclipse/che/api/factory/server/bitbucket/BitbucketApiClient.java
@@ -236,7 +236,7 @@ public class BitbucketApiClient {
           case HTTP_NOT_FOUND:
             throw new ScmItemNotFoundException(body);
           case HTTP_UNAUTHORIZED:
-            throw new ScmUnauthorizedException(body, "github", "v1", "");
+            throw new ScmUnauthorizedException(body, "bitbucket", "v2", "");
           default:
             throw new ScmCommunicationException(
                 "Unexpected status code " + response.statusCode() + " " + response.toString());

--- a/wsmaster/che-core-api-factory-bitbucket/src/main/java/org/eclipse/che/api/factory/server/bitbucket/BitbucketPersonalAccessTokenFetcher.java
+++ b/wsmaster/che-core-api-factory-bitbucket/src/main/java/org/eclipse/che/api/factory/server/bitbucket/BitbucketPersonalAccessTokenFetcher.java
@@ -166,13 +166,17 @@ public class BitbucketPersonalAccessTokenFetcher implements PersonalAccessTokenF
     try {
       String[] scopes = bitbucketApiClient.getTokenScopes(personalAccessToken.getToken()).second;
       return Optional.of(isValidScope(Sets.newHashSet(scopes)));
-    } catch (ScmItemNotFoundException | ScmCommunicationException | ScmBadRequestException e) {
+    } catch (ScmItemNotFoundException
+        | ScmCommunicationException
+        | ScmBadRequestException
+        | ScmUnauthorizedException e) {
       return Optional.of(Boolean.FALSE);
     }
   }
 
   @Override
-  public Optional<Pair<Boolean, String>> isValid(PersonalAccessTokenParams params) {
+  public Optional<Pair<Boolean, String>> isValid(PersonalAccessTokenParams params)
+      throws ScmCommunicationException {
     if (!bitbucketApiClient.isConnected(params.getScmProviderUrl())) {
       LOG.debug("not a valid url {} for current fetcher ", params.getScmProviderUrl());
       return Optional.empty();
@@ -184,7 +188,7 @@ public class BitbucketPersonalAccessTokenFetcher implements PersonalAccessTokenF
           Pair.of(
               isValidScope(Sets.newHashSet(pair.second)) ? Boolean.TRUE : Boolean.FALSE,
               pair.first));
-    } catch (ScmItemNotFoundException | ScmCommunicationException | ScmBadRequestException e) {
+    } catch (ScmItemNotFoundException | ScmBadRequestException | ScmUnauthorizedException e) {
       return Optional.empty();
     }
   }

--- a/wsmaster/che-core-api-factory-bitbucket/src/test/java/org/eclipse/che/api/factory/server/bitbucket/BitbucketPersonalAccessTokenFetcherTest.java
+++ b/wsmaster/che-core-api-factory-bitbucket/src/test/java/org/eclipse/che/api/factory/server/bitbucket/BitbucketPersonalAccessTokenFetcherTest.java
@@ -17,7 +17,7 @@ import static com.github.tomakehurst.wiremock.client.WireMock.get;
 import static com.github.tomakehurst.wiremock.client.WireMock.stubFor;
 import static com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo;
 import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.wireMockConfig;
-import static java.net.HttpURLConnection.HTTP_FORBIDDEN;
+import static java.net.HttpURLConnection.HTTP_UNAUTHORIZED;
 import static org.eclipse.che.api.factory.server.scm.PersonalAccessTokenFetcher.OAUTH_2_PREFIX;
 import static org.eclipse.che.dto.server.DtoFactory.newDto;
 import static org.mockito.ArgumentMatchers.anyString;
@@ -211,7 +211,7 @@ public class BitbucketPersonalAccessTokenFetcherTest {
 
   @Test
   public void shouldNotValidateExpiredOauthToken() throws Exception {
-    stubFor(get(urlEqualTo("/user")).willReturn(aResponse().withStatus(HTTP_FORBIDDEN)));
+    stubFor(get(urlEqualTo("/user")).willReturn(aResponse().withStatus(HTTP_UNAUTHORIZED)));
 
     PersonalAccessTokenParams params =
         new PersonalAccessTokenParams(
@@ -235,7 +235,7 @@ public class BitbucketPersonalAccessTokenFetcherTest {
     stubFor(
         get(urlEqualTo("/user"))
             .withHeader(HttpHeaders.AUTHORIZATION, equalTo("token " + bitbucketOauthToken))
-            .willReturn(aResponse().withStatus(HTTP_FORBIDDEN)));
+            .willReturn(aResponse().withStatus(HTTP_UNAUTHORIZED)));
 
     bitbucketPersonalAccessTokenFetcher.fetchPersonalAccessToken(
         subject, BitbucketApiClient.BITBUCKET_SERVER);

--- a/wsmaster/che-core-api-factory-github-common/src/main/java/org/eclipse/che/api/factory/server/github/AbstractGithubPersonalAccessTokenFetcher.java
+++ b/wsmaster/che-core-api-factory-github-common/src/main/java/org/eclipse/che/api/factory/server/github/AbstractGithubPersonalAccessTokenFetcher.java
@@ -215,13 +215,17 @@ public abstract class AbstractGithubPersonalAccessTokenFetcher
           return Optional.of(Boolean.FALSE);
         }
       }
-    } catch (ScmItemNotFoundException | ScmCommunicationException | ScmBadRequestException e) {
+    } catch (ScmItemNotFoundException
+        | ScmCommunicationException
+        | ScmBadRequestException
+        | ScmUnauthorizedException e) {
       return Optional.of(Boolean.FALSE);
     }
   }
 
   @Override
-  public Optional<Pair<Boolean, String>> isValid(PersonalAccessTokenParams params) {
+  public Optional<Pair<Boolean, String>> isValid(PersonalAccessTokenParams params)
+      throws ScmCommunicationException {
     GithubApiClient apiClient;
     if (githubApiClient.isConnected(params.getScmProviderUrl())) {
       // The url from the token has the same url as the api client, no need to create a new one.
@@ -247,7 +251,7 @@ public abstract class AbstractGithubPersonalAccessTokenFetcher
         GithubUser user = apiClient.getUser(params.getToken());
         return Optional.of(Pair.of(Boolean.TRUE, user.getLogin()));
       }
-    } catch (ScmItemNotFoundException | ScmCommunicationException | ScmBadRequestException e) {
+    } catch (ScmItemNotFoundException | ScmBadRequestException | ScmUnauthorizedException e) {
       return Optional.empty();
     }
   }

--- a/wsmaster/che-core-api-factory-github-common/src/main/java/org/eclipse/che/api/factory/server/github/AbstractGithubUserDataFetcher.java
+++ b/wsmaster/che-core-api-factory-github-common/src/main/java/org/eclipse/che/api/factory/server/github/AbstractGithubUserDataFetcher.java
@@ -23,6 +23,7 @@ import org.eclipse.che.api.factory.server.scm.PersonalAccessTokenManager;
 import org.eclipse.che.api.factory.server.scm.exception.ScmBadRequestException;
 import org.eclipse.che.api.factory.server.scm.exception.ScmCommunicationException;
 import org.eclipse.che.api.factory.server.scm.exception.ScmItemNotFoundException;
+import org.eclipse.che.api.factory.server.scm.exception.ScmUnauthorizedException;
 
 /** GitHub user data retriever. */
 public abstract class AbstractGithubUserDataFetcher extends AbstractGitUserDataFetcher {
@@ -53,7 +54,8 @@ public abstract class AbstractGithubUserDataFetcher extends AbstractGitUserDataF
 
   @Override
   protected GitUserData fetchGitUserDataWithOAuthToken(String token)
-      throws ScmItemNotFoundException, ScmCommunicationException, ScmBadRequestException {
+      throws ScmItemNotFoundException, ScmCommunicationException, ScmBadRequestException,
+          ScmUnauthorizedException {
     GithubUser user = githubApiClient.getUser(token);
     if (isNullOrEmpty(user.getName()) || isNullOrEmpty(user.getEmail())) {
       throw new ScmItemNotFoundException(NO_USERNAME_AND_EMAIL_ERROR_MESSAGE);
@@ -65,7 +67,8 @@ public abstract class AbstractGithubUserDataFetcher extends AbstractGitUserDataF
   @Override
   protected GitUserData fetchGitUserDataWithPersonalAccessToken(
       PersonalAccessToken personalAccessToken)
-      throws ScmItemNotFoundException, ScmCommunicationException, ScmBadRequestException {
+      throws ScmItemNotFoundException, ScmCommunicationException, ScmBadRequestException,
+          ScmUnauthorizedException {
     GithubApiClient apiClient =
         githubApiClient.isConnected(personalAccessToken.getScmProviderUrl())
             ? githubApiClient

--- a/wsmaster/che-core-api-factory-github-common/src/main/java/org/eclipse/che/api/factory/server/github/GithubApiClient.java
+++ b/wsmaster/che-core-api-factory-github-common/src/main/java/org/eclipse/che/api/factory/server/github/GithubApiClient.java
@@ -277,6 +277,7 @@ public class GithubApiClient {
       Function<HttpResponse<InputStream>, T> responseConverter)
       throws ScmBadRequestException, ScmItemNotFoundException, ScmCommunicationException,
           ScmUnauthorizedException {
+    String provider = GITHUB_SAAS_ENDPOINT.equals(getServerUrl()) ? "github" : "github-server";
     try {
       HttpResponse<InputStream> response =
           httpClient.send(request, HttpResponse.BodyHandlers.ofInputStream());
@@ -300,11 +301,11 @@ public class GithubApiClient {
             throw new ScmUnauthorizedException(body, "github", "v2", "");
           default:
             throw new ScmCommunicationException(
-                "Unexpected status code " + statusCode + " " + body, statusCode, "github");
+                "Unexpected status code " + statusCode + " " + body, statusCode, provider);
         }
       }
     } catch (IOException | InterruptedException | UncheckedIOException e) {
-      throw new ScmCommunicationException(e.getMessage(), e, "github");
+      throw new ScmCommunicationException(e.getMessage(), e, provider);
     }
   }
 

--- a/wsmaster/che-core-api-factory-github-common/src/main/java/org/eclipse/che/api/factory/server/github/GithubApiClient.java
+++ b/wsmaster/che-core-api-factory-github-common/src/main/java/org/eclipse/che/api/factory/server/github/GithubApiClient.java
@@ -300,11 +300,11 @@ public class GithubApiClient {
             throw new ScmUnauthorizedException(body, "github", "v2", "");
           default:
             throw new ScmCommunicationException(
-                "Unexpected status code " + statusCode + " " + body, statusCode);
+                "Unexpected status code " + statusCode + " " + body, statusCode, "github");
         }
       }
     } catch (IOException | InterruptedException | UncheckedIOException e) {
-      throw new ScmCommunicationException(e.getMessage(), e);
+      throw new ScmCommunicationException(e.getMessage(), e, "github");
     }
   }
 

--- a/wsmaster/che-core-api-factory-github-common/src/main/java/org/eclipse/che/api/factory/server/github/GithubApiClient.java
+++ b/wsmaster/che-core-api-factory-github-common/src/main/java/org/eclipse/che/api/factory/server/github/GithubApiClient.java
@@ -297,7 +297,7 @@ public class GithubApiClient {
           case HTTP_NOT_FOUND:
             throw new ScmItemNotFoundException(body);
           case HTTP_UNAUTHORIZED:
-            throw new ScmUnauthorizedException(body, "github", "v1", "");
+            throw new ScmUnauthorizedException(body, "github", "v2", "");
           default:
             throw new ScmCommunicationException(
                 "Unexpected status code " + statusCode + " " + body, statusCode);

--- a/wsmaster/che-core-api-factory-github-common/src/main/java/org/eclipse/che/api/factory/server/github/GithubApiClient.java
+++ b/wsmaster/che-core-api-factory-github-common/src/main/java/org/eclipse/che/api/factory/server/github/GithubApiClient.java
@@ -16,6 +16,7 @@ import static java.net.HttpURLConnection.HTTP_BAD_REQUEST;
 import static java.net.HttpURLConnection.HTTP_NOT_FOUND;
 import static java.net.HttpURLConnection.HTTP_NO_CONTENT;
 import static java.net.HttpURLConnection.HTTP_OK;
+import static java.net.HttpURLConnection.HTTP_UNAUTHORIZED;
 import static java.time.Duration.ofSeconds;
 import static org.eclipse.che.commons.lang.StringUtils.trimEnd;
 
@@ -40,6 +41,7 @@ import java.util.function.Function;
 import org.eclipse.che.api.factory.server.scm.exception.ScmBadRequestException;
 import org.eclipse.che.api.factory.server.scm.exception.ScmCommunicationException;
 import org.eclipse.che.api.factory.server.scm.exception.ScmItemNotFoundException;
+import org.eclipse.che.api.factory.server.scm.exception.ScmUnauthorizedException;
 import org.eclipse.che.commons.annotation.Nullable;
 import org.eclipse.che.commons.lang.Pair;
 import org.eclipse.che.commons.lang.concurrent.LoggingUncaughtExceptionHandler;
@@ -103,7 +105,8 @@ public class GithubApiClient {
    * @throws ScmBadRequestException
    */
   public GithubUser getUser(String authenticationToken)
-      throws ScmItemNotFoundException, ScmCommunicationException, ScmBadRequestException {
+      throws ScmItemNotFoundException, ScmCommunicationException, ScmBadRequestException,
+          ScmUnauthorizedException {
     final URI uri = apiServerUrl.resolve("./user");
     HttpRequest request = buildGithubApiRequest(uri, authenticationToken);
     LOG.trace("executeRequest={}", request);
@@ -133,7 +136,8 @@ public class GithubApiClient {
    */
   public GithubPullRequest getPullRequest(
       String id, String username, String repoName, String authenticationToken)
-      throws ScmItemNotFoundException, ScmCommunicationException, ScmBadRequestException {
+      throws ScmItemNotFoundException, ScmCommunicationException, ScmBadRequestException,
+          ScmUnauthorizedException {
     final URI uri =
         apiServerUrl.resolve(String.format("./repos/%s/%s/pulls/%s", username, repoName, id));
     HttpRequest request = buildGithubApiRequest(uri, authenticationToken);
@@ -167,7 +171,7 @@ public class GithubApiClient {
   public GithubCommit getLatestCommit(
       String user, String repository, String branch, @Nullable String authenticationToken)
       throws ScmBadRequestException, ScmItemNotFoundException, ScmCommunicationException,
-          URISyntaxException {
+          URISyntaxException, ScmUnauthorizedException {
 
     final URI uri = apiServerUrl.resolve(String.format("./repos/%s/%s/commits", user, repository));
 
@@ -208,7 +212,8 @@ public class GithubApiClient {
    * @throws ScmBadRequestException
    */
   public Pair<String, String[]> getTokenScopes(String authenticationToken)
-      throws ScmItemNotFoundException, ScmCommunicationException, ScmBadRequestException {
+      throws ScmItemNotFoundException, ScmCommunicationException, ScmBadRequestException,
+          ScmUnauthorizedException {
     final URI uri = apiServerUrl.resolve("./user");
     HttpRequest request = buildGithubApiRequest(uri, authenticationToken);
     LOG.trace("executeRequest={}", request);
@@ -270,7 +275,8 @@ public class GithubApiClient {
       HttpClient httpClient,
       HttpRequest request,
       Function<HttpResponse<InputStream>, T> responseConverter)
-      throws ScmBadRequestException, ScmItemNotFoundException, ScmCommunicationException {
+      throws ScmBadRequestException, ScmItemNotFoundException, ScmCommunicationException,
+          ScmUnauthorizedException {
     try {
       HttpResponse<InputStream> response =
           httpClient.send(request, HttpResponse.BodyHandlers.ofInputStream());
@@ -290,6 +296,8 @@ public class GithubApiClient {
             throw new ScmBadRequestException(body);
           case HTTP_NOT_FOUND:
             throw new ScmItemNotFoundException(body);
+          case HTTP_UNAUTHORIZED:
+            throw new ScmUnauthorizedException(body, "github", "v1", "");
           default:
             throw new ScmCommunicationException(
                 "Unexpected status code " + statusCode + " " + body, statusCode);

--- a/wsmaster/che-core-api-factory-github/src/test/java/org/eclipse/che/api/factory/server/github/GithubPersonalAccessTokenFetcherTest.java
+++ b/wsmaster/che-core-api-factory-github/src/test/java/org/eclipse/che/api/factory/server/github/GithubPersonalAccessTokenFetcherTest.java
@@ -17,7 +17,7 @@ import static com.github.tomakehurst.wiremock.client.WireMock.get;
 import static com.github.tomakehurst.wiremock.client.WireMock.stubFor;
 import static com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo;
 import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.wireMockConfig;
-import static java.net.HttpURLConnection.HTTP_FORBIDDEN;
+import static java.net.HttpURLConnection.HTTP_UNAUTHORIZED;
 import static org.eclipse.che.api.factory.server.github.GithubPersonalAccessTokenFetcher.DEFAULT_TOKEN_SCOPES;
 import static org.eclipse.che.api.factory.server.scm.PersonalAccessTokenFetcher.OAUTH_2_PREFIX;
 import static org.eclipse.che.dto.server.DtoFactory.newDto;
@@ -176,7 +176,7 @@ public class GithubPersonalAccessTokenFetcherTest {
     stubFor(
         get(urlEqualTo("/api/v3/user"))
             .withHeader(HttpHeaders.AUTHORIZATION, equalTo("token " + githubOauthToken))
-            .willReturn(aResponse().withStatus(HTTP_FORBIDDEN)));
+            .willReturn(aResponse().withStatus(HTTP_UNAUTHORIZED)));
 
     githubPATFetcher.fetchPersonalAccessToken(subject, wireMockServer.url("/"));
   }
@@ -254,7 +254,7 @@ public class GithubPersonalAccessTokenFetcherTest {
 
   @Test
   public void shouldNotValidateExpiredOauthToken() throws Exception {
-    stubFor(get(urlEqualTo("/api/v3/user")).willReturn(aResponse().withStatus(HTTP_FORBIDDEN)));
+    stubFor(get(urlEqualTo("/api/v3/user")).willReturn(aResponse().withStatus(HTTP_UNAUTHORIZED)));
 
     PersonalAccessTokenParams params =
         new PersonalAccessTokenParams(

--- a/wsmaster/che-core-api-factory-gitlab/src/main/java/org/eclipse/che/api/factory/server/gitlab/GitlabApiClient.java
+++ b/wsmaster/che-core-api-factory-gitlab/src/main/java/org/eclipse/che/api/factory/server/gitlab/GitlabApiClient.java
@@ -148,6 +148,7 @@ public class GitlabApiClient {
       HttpClient httpClient, HttpRequest request, Function<InputStream, T> bodyConverter)
       throws ScmBadRequestException, ScmItemNotFoundException, ScmCommunicationException,
           ScmUnauthorizedException {
+    String provider = "http://gitlab.com".equals(serverUrl.toString()) ? "gitlab" : "gitlab-server";
     try {
       HttpResponse<InputStream> response =
           httpClient.send(request, HttpResponse.BodyHandlers.ofInputStream());
@@ -169,11 +170,11 @@ public class GitlabApiClient {
             throw new ScmCommunicationException(
                 "Unexpected status code " + response.statusCode() + " " + response,
                 response.statusCode(),
-                "gitlab");
+                provider);
         }
       }
     } catch (IOException | InterruptedException | UncheckedIOException e) {
-      throw new ScmCommunicationException(e.getMessage(), e, "gitlab");
+      throw new ScmCommunicationException(e.getMessage(), e, provider);
     }
   }
 

--- a/wsmaster/che-core-api-factory-gitlab/src/main/java/org/eclipse/che/api/factory/server/gitlab/GitlabApiClient.java
+++ b/wsmaster/che-core-api-factory-gitlab/src/main/java/org/eclipse/che/api/factory/server/gitlab/GitlabApiClient.java
@@ -164,7 +164,7 @@ public class GitlabApiClient {
           case HTTP_NOT_FOUND:
             throw new ScmItemNotFoundException(body);
           case HTTP_UNAUTHORIZED:
-            throw new ScmUnauthorizedException(body, "github", "v1", "");
+            throw new ScmUnauthorizedException(body, "gitlab", "v2", "");
           default:
             throw new ScmCommunicationException(
                 "Unexpected status code " + response.statusCode() + " " + response,

--- a/wsmaster/che-core-api-factory-gitlab/src/main/java/org/eclipse/che/api/factory/server/gitlab/GitlabApiClient.java
+++ b/wsmaster/che-core-api-factory-gitlab/src/main/java/org/eclipse/che/api/factory/server/gitlab/GitlabApiClient.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012-2023 Red Hat, Inc.
+ * Copyright (c) 2012-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/
@@ -13,6 +13,7 @@ package org.eclipse.che.api.factory.server.gitlab;
 
 import static java.net.HttpURLConnection.HTTP_BAD_REQUEST;
 import static java.net.HttpURLConnection.HTTP_NOT_FOUND;
+import static java.net.HttpURLConnection.HTTP_UNAUTHORIZED;
 import static java.time.Duration.ofSeconds;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -33,6 +34,7 @@ import java.util.function.Function;
 import org.eclipse.che.api.factory.server.scm.exception.ScmBadRequestException;
 import org.eclipse.che.api.factory.server.scm.exception.ScmCommunicationException;
 import org.eclipse.che.api.factory.server.scm.exception.ScmItemNotFoundException;
+import org.eclipse.che.api.factory.server.scm.exception.ScmUnauthorizedException;
 import org.eclipse.che.commons.lang.concurrent.LoggingUncaughtExceptionHandler;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -65,7 +67,8 @@ public class GitlabApiClient {
   }
 
   public GitlabUser getUser(String authenticationToken)
-      throws ScmItemNotFoundException, ScmCommunicationException, ScmBadRequestException {
+      throws ScmItemNotFoundException, ScmCommunicationException, ScmBadRequestException,
+          ScmUnauthorizedException {
     final URI uri = serverUrl.resolve("/api/v4/user");
     HttpRequest request =
         HttpRequest.newBuilder(uri)
@@ -88,7 +91,7 @@ public class GitlabApiClient {
   }
 
   public GitlabPersonalAccessTokenInfo getPersonalAccessTokenInfo(String authenticationToken)
-      throws ScmItemNotFoundException, ScmCommunicationException {
+      throws ScmItemNotFoundException, ScmCommunicationException, ScmUnauthorizedException {
     final URI uri = serverUrl.resolve("/api/v4/personal_access_tokens/self");
     HttpRequest request =
         HttpRequest.newBuilder(uri)
@@ -115,7 +118,7 @@ public class GitlabApiClient {
   }
 
   public GitlabOauthTokenInfo getOAuthTokenInfo(String authenticationToken)
-      throws ScmItemNotFoundException, ScmCommunicationException {
+      throws ScmItemNotFoundException, ScmCommunicationException, ScmUnauthorizedException {
     final URI uri = serverUrl.resolve("/oauth/token/info");
     HttpRequest request =
         HttpRequest.newBuilder(uri)
@@ -143,7 +146,8 @@ public class GitlabApiClient {
 
   private <T> T executeRequest(
       HttpClient httpClient, HttpRequest request, Function<InputStream, T> bodyConverter)
-      throws ScmBadRequestException, ScmItemNotFoundException, ScmCommunicationException {
+      throws ScmBadRequestException, ScmItemNotFoundException, ScmCommunicationException,
+          ScmUnauthorizedException {
     try {
       HttpResponse<InputStream> response =
           httpClient.send(request, HttpResponse.BodyHandlers.ofInputStream());
@@ -159,6 +163,8 @@ public class GitlabApiClient {
             throw new ScmBadRequestException(body);
           case HTTP_NOT_FOUND:
             throw new ScmItemNotFoundException(body);
+          case HTTP_UNAUTHORIZED:
+            throw new ScmUnauthorizedException(body, "github", "v1", "");
           default:
             throw new ScmCommunicationException(
                 "Unexpected status code " + response.statusCode() + " " + response,

--- a/wsmaster/che-core-api-factory-gitlab/src/main/java/org/eclipse/che/api/factory/server/gitlab/GitlabApiClient.java
+++ b/wsmaster/che-core-api-factory-gitlab/src/main/java/org/eclipse/che/api/factory/server/gitlab/GitlabApiClient.java
@@ -168,11 +168,12 @@ public class GitlabApiClient {
           default:
             throw new ScmCommunicationException(
                 "Unexpected status code " + response.statusCode() + " " + response,
-                response.statusCode());
+                response.statusCode(),
+                "gitlab");
         }
       }
     } catch (IOException | InterruptedException | UncheckedIOException e) {
-      throw new ScmCommunicationException(e.getMessage(), e);
+      throw new ScmCommunicationException(e.getMessage(), e, "gitlab");
     }
   }
 

--- a/wsmaster/che-core-api-factory-gitlab/src/main/java/org/eclipse/che/api/factory/server/gitlab/GitlabOAuthTokenFetcher.java
+++ b/wsmaster/che-core-api-factory-gitlab/src/main/java/org/eclipse/che/api/factory/server/gitlab/GitlabOAuthTokenFetcher.java
@@ -188,7 +188,7 @@ public class GitlabOAuthTokenFetcher implements PersonalAccessTokenFetcher {
         GitlabOauthTokenInfo info =
             gitlabApiClient.getOAuthTokenInfo(personalAccessToken.getToken());
         return Optional.of(Sets.newHashSet(info.getScope()).containsAll(DEFAULT_TOKEN_SCOPES));
-      } catch (ScmItemNotFoundException | ScmCommunicationException e) {
+      } catch (ScmItemNotFoundException | ScmCommunicationException | ScmUnauthorizedException e) {
         return Optional.of(Boolean.FALSE);
       }
     } else {
@@ -201,14 +201,18 @@ public class GitlabOAuthTokenFetcher implements PersonalAccessTokenFetcher {
         } else {
           return Optional.of(Boolean.FALSE);
         }
-      } catch (ScmItemNotFoundException | ScmCommunicationException | ScmBadRequestException e) {
+      } catch (ScmItemNotFoundException
+          | ScmCommunicationException
+          | ScmBadRequestException
+          | ScmUnauthorizedException e) {
         return Optional.of(Boolean.FALSE);
       }
     }
   }
 
   @Override
-  public Optional<Pair<Boolean, String>> isValid(PersonalAccessTokenParams params) {
+  public Optional<Pair<Boolean, String>> isValid(PersonalAccessTokenParams params)
+      throws ScmCommunicationException {
     GitlabApiClient gitlabApiClient = getApiClient(params.getScmProviderUrl());
     if (gitlabApiClient == null || !gitlabApiClient.isConnected(params.getScmProviderUrl())) {
       if (OAUTH_PROVIDER_NAME.equals(params.getScmTokenName())) {
@@ -234,7 +238,7 @@ public class GitlabOAuthTokenFetcher implements PersonalAccessTokenFetcher {
       // latest GitLab version, we just perform check by accessing something from API.
       // TODO: add PAT scope validation
       return Optional.of(Pair.of(Boolean.TRUE, user.getUsername()));
-    } catch (ScmItemNotFoundException | ScmCommunicationException | ScmBadRequestException e) {
+    } catch (ScmItemNotFoundException | ScmBadRequestException | ScmUnauthorizedException e) {
       return Optional.empty();
     }
   }

--- a/wsmaster/che-core-api-factory-gitlab/src/main/java/org/eclipse/che/api/factory/server/gitlab/GitlabUrlParser.java
+++ b/wsmaster/che-core-api-factory-gitlab/src/main/java/org/eclipse/che/api/factory/server/gitlab/GitlabUrlParser.java
@@ -12,7 +12,6 @@
 package org.eclipse.che.api.factory.server.gitlab;
 
 import static java.lang.String.format;
-import static java.net.HttpURLConnection.HTTP_UNAUTHORIZED;
 import static java.util.regex.Pattern.compile;
 import static org.eclipse.che.commons.lang.StringUtils.trimEnd;
 
@@ -31,6 +30,7 @@ import org.eclipse.che.api.factory.server.scm.PersonalAccessTokenManager;
 import org.eclipse.che.api.factory.server.scm.exception.ScmCommunicationException;
 import org.eclipse.che.api.factory.server.scm.exception.ScmConfigurationPersistenceException;
 import org.eclipse.che.api.factory.server.scm.exception.ScmItemNotFoundException;
+import org.eclipse.che.api.factory.server.scm.exception.ScmUnauthorizedException;
 import org.eclipse.che.api.factory.server.urlfactory.DevfileFilenamesProvider;
 import org.eclipse.che.commons.annotation.Nullable;
 import org.eclipse.che.commons.env.EnvironmentContext;
@@ -90,7 +90,7 @@ public class GitlabUrlParser {
           PersonalAccessToken accessToken = token.get();
           return accessToken.getScmTokenName().equals(OAUTH_PROVIDER_NAME);
         }
-      } catch (ScmConfigurationPersistenceException exception) {
+      } catch (ScmConfigurationPersistenceException | ScmCommunicationException exception) {
         return false;
       }
     }
@@ -115,9 +115,9 @@ public class GitlabUrlParser {
         // If the token request catches the unauthorised error, it means that the provided url
         // belongs to Gitlab.
         gitlabApiClient.getOAuthTokenInfo("");
-      } catch (ScmCommunicationException e) {
-        return e.getStatusCode() == HTTP_UNAUTHORIZED;
-      } catch (ScmItemNotFoundException | IllegalArgumentException e) {
+      } catch (ScmUnauthorizedException e) {
+        return true;
+      } catch (ScmItemNotFoundException | IllegalArgumentException | ScmCommunicationException e) {
         return false;
       }
     }

--- a/wsmaster/che-core-api-factory-gitlab/src/main/java/org/eclipse/che/api/factory/server/gitlab/GitlabUserDataFetcher.java
+++ b/wsmaster/che-core-api-factory-gitlab/src/main/java/org/eclipse/che/api/factory/server/gitlab/GitlabUserDataFetcher.java
@@ -26,6 +26,7 @@ import org.eclipse.che.api.factory.server.scm.*;
 import org.eclipse.che.api.factory.server.scm.exception.ScmBadRequestException;
 import org.eclipse.che.api.factory.server.scm.exception.ScmCommunicationException;
 import org.eclipse.che.api.factory.server.scm.exception.ScmItemNotFoundException;
+import org.eclipse.che.api.factory.server.scm.exception.ScmUnauthorizedException;
 import org.eclipse.che.commons.annotation.Nullable;
 import org.eclipse.che.commons.lang.StringUtils;
 import org.eclipse.che.inject.ConfigurationException;
@@ -72,7 +73,8 @@ public class GitlabUserDataFetcher extends AbstractGitUserDataFetcher {
 
   @Override
   protected GitUserData fetchGitUserDataWithOAuthToken(String token)
-      throws ScmItemNotFoundException, ScmCommunicationException, ScmBadRequestException {
+      throws ScmItemNotFoundException, ScmCommunicationException, ScmBadRequestException,
+          ScmUnauthorizedException {
     for (String gitlabServerEndpoint : this.registeredGitlabEndpoints) {
       GitlabUser user = new GitlabApiClient(gitlabServerEndpoint).getUser(token);
       return new GitUserData(user.getName(), user.getEmail());
@@ -83,7 +85,8 @@ public class GitlabUserDataFetcher extends AbstractGitUserDataFetcher {
   @Override
   protected GitUserData fetchGitUserDataWithPersonalAccessToken(
       PersonalAccessToken personalAccessToken)
-      throws ScmItemNotFoundException, ScmCommunicationException, ScmBadRequestException {
+      throws ScmItemNotFoundException, ScmCommunicationException, ScmBadRequestException,
+          ScmUnauthorizedException {
     GitlabUser user =
         new GitlabApiClient(personalAccessToken.getScmProviderUrl())
             .getUser(personalAccessToken.getToken());

--- a/wsmaster/che-core-api-factory/src/main/java/org/eclipse/che/api/factory/server/ApiExceptionMapper.java
+++ b/wsmaster/che-core-api-factory/src/main/java/org/eclipse/che/api/factory/server/ApiExceptionMapper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012-2023 Red Hat, Inc.
+ * Copyright (c) 2012-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/
@@ -11,11 +11,15 @@
  */
 package org.eclipse.che.api.factory.server;
 
+import static com.google.common.base.Strings.isNullOrEmpty;
+import static org.eclipse.che.dto.server.DtoFactory.newDto;
+
 import java.util.Map;
 import org.eclipse.che.api.core.ApiException;
 import org.eclipse.che.api.core.BadRequestException;
 import org.eclipse.che.api.core.ServerException;
 import org.eclipse.che.api.core.UnauthorizedException;
+import org.eclipse.che.api.core.rest.shared.dto.ExtendedError;
 import org.eclipse.che.api.factory.server.scm.exception.ScmCommunicationException;
 import org.eclipse.che.api.factory.server.scm.exception.ScmUnauthorizedException;
 import org.eclipse.che.api.factory.server.scm.exception.UnknownScmProviderException;
@@ -48,6 +52,16 @@ public class ApiExceptionMapper {
                 + scmUnauthorizedException.getMessage());
   }
 
+  public static ApiException toApiException(ScmCommunicationException scmCommunicationException) {
+    ApiException apiException = getApiException(scmCommunicationException);
+    return (apiException != null)
+        ? apiException
+        : new ServerException(
+            "Error occurred during SCM communication."
+                + "Cause: "
+                + scmCommunicationException.getMessage());
+  }
+
   public static ApiException toApiException(
       DevfileException devfileException, DevfileLocation location) {
     ApiException cause = getApiException(devfileException.getCause());
@@ -70,15 +84,25 @@ public class ApiExceptionMapper {
               "oauth_version", scmCause.getOauthVersion(),
               "oauth_provider", scmCause.getOauthProvider(),
               "oauth_authentication_url", scmCause.getAuthenticateUrl()));
-    } else if (throwable instanceof UnknownScmProviderException) {
-      return new ServerException(
-          "Provided location is unknown or misconfigured on the server side. Error message: "
-              + throwable.getMessage());
-    } else if (throwable instanceof ScmCommunicationException) {
-      return new ServerException(
-          "There is an error happened when communicate with SCM server. Error message: "
-              + throwable.getMessage());
+    } else {
+      if (throwable instanceof UnknownScmProviderException) {
+        return new ServerException(
+            appendErrorMessage(
+                "Provided location is unknown or misconfigured on the server side",
+                throwable.getMessage()));
+      } else if (throwable instanceof ScmCommunicationException) {
+        return new ServerException(
+            newDto(ExtendedError.class)
+                .withMessage(
+                    appendErrorMessage(
+                        "Error occurred during SCM communication.", throwable.getMessage()))
+                .withErrorCode(404));
+      }
     }
     return null;
+  }
+
+  private static String appendErrorMessage(String message, String errorMessage) {
+    return message + (isNullOrEmpty(errorMessage) ? "" : " Error message: " + errorMessage);
   }
 }

--- a/wsmaster/che-core-api-factory/src/main/java/org/eclipse/che/api/factory/server/ApiExceptionMapper.java
+++ b/wsmaster/che-core-api-factory/src/main/java/org/eclipse/che/api/factory/server/ApiExceptionMapper.java
@@ -14,6 +14,7 @@ package org.eclipse.che.api.factory.server;
 import static com.google.common.base.Strings.isNullOrEmpty;
 import static org.eclipse.che.dto.server.DtoFactory.newDto;
 
+import java.util.Collections;
 import java.util.Map;
 import org.eclipse.che.api.core.ApiException;
 import org.eclipse.che.api.core.BadRequestException;
@@ -96,7 +97,10 @@ public class ApiExceptionMapper {
                 .withMessage(
                     appendErrorMessage(
                         "Error occurred during SCM communication.", throwable.getMessage()))
-                .withErrorCode(404));
+                .withErrorCode(404)
+                .withAttributes(
+                    Collections.singletonMap(
+                        "provider", ((ScmCommunicationException) throwable).getProvider())));
       }
     }
     return null;

--- a/wsmaster/che-core-api-factory/src/main/java/org/eclipse/che/api/factory/server/FactoryService.java
+++ b/wsmaster/che-core-api-factory/src/main/java/org/eclipse/che/api/factory/server/FactoryService.java
@@ -159,13 +159,14 @@ public class FactoryService extends Service {
           personalAccessTokenManager.getAndStore(scmServerUrl);
         }
       }
-    } catch (ScmCommunicationException
-        | ScmConfigurationPersistenceException
-        | UnknownScmProviderException
-        | UnsatisfiedScmPreconditionException e) {
+    } catch (ScmConfigurationPersistenceException | UnsatisfiedScmPreconditionException e) {
       throw new ApiException(e);
     } catch (ScmUnauthorizedException e) {
       throw toApiException(e);
+    } catch (ScmCommunicationException e) {
+      throw toApiException(e);
+    } catch (UnknownScmProviderException e) {
+      // ignore the exception as it is not a problem if the provider from the given URL is unknown
     }
   }
 

--- a/wsmaster/che-core-api-factory/src/main/java/org/eclipse/che/api/factory/server/scm/AbstractGitUserDataFetcher.java
+++ b/wsmaster/che-core-api-factory/src/main/java/org/eclipse/che/api/factory/server/scm/AbstractGitUserDataFetcher.java
@@ -56,11 +56,13 @@ public abstract class AbstractGitUserDataFetcher implements GitUserDataFetcher {
   }
 
   protected abstract GitUserData fetchGitUserDataWithOAuthToken(String token)
-      throws ScmItemNotFoundException, ScmCommunicationException, ScmBadRequestException;
+      throws ScmItemNotFoundException, ScmCommunicationException, ScmBadRequestException,
+          ScmUnauthorizedException;
 
   protected abstract GitUserData fetchGitUserDataWithPersonalAccessToken(
       PersonalAccessToken personalAccessToken)
-      throws ScmItemNotFoundException, ScmCommunicationException, ScmBadRequestException;
+      throws ScmItemNotFoundException, ScmCommunicationException, ScmBadRequestException,
+          ScmUnauthorizedException;
 
   protected abstract String getLocalAuthenticateUrl();
 }

--- a/wsmaster/che-core-api-factory/src/main/java/org/eclipse/che/api/factory/server/scm/PersonalAccessTokenFetcher.java
+++ b/wsmaster/che-core-api-factory/src/main/java/org/eclipse/che/api/factory/server/scm/PersonalAccessTokenFetcher.java
@@ -75,6 +75,8 @@ public interface PersonalAccessTokenFetcher {
    *     the token has expected scope of permissions, false if the token scopes does not match the
    *     expected ones. Empty optional if {@link PersonalAccessTokenFetcher} is not able to confirm
    *     or deny that token is valid.
+   * @throws ScmCommunicationException - problem occurred during communication with SCM server.
    */
-  Optional<Pair<Boolean, String>> isValid(PersonalAccessTokenParams params);
+  Optional<Pair<Boolean, String>> isValid(PersonalAccessTokenParams params)
+      throws ScmCommunicationException;
 }

--- a/wsmaster/che-core-api-factory/src/main/java/org/eclipse/che/api/factory/server/scm/PersonalAccessTokenManager.java
+++ b/wsmaster/che-core-api-factory/src/main/java/org/eclipse/che/api/factory/server/scm/PersonalAccessTokenManager.java
@@ -48,9 +48,10 @@ public interface PersonalAccessTokenManager {
    * @return personal access token
    * @throws ScmConfigurationPersistenceException - problem occurred during communication with
    *     permanent storage.
+   * @throws ScmCommunicationException - problem occurred during communication with SCM server.
    */
   Optional<PersonalAccessToken> get(Subject cheUser, String scmServerUrl)
-      throws ScmConfigurationPersistenceException;
+      throws ScmConfigurationPersistenceException, ScmCommunicationException;
 
   /**
    * Gets {@link PersonalAccessToken} from permanent storage.
@@ -79,10 +80,11 @@ public interface PersonalAccessTokenManager {
    * @return personal access token
    * @throws ScmConfigurationPersistenceException - problem occurred during communication with
    *     permanent storage.
+   * @throws ScmCommunicationException - problem occurred during communication with SCM server.
    */
   Optional<PersonalAccessToken> get(
       Subject cheUser, String oAuthProviderName, @Nullable String scmServerUrl)
-      throws ScmConfigurationPersistenceException;
+      throws ScmConfigurationPersistenceException, ScmCommunicationException;
 
   /**
    * Gets {@link PersonalAccessToken} from permanent storage. If the token is not found try to fetch

--- a/wsmaster/che-core-api-factory/src/main/java/org/eclipse/che/api/factory/server/scm/ScmPersonalAccessTokenFetcher.java
+++ b/wsmaster/che-core-api-factory/src/main/java/org/eclipse/che/api/factory/server/scm/ScmPersonalAccessTokenFetcher.java
@@ -94,7 +94,7 @@ public class ScmPersonalAccessTokenFetcher {
    * fetchers return an scm username, return it. Otherwise, return null.
    */
   public Optional<String> getScmUsername(PersonalAccessTokenParams params)
-      throws UnknownScmProviderException {
+      throws UnknownScmProviderException, ScmCommunicationException {
     for (PersonalAccessTokenFetcher fetcher : personalAccessTokenFetchers) {
       Optional<Pair<Boolean, String>> isValid = fetcher.isValid(params);
       if (isValid.isPresent() && isValid.get().first) {

--- a/wsmaster/che-core-api-factory/src/main/java/org/eclipse/che/api/factory/server/scm/exception/ScmCommunicationException.java
+++ b/wsmaster/che-core-api-factory/src/main/java/org/eclipse/che/api/factory/server/scm/exception/ScmCommunicationException.java
@@ -26,6 +26,11 @@ public class ScmCommunicationException extends Exception {
     this.provider = provider;
   }
 
+  public ScmCommunicationException(String message, int statusCode) {
+    super(message);
+    this.statusCode = statusCode;
+  }
+
   public ScmCommunicationException(String message, Throwable cause) {
     super(message, cause);
   }

--- a/wsmaster/che-core-api-factory/src/main/java/org/eclipse/che/api/factory/server/scm/exception/ScmCommunicationException.java
+++ b/wsmaster/che-core-api-factory/src/main/java/org/eclipse/che/api/factory/server/scm/exception/ScmCommunicationException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012-2023 Red Hat, Inc.
+ * Copyright (c) 2012-2024 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/
@@ -14,21 +14,36 @@ package org.eclipse.che.api.factory.server.scm.exception;
 /** Thrown when problem occurred during communication with scm provider */
 public class ScmCommunicationException extends Exception {
   private int statusCode;
+  private String provider;
 
   public ScmCommunicationException(String message) {
     super(message);
   }
 
-  public ScmCommunicationException(String message, int statusCode) {
+  public ScmCommunicationException(String message, int statusCode, String provider) {
     super(message);
     this.statusCode = statusCode;
+    this.provider = provider;
   }
 
   public ScmCommunicationException(String message, Throwable cause) {
     super(message, cause);
   }
 
+  public ScmCommunicationException(String message, Throwable cause, String provider) {
+    super(message, cause);
+    this.provider = provider;
+  }
+
   public int getStatusCode() {
     return statusCode;
+  }
+
+  public String getProvider() {
+    return provider;
+  }
+
+  public void setProvider(String provider) {
+    this.provider = provider;
   }
 }


### PR DESCRIPTION
<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests
-->

### What does this PR do?
* Throw the `ScmCommunicationException` on token validation step instead of returning invalid result.
* Propagate the `ScmCommunicationException` to the dashboard as an `ApiException`.
* Throw `ScmUnauthorizedException` on each scm api request with invalid token.
* Log error instead of throwing `RuntimeException` on workspace provision steps.

### Screenshot/screencast of this PR
<!-- Please include a screenshot or a screencast explaining what is doing this PR -->


### What issues does this PR fix or reference?
<!-- Please include any related issue from eclipse che repository (or from another issue tracker).
     Include link to other pull requests like documentation PR from [the docs repo](https://github.com/eclipse/che-docs)
-->
https://github.com/eclipse-che/che/issues/23076

### How to test this PR?
<!-- Please explain for example :
  - The test platform (openshift, kubernetes, minikube, CodeReady Container, docker-desktop, etc)
  - Installation method: chectl / che-operator
  - steps to reproduce
 -->
1. Deploy Che from the PR image: `quay.io/ivinokur/che-server:che-23076` The image is built with a modification: to simulate the unreachable SCM server I changed the api endpoint url in the GitHub api client:
https://github.com/eclipse-che/che-server/blob/e04d787ed847f06faf9d18c56f0774de3cfa8b7c/wsmaster/che-core-api-factory-github-common/src/main/java/org/eclipse/che/api/factory/server/github/GithubApiClient.java#L57
2. Configure Che to use dashboard image from the related pull request: `quay.io/eclipse/che-dashboard:pr-1179`
3. Configure [GitHub oauth](https://eclipse.dev/che/docs/stable/administration-guide/configuring-oauth-2-for-github/)
4. Start a workspace from a GitHub repository with devfile.

See: a warning notification appears during workspace startup:
![Screenshot 2024-08-30 at 13 59 48](https://github.com/user-attachments/assets/57dd26d4-28ed-4cfc-b658-cf376b812ec1)
The workspace starts successfully. 


### PR Checklist

[As the author of this Pull Request I made sure that:](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#pull-request-template-and-its-checklist)

- [ ] [The Eclipse Contributor Agreement is valid](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-eclipse-contributor-agreement-is-valid)
- [ ] [Code produced is complete](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-produced-is-complete)
- [ ] [Code builds without errors](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-builds-without-errors)
- [ ] [Tests are covering the bugfix](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#tests-are-covering-the-bugfix)
- [ ] [The repository devfile is up to date and works](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-repository-devfile-is-up-to-date-and-works)
- [ ] [Sections `What issues does this PR fix or reference` and `How to test this PR` completed](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#sections-what-issues-does-this-pr-fix-or-reference-and-how-to-test-this-pr-completed)
- [ ] [Relevant user documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [Relevant contributing documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [CI/CD changes implemented, documented and communicated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#cicd-changes-implemented-documented-and-communicated)

### Release Notes

### Reviewers

Reviewers, please comment how you tested the PR when approving it.
