### PR TITLE
Extend the raw devfile url pattern with Bitbucket server query parameter

### DIFF
--- a/wsmaster/che-core-api-factory/src/main/java/org/eclipse/che/api/factory/server/RawDevfileUrlFactoryParameterResolver.java
+++ b/wsmaster/che-core-api-factory/src/main/java/org/eclipse/che/api/factory/server/RawDevfileUrlFactoryParameterResolver.java
@@ -45,7 +45,8 @@ public class RawDevfileUrlFactoryParameterResolver extends BaseFactoryParameterR
     implements FactoryParametersResolver {
 
   private static final String PROVIDER_NAME = "raw-devfile-url";
-  private static final Pattern PATTERN = Pattern.compile("^https?://.*\\.ya?ml(\\?token=.*)?$");
+  private static final Pattern PATTERN =
+      Pattern.compile("^https?://.*\\.ya?ml((\\?token=.*)|(\\?at=refs/heads/.*))?$");
 
   protected final URLFactoryBuilder urlFactoryBuilder;
   protected final URLFetcher urlFetcher;

--- a/wsmaster/che-core-api-factory/src/test/java/org/eclipse/che/api/factory/server/RawDevfileUrlFactoryParameterResolverTest.java
+++ b/wsmaster/che-core-api-factory/src/test/java/org/eclipse/che/api/factory/server/RawDevfileUrlFactoryParameterResolverTest.java
@@ -208,7 +208,11 @@ public class RawDevfileUrlFactoryParameterResolverTest {
       "https://host/path/devfile.yaml?token=TOKEN123",
       "https://host/path/.devfile.yaml?token=TOKEN123",
       "https://host/path/any-name.yaml?token=TOKEN123",
-      "https://host/path/any-name.yml?token=TOKEN123"
+      "https://host/path/any-name.yml?token=TOKEN123",
+      "https://host/path/devfile.yaml?at=refs/heads/branch",
+      "https://host/path/.devfile.yaml?at=refs/heads/branch",
+      "https://host/path/any-name.yaml?at=refs/heads/branch",
+      "https://host/path/any-name.yml?at=refs/heads/branch"
     };
   }
 


### PR DESCRIPTION
<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests
-->

### What does this PR do?
Extend the raw devfile url pattern with Bitbucket server query parameter. This fixes an issue that starting a workspace from a raw devfile url from private Bitbucket server repository shows a wrong error:
![screenshot-eclipse-che_apps_rosa_wgjtd-8at7g-nku_afgo_p3_openshiftapps_com-2024_10_28-14_05_55](https://github.com/user-attachments/assets/9a2e1cac-acfb-4bf2-a0e0-c57a87bc9ae9)
The error is about wrong oauth configuration but it is reproduced without any oauth configurations at all.

### Screenshot/screencast of this PR
<!-- Please include a screenshot or a screencast explaining what is doing this PR -->


### What issues does this PR fix or reference?
<!-- Please include any related issue from eclipse che repository (or from another issue tracker).
     Include link to other pull requests like documentation PR from [the docs repo](https://github.com/eclipse/che-docs)
-->
fixes https://github.com/eclipse-che/che/issues/23158

### How to test this PR?
<!-- Please explain for example :
  - The test platform (openshift, kubernetes, minikube, CodeReady Container, docker-desktop, etc)
  - Installation method: chectl / che-operator
  - steps to reproduce
 -->
1. Deploy che with the PR image: `quay.io/eclipse/che-server:pr-732`
2. Get a Raw devfile url from a **PRIVATE** Bitbucket server repository.
3. Start a workspace from the raw devfile url.
4. See: the workspace start interrupts with the error:
![screenshot-eclipse-che_apps_rosa_wgjtd-8at7g-nku_afgo_p3_openshiftapps_com-2024_10_28-13_58_35](https://github.com/user-attachments/assets/c59c4c9a-9bde-4517-8816-57e30c5eb4d2)

### PR Checklist

[As the author of this Pull Request I made sure that:](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#pull-request-template-and-its-checklist)

- [ ] [The Eclipse Contributor Agreement is valid](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-eclipse-contributor-agreement-is-valid)
- [ ] [Code produced is complete](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-produced-is-complete)
- [ ] [Code builds without errors](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-builds-without-errors)
- [ ] [Tests are covering the bugfix](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#tests-are-covering-the-bugfix)
- [ ] [The repository devfile is up to date and works](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-repository-devfile-is-up-to-date-and-works)
- [ ] [Sections `What issues does this PR fix or reference` and `How to test this PR` completed](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#sections-what-issues-does-this-pr-fix-or-reference-and-how-to-test-this-pr-completed)
- [ ] [Relevant user documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [Relevant contributing documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [CI/CD changes implemented, documented and communicated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#cicd-changes-implemented-documented-and-communicated)

### Release Notes

### Reviewers

Reviewers, please comment how you tested the PR when approving it.
