### PR TITLE
Use HTTP response status code to check gitlab repositories accessibility

### DIFF
--- a/wsmaster/che-core-api-factory-gitlab-common/src/main/java/org/eclipse/che/api/factory/server/gitlab/GitlabAuthorizingFileContentProvider.java
+++ b/wsmaster/che-core-api-factory-gitlab-common/src/main/java/org/eclipse/che/api/factory/server/gitlab/GitlabAuthorizingFileContentProvider.java
@@ -46,7 +46,7 @@ class GitlabAuthorizingFileContentProvider extends AuthorizingFileContentProvide
                 Executors.newCachedThreadPool(
                     new ThreadFactoryBuilder()
                         .setUncaughtExceptionHandler(LoggingUncaughtExceptionHandler.getInstance())
-                        .setNameFormat(GitlabApiClient.class.getName() + "-%d")
+                        .setNameFormat(GitlabAuthorizingFileContentProvider.class.getName() + "-%d")
                         .setDaemon(true)
                         .build()))
             .connectTimeout(DEFAULT_HTTP_TIMEOUT)

--- a/wsmaster/che-core-api-factory-gitlab-common/src/main/java/org/eclipse/che/api/factory/server/gitlab/GitlabAuthorizingFileContentProvider.java
+++ b/wsmaster/che-core-api-factory-gitlab-common/src/main/java/org/eclipse/che/api/factory/server/gitlab/GitlabAuthorizingFileContentProvider.java
@@ -11,27 +11,62 @@
  */
 package org.eclipse.che.api.factory.server.gitlab;
 
+import static java.net.HttpURLConnection.HTTP_OK;
+import static java.time.Duration.ofSeconds;
+
+import com.google.common.util.concurrent.ThreadFactoryBuilder;
 import java.io.IOException;
+import java.io.InputStream;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.time.Duration;
+import java.util.concurrent.Executors;
 import org.eclipse.che.api.factory.server.scm.AuthorizingFileContentProvider;
 import org.eclipse.che.api.factory.server.scm.PersonalAccessTokenManager;
 import org.eclipse.che.api.workspace.server.devfile.URLFetcher;
+import org.eclipse.che.commons.lang.concurrent.LoggingUncaughtExceptionHandler;
 
 /** Gitlab specific authorizing file content provider. */
 class GitlabAuthorizingFileContentProvider extends AuthorizingFileContentProvider<GitlabUrl> {
+
+  private final HttpClient httpClient;
+
+  private static final Duration DEFAULT_HTTP_TIMEOUT = ofSeconds(10);
 
   GitlabAuthorizingFileContentProvider(
       GitlabUrl gitlabUrl,
       URLFetcher urlFetcher,
       PersonalAccessTokenManager personalAccessTokenManager) {
     super(gitlabUrl, urlFetcher, personalAccessTokenManager);
+    this.httpClient =
+        HttpClient.newBuilder()
+            .executor(
+                Executors.newCachedThreadPool(
+                    new ThreadFactoryBuilder()
+                        .setUncaughtExceptionHandler(LoggingUncaughtExceptionHandler.getInstance())
+                        .setNameFormat(GitlabApiClient.class.getName() + "-%d")
+                        .setDaemon(true)
+                        .build()))
+            .connectTimeout(DEFAULT_HTTP_TIMEOUT)
+            .version(HttpClient.Version.HTTP_1_1)
+            .build();
   }
 
   @Override
   protected boolean isPublicRepository(GitlabUrl remoteFactoryUrl) {
+    HttpRequest request =
+        HttpRequest.newBuilder(
+                URI.create(
+                    remoteFactoryUrl.getProviderUrl() + '/' + remoteFactoryUrl.getSubGroups()))
+            .timeout(DEFAULT_HTTP_TIMEOUT)
+            .build();
     try {
-      urlFetcher.fetch(remoteFactoryUrl.getProviderUrl() + '/' + remoteFactoryUrl.getSubGroups());
-      return true;
-    } catch (IOException e) {
+      HttpResponse<InputStream> response =
+          httpClient.send(request, HttpResponse.BodyHandlers.ofInputStream());
+      return response.statusCode() == HTTP_OK;
+    } catch (IOException | InterruptedException e) {
       return false;
     }
   }

--- a/wsmaster/che-core-api-factory-gitlab/src/test/java/org/eclipse/che/api/factory/server/gitlab/GitlabAuthorizingFileContentProviderTest.java
+++ b/wsmaster/che-core-api-factory-gitlab/src/test/java/org/eclipse/che/api/factory/server/gitlab/GitlabAuthorizingFileContentProviderTest.java
@@ -11,29 +11,60 @@
  */
 package org.eclipse.che.api.factory.server.gitlab;
 
+import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
+import static com.github.tomakehurst.wiremock.client.WireMock.get;
+import static com.github.tomakehurst.wiremock.client.WireMock.stubFor;
+import static com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo;
+import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.wireMockConfig;
+import static java.lang.String.format;
+import static java.net.HttpURLConnection.HTTP_MOVED_TEMP;
+import static java.net.HttpURLConnection.HTTP_OK;
 import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import com.github.tomakehurst.wiremock.WireMockServer;
+import com.github.tomakehurst.wiremock.client.WireMock;
+import com.github.tomakehurst.wiremock.common.Slf4jNotifier;
 import java.io.FileNotFoundException;
+import java.net.URI;
 import org.eclipse.che.api.factory.server.scm.PersonalAccessToken;
 import org.eclipse.che.api.factory.server.scm.PersonalAccessTokenManager;
 import org.eclipse.che.api.factory.server.scm.exception.UnknownScmProviderException;
 import org.eclipse.che.api.workspace.server.devfile.FileContentProvider;
 import org.eclipse.che.api.workspace.server.devfile.URLFetcher;
+import org.eclipse.che.api.workspace.server.devfile.exception.DevfileException;
 import org.mockito.Mock;
-import org.mockito.Mockito;
 import org.mockito.testng.MockitoTestNGListener;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Listeners;
 import org.testng.annotations.Test;
 
 @Listeners(MockitoTestNGListener.class)
 public class GitlabAuthorizingFileContentProviderTest {
   @Mock private PersonalAccessTokenManager personalAccessTokenManager;
+  @Mock private URLFetcher urlFetcher;
+
+  private WireMockServer wireMockServer;
+  private WireMock wireMock;
+
+  @BeforeMethod
+  public void start() {
+    wireMockServer =
+        new WireMockServer(wireMockConfig().notifier(new Slf4jNotifier(false)).dynamicPort());
+    wireMockServer.start();
+    WireMock.configureFor("localhost", wireMockServer.port());
+    wireMock = new WireMock("localhost", wireMockServer.port());
+  }
+
+  @AfterMethod
+  void stop() {
+    wireMockServer.stop();
+  }
 
   @Test
   public void shouldExpandRelativePaths() throws Exception {
-    URLFetcher urlFetcher = Mockito.mock(URLFetcher.class);
     GitlabUrl gitlabUrl = new GitlabUrl().withHostName("gitlab.net").withSubGroups("eclipse/che");
     FileContentProvider fileContentProvider =
         new GitlabAuthorizingFileContentProvider(gitlabUrl, urlFetcher, personalAccessTokenManager);
@@ -49,7 +80,6 @@ public class GitlabAuthorizingFileContentProviderTest {
 
   @Test
   public void shouldPreserveAbsolutePaths() throws Exception {
-    URLFetcher urlFetcher = Mockito.mock(URLFetcher.class);
     GitlabUrl gitlabUrl = new GitlabUrl().withHostName("gitlab.net").withSubGroups("eclipse/che");
     FileContentProvider fileContentProvider =
         new GitlabAuthorizingFileContentProvider(gitlabUrl, urlFetcher, personalAccessTokenManager);
@@ -65,17 +95,52 @@ public class GitlabAuthorizingFileContentProviderTest {
   @Test(expectedExceptions = FileNotFoundException.class)
   public void shouldThrowFileNotFoundException() throws Exception {
     // given
-    URLFetcher urlFetcher = Mockito.mock(URLFetcher.class);
     when(urlFetcher.fetch(
             eq(
-                "https://gitlab.com/api/v4/projects/eclipse%2Fche/repository/files/devfile.yaml/raw?ref=HEAD")))
+                wireMockServer.url(
+                    "/api/v4/projects/eclipse%2Fche/repository/files/devfile.yaml/raw?ref=HEAD"))))
         .thenThrow(new FileNotFoundException());
-    when(urlFetcher.fetch(eq("https://gitlab.com/eclipse/che"))).thenReturn("content");
+    when(urlFetcher.fetch(eq("http://gitlab.com/eclipse/che"))).thenReturn("content");
     when(personalAccessTokenManager.getAndStore(anyString()))
         .thenThrow(new UnknownScmProviderException("", ""));
-    GitlabUrl gitlabUrl = new GitlabUrl().withHostName("gitlab.com").withSubGroups("eclipse/che");
+    URI uri = URI.create(wireMockServer.url("/"));
+    GitlabUrl gitlabUrl =
+        new GitlabUrl()
+            .withScheme("http")
+            .withHostName(format("%s:%s", uri.getHost(), uri.getPort()))
+            .withSubGroups("eclipse/che");
     FileContentProvider fileContentProvider =
         new GitlabAuthorizingFileContentProvider(gitlabUrl, urlFetcher, personalAccessTokenManager);
+
+    stubFor(get(urlEqualTo("/eclipse/che")).willReturn(aResponse().withStatus(HTTP_OK)));
+
+    // when
+    fileContentProvider.fetchContent("devfile.yaml");
+  }
+
+  @Test(
+      expectedExceptions = DevfileException.class,
+      expectedExceptionsMessageRegExp = "Could not reach devfile at test path")
+  public void shouldThrowDevfileException() throws Exception {
+    // given
+    when(urlFetcher.fetch(
+            eq(
+                wireMockServer.url(
+                    "/api/v4/projects/eclipse%2Fche/repository/files/devfile.yaml/raw?ref=HEAD"))))
+        .thenThrow(new FileNotFoundException("test path"));
+    when(urlFetcher.fetch(eq("http://gitlab.com/eclipse/che"))).thenReturn("content");
+    when(personalAccessTokenManager.getAndStore(anyString()))
+        .thenThrow(new UnknownScmProviderException("", ""));
+    URI uri = URI.create(wireMockServer.url("/"));
+    GitlabUrl gitlabUrl =
+        new GitlabUrl()
+            .withScheme("http")
+            .withHostName(format("%s:%s", uri.getHost(), uri.getPort()))
+            .withSubGroups("eclipse/che");
+    FileContentProvider fileContentProvider =
+        new GitlabAuthorizingFileContentProvider(gitlabUrl, urlFetcher, personalAccessTokenManager);
+
+    stubFor(get(urlEqualTo("/eclipse/che")).willReturn(aResponse().withStatus(HTTP_MOVED_TEMP)));
 
     // when
     fileContentProvider.fetchContent("devfile.yaml");

--- a/wsmaster/che-core-api-factory-gitlab/src/test/java/org/eclipse/che/api/factory/server/gitlab/GitlabAuthorizingFileContentProviderTest.java
+++ b/wsmaster/che-core-api-factory-gitlab/src/test/java/org/eclipse/che/api/factory/server/gitlab/GitlabAuthorizingFileContentProviderTest.java
@@ -100,7 +100,6 @@ public class GitlabAuthorizingFileContentProviderTest {
                 wireMockServer.url(
                     "/api/v4/projects/eclipse%2Fche/repository/files/devfile.yaml/raw?ref=HEAD"))))
         .thenThrow(new FileNotFoundException());
-    when(urlFetcher.fetch(eq("http://gitlab.com/eclipse/che"))).thenReturn("content");
     when(personalAccessTokenManager.getAndStore(anyString()))
         .thenThrow(new UnknownScmProviderException("", ""));
     URI uri = URI.create(wireMockServer.url("/"));
@@ -128,7 +127,6 @@ public class GitlabAuthorizingFileContentProviderTest {
                 wireMockServer.url(
                     "/api/v4/projects/eclipse%2Fche/repository/files/devfile.yaml/raw?ref=HEAD"))))
         .thenThrow(new FileNotFoundException("test path"));
-    when(urlFetcher.fetch(eq("http://gitlab.com/eclipse/che"))).thenReturn("content");
     when(personalAccessTokenManager.getAndStore(anyString()))
         .thenThrow(new UnknownScmProviderException("", ""));
     URI uri = URI.create(wireMockServer.url("/"));


### PR DESCRIPTION
<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests
-->

### What does this PR do?
Improve the `isPublicRepository()` function in the `GitlabAuthorizingFileContentProvider` class to check the http response status code. The previous way with the `urlFetcher` does not work because gitlab server returns a content of an html page with credentials input instead of an error.

### Screenshot/screencast of this PR
<!-- Please include a screenshot or a screencast explaining what is doing this PR -->


### What issues does this PR fix or reference?
<!-- Please include any related issue from eclipse che repository (or from another issue tracker).
     Include link to other pull requests like documentation PR from [the docs repo](https://github.com/eclipse/che-docs)
-->
https://issues.redhat.com/browse/CRW-7608

### How to test this PR?
<!-- Please explain for example :
  - The test platform (openshift, kubernetes, minikube, CodeReady Container, docker-desktop, etc)
  - Installation method: chectl / che-operator
  - steps to reproduce
 -->
1. Deploy che with the pull request image: `quay.io/eclipse/che-server:pr-741`
2. Start a workspace from a private gitlab server repository.

See: workspace start fails with the expected error message:
![screenshot-eclipse-che_apps_rosa_p9t96-996tb-ydw_ylq7_p3_openshiftapps_com-2024_11_18-12_43_37](https://github.com/user-attachments/assets/7e5163f0-3130-4a9d-8663-a6dfb4861883)


### PR Checklist

[As the author of this Pull Request I made sure that:](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#pull-request-template-and-its-checklist)

- [ ] [The Eclipse Contributor Agreement is valid](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-eclipse-contributor-agreement-is-valid)
- [ ] [Code produced is complete](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-produced-is-complete)
- [ ] [Code builds without errors](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-builds-without-errors)
- [ ] [Tests are covering the bugfix](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#tests-are-covering-the-bugfix)
- [ ] [The repository devfile is up to date and works](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-repository-devfile-is-up-to-date-and-works)
- [ ] [Sections `What issues does this PR fix or reference` and `How to test this PR` completed](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#sections-what-issues-does-this-pr-fix-or-reference-and-how-to-test-this-pr-completed)
- [ ] [Relevant user documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [Relevant contributing documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [CI/CD changes implemented, documented and communicated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#cicd-changes-implemented-documented-and-communicated)

### Release Notes
With this fix workspace start from a private gitlab repository will interrupt with an error if no token is present. 
### Reviewers

Reviewers, please comment how you tested the PR when approving it.
