### PR TITLE
fix: apply strategic merge to workspace-preferences-configmap

### DIFF
--- a/infrastructures/infrastructure-factory/src/main/java/org/eclipse/che/api/factory/server/scm/kubernetes/KubernetesAuthorisationRequestManager.java
+++ b/infrastructures/infrastructure-factory/src/main/java/org/eclipse/che/api/factory/server/scm/kubernetes/KubernetesAuthorisationRequestManager.java
@@ -21,6 +21,8 @@ import static org.eclipse.che.workspace.infrastructure.kubernetes.namespace.Abst
 import com.google.gson.Gson;
 import io.fabric8.kubernetes.api.model.ConfigMap;
 import io.fabric8.kubernetes.client.KubernetesClient;
+import io.fabric8.kubernetes.client.dsl.base.PatchContext;
+import io.fabric8.kubernetes.client.dsl.base.PatchType;
 import jakarta.ws.rs.core.UriInfo;
 import java.net.URL;
 import java.util.HashSet;
@@ -118,7 +120,7 @@ public class KubernetesAuthorisationRequestManager implements AuthorisationReque
           .configMaps()
           .inNamespace(getFirstNamespace())
           .withName(PREFERENCES_CONFIGMAP_NAME)
-          .patch(configMap);
+          .patch(PatchContext.of(PatchType.STRATEGIC_MERGE), configMap);
     } catch (UnsatisfiedScmPreconditionException
         | ScmConfigurationPersistenceException
         | InfrastructureException e) {


### PR DESCRIPTION
<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests
-->

### What does this PR do?

This PR fixes the bug that causes overwriting the data section of the `workspace-preferences-configmap`.

### Screenshot/screencast of this PR
<!-- Please include a screenshot or a screencast explaining what is doing this PR -->
n/a

### What issues does this PR fix or reference?
<!-- Please include any related issue from eclipse che repository (or from another issue tracker).
     Include link to other pull requests like documentation PR from [the docs repo](https://github.com/eclipse/che-docs)
-->

fixes https://issues.redhat.com/browse/CRW-7179
fixes https://github.com/eclipse-che/che/issues/23154

### How to test this PR?
<!-- Please explain for example :
  - The test platform (openshift, kubernetes, minikube, CodeReady Container, docker-desktop, etc)
  - Installation method: chectl / che-operator
  - steps to reproduce
 -->

1. Deploy the Eclipse Che (or DevSpaces) using this image: `quay.io/okurinny/che-server:next`;
2. Configure OAuth2 for the Bitbucket Cloud https://eclipse.dev/che/docs/stable/administration-guide/configuring-oauth-2-for-the-bitbucket-cloud/;
3. Launch a factory using a project URL from your Bitbucket Cloud;
4. Decline the authorization prompt;
5. At this point
    - the dashboard should proceed with creating the new workspace;
    - the Untrusted repository modal should not appear.
  
### PR Checklist

[As the author of this Pull Request I made sure that:](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#pull-request-template-and-its-checklist)

- [ ] [The Eclipse Contributor Agreement is valid](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-eclipse-contributor-agreement-is-valid)
- [ ] [Code produced is complete](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-produced-is-complete)
- [ ] [Code builds without errors](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-builds-without-errors)
- [ ] [Tests are covering the bugfix](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#tests-are-covering-the-bugfix)
- [ ] [The repository devfile is up to date and works](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-repository-devfile-is-up-to-date-and-works)
- [ ] [Sections `What issues does this PR fix or reference` and `How to test this PR` completed](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#sections-what-issues-does-this-pr-fix-or-reference-and-how-to-test-this-pr-completed)
- [ ] [Relevant user documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [Relevant contributing documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [CI/CD changes implemented, documented and communicated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#cicd-changes-implemented-documented-and-communicated)

### Release Notes

### Reviewers

Reviewers, please comment how you tested the PR when approving it.
