### PR TITLE
Develocity and build cache integration

### DIFF
--- a/.github/workflows/build-pr-check.yml
+++ b/.github/workflows/build-pr-check.yml
@@ -47,6 +47,8 @@ jobs:
         registry: quay.io
     - name: Build with Maven
       run: mvn -B clean install -U -Pintegration
+      env:
+        DEVELOCITY_ACCESS_KEY: ${{ secrets.DEVELOCITY_API_TOKEN }}
     - name: Build and push images
       if: github.event_name == 'pull_request'
       run: ./build/build.sh --tag:${{ env.PR_IMAGE_TAG }} --build-platforms:linux/amd64,linux/ppc64le,linux/arm64 --builder:podman --push-image

--- a/.github/workflows/next-build.yml
+++ b/.github/workflows/next-build.yml
@@ -44,6 +44,8 @@ jobs:
         registry: quay.io
     - name: Build with Maven
       run: mvn -B clean install -U -Pintegration
+      env:
+        DEVELOCITY_ACCESS_KEY: ${{ secrets.DEVELOCITY_API_TOKEN }}
     - name: Build and push images
       id: build
       run: |

--- a/.github/workflows/sonar.yaml
+++ b/.github/workflows/sonar.yaml
@@ -27,4 +27,5 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}  # Needed to get PR information, if any
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+          DEVELOCITY_ACCESS_KEY: ${{ secrets.DEVELOCITY_API_TOKEN }}
         run: mvn -B clean verify org.sonarsource.scanner.maven:sonar-maven-plugin:sonar -Psonar -Pintegration

--- a/.gitignore
+++ b/.gitignore
@@ -98,3 +98,6 @@ tests/e2e/load-test-folder
 */.grunt
 */.lock-wscript
 */cypress-tests/dist
+
+# Develocity
+.mvn/.develocity/develocity-workspace-id

--- a/.mvn/develocity.xml
+++ b/.mvn/develocity.xml
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes" ?>
+<!--
+
+    Copyright (c) 2012-2025 Red Hat, Inc. and others.
+    This program and the accompanying materials are made
+    available under the terms of the Eclipse Public License 2.0
+    which is available at https://www.eclipse.org/legal/epl-2.0/
+
+    SPDX-License-Identifier: EPL-2.0
+
+    Contributors:
+      Gasper Kojek
+
+-->
+<develocity
+  xmlns="https://www.gradle.com/develocity-maven" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="https://www.gradle.com/develocity-maven https://www.gradle.com/schema/develocity-maven.xsd">
+  <server>
+    <url>https://develocity-staging.eclipse.org</url>
+  </server>
+  <projectId>ecd.che</projectId>
+  <buildScan>
+    <obfuscation>
+      <ipAddresses>0.0.0.0</ipAddresses>
+    </obfuscation>
+    <publishing>
+      <onlyIf>
+        <![CDATA[authenticated]]>
+      </onlyIf>
+    </publishing>
+    <backgroundBuildScanUpload>#{isFalse(env['CI'])}</backgroundBuildScanUpload>
+  </buildScan>
+  <buildCache>
+    <local>
+      <enabled>#{isFalse(env['CI'])}</enabled>
+    </local>
+    <remote>
+      <enabled>true</enabled>
+      <storeEnabled>#{isTrue(env['CI'])}</storeEnabled>
+    </remote>
+  </buildCache>
+</develocity>

--- a/.mvn/extensions.xml
+++ b/.mvn/extensions.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (c) 2012-2025 Red Hat, Inc. and others.
+    This program and the accompanying materials are made
+    available under the terms of the Eclipse Public License 2.0
+    which is available at https://www.eclipse.org/legal/epl-2.0/
+
+    SPDX-License-Identifier: EPL-2.0
+
+    Contributors:
+      Gasper Kojek
+
+-->
+<extensions>
+	<extension>
+		<groupId>com.gradle</groupId>
+		<artifactId>develocity-maven-extension</artifactId>
+		<version>1.23.1</version>
+	</extension>
+	<extension>
+		<groupId>com.gradle</groupId>
+		<artifactId>common-custom-user-data-maven-extension</artifactId>
+		<version>2.0.1</version>
+	</extension>
+</extensions>

--- a/pom.xml
+++ b/pom.xml
@@ -1853,6 +1853,25 @@
                         </dependency>
                     </dependencies>
                 </plugin>
+                <plugin>
+                    <groupId>com.gradle</groupId>
+                    <artifactId>develocity-maven-extension</artifactId>
+                    <configuration>
+                        <develocity>
+                            <normalization>
+                                <runtimeClassPath>
+                                    <metaInf>
+                                        <ignoredAttributes>
+                                            <ignore>Implementation-Version</ignore>
+                                            <ignore>Date</ignore>
+                                            <ignore>SCM-Revision</ignore>
+                                        </ignoredAttributes>
+                                    </metaInf>
+                                </runtimeClassPath>
+                            </normalization>
+                        </develocity>
+                    </configuration>
+                </plugin>
             </plugins>
         </pluginManagement>
         <plugins>


### PR DESCRIPTION
<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests
-->

### What does this PR do?
This PR will enable you to publish Build Scans to [develocity-staging.eclipse.org](https://develocity-staging.eclipse.org), as well as use build caching, as explained in the issue https://github.com/eclipse-che/che/issues/23358.

#### Description
This PR publishes a build scan for every CI build and for every local build from an authenticated Eclipse committer. The build will not fail if publishing fails. Setting the access key env var was added in relevant Github Actions workflows, however, the secret will need to be set by Eclipse infra - you can initiate that by opening a [helpdesk](https://gitlab.eclipse.org/eclipsefdn/helpdesk/-/issues) ticket.

The build scans of the Eclipse Che-Server project are published to the Develocity instance at [develocity-staging.eclipse.org](https://develocity-staging.eclipse.org), hosted by the Eclipse Foundation and run in partnership between the Eclipse and Gradle. This Develocity instance has all features and extensions enabled and is freely available for use by the Eclipse Che-Server project and all other Eclipse projects.

On this Develocity instance, the Eclipse Che-Server project will have access not only to all of the published build scans but also to other aggregate data features such as:

* Dashboards to view all historical build scans, along with performance [trends](https://develocity-staging.eclipse.org/scans/trends?search.relativeStartTime=P28D&trends.timeResolution=week) over time. For example, look at the [Quarkus instance trends dashboard](https://ge.quarkus.io/scans/trends?search.relativeStartTime=P28D&search.tags=ci&search.timeZoneId=Europe%2FLjubljana) with the `ci` filter applied.
* [Build failure analytics](https://develocity-staging.eclipse.org/scans/failures?search.relativeStartTime=P28D) for enhanced investigation and diagnosis of build failures. You can also explore the [Quarkus instance](https://ge.quarkus.io/scans/failures?search.relativeStartTime=P28D&search.timeZoneId=Europe%2FLjubljana) for example of a different OSS projects Develocity instance.
* [Test failure analytics](https://develocity-staging.eclipse.org/scans/tests?search.relativeStartTime=P28D) to better understand trends and causes around slow, failing, and flaky tests. Going to the [Quarkus instance](https://ge.quarkus.io/scans/tests?search.relativeStartTime=P28D&search.timeZoneId=Europe%2FLjubljana) again, this will probably give you a better representation of the type of data available. You can also order it by flakiness, which is a good starting point when deciding which tests need fixing the most.

This will also enable you to (optionally) use build time optimization features, such as (remote) build caching and Predictive Test Selection. In this PR, build caching is enabled, with the local cache being disabled on CI and only allowing CI to write to the remote cache, as per the general recommendations.

More information can be read in the [Eclipse announcement](https://www.eclipse.org/lists/cross-project-issues-dev/msg20000.html). 

Please let me know if there are any questions about the value of Develocity or the changes in this pull request and I’d be happy to address them.

#### IMPORTANT
**To get scans publishing on CI, a [helpdesk](https://gitlab.eclipse.org/eclipsefdn/helpdesk/-/issues) ticket needs to be opened in order for those credentials to be created, as explained in the [initiative documentation](https://gitlab.eclipse.org/eclipsefdn/it/releng/develocity/develocity-documentation#ci-integration).**


### Screenshot/screencast of this PR

An example build scan of a local build can be observed [here](https://ge.solutions-team.gradle.com/s/5tiv4zs6w6dzw). You can also observe that the build time was reduced by [1m 35s by using the build cache](https://ge.solutions-team.gradle.com/s/5tiv4zs6w6dzw#timeline). 

I've also found that the build time could further be improved by fixing [volatile goal inputs](https://ge.solutions-team.gradle.com/c/3s2sxocry2vvq/z73hpofbeyub2/goal-inputs?expanded=WyJsNWlzNnJtMzNudTNpLWNvbXBpbGVzb3VyY2Vyb290cyIsImw1aXM2cm0zM251M2ktY29tcGlsZVNvdXJjZVJvb3RzLTAtMCIsInNmMzczM3EzYzRveWEtdGVzdGNsYXNzcGF0aGVsZW1lbnRzIiwic2YzNzMzcTNjNG95YS10ZXN0Q2xhc3NwYXRoRWxlbWVudHMtMC0wIiwicTJtYW5odGtmZ2lzYy1jb21waWxlc291cmNlcm9vdHMiLCJxMm1hbmh0a2ZnaXNjLWNvbXBpbGVTb3VyY2VSb290cy0wLTAiLCJldjZnbDZpZm51N2ttLWNvbXBpbGVzb3VyY2Vyb290cyIsImdjNWN6N2hlYnphanktdGVzdGNsYXNzcGF0aGVsZW1lbnRzIiwiZ2M1Y3o3aGViemFqeS10ZXN0Q2xhc3NwYXRoRWxlbWVudHMtMC0wIiwiZXY2Z2w2aWZudTdrbS1jb21waWxlU291cmNlUm9vdHMtMC0wIiwiaWplNzNyaHYzNGx4ay10ZXN0Y2xhc3NwYXRoZWxlbWVudHMiXQ#change-l5is6rm33nu3i-compileSourceRoots-0-0-0), which manifest itself as the generated `DtoServerImpls.java`, which is not deterministic -> ordering differs on different runs. By making the [DtoGenerator](https://github.com/eclipse-che/che-server/blob/main/core/che-core-api-dto/src/main/java/org/eclipse/che/dto/generator/DtoGenerator.java#L121) generate deterministic files, the build time could be reduced by additional [2m 6s](https://ge.solutions-team.gradle.com/s/5tiv4zs6w6dzw/performance/execution#cacheable).


### What issues does this PR fix or reference?
https://github.com/eclipse-che/che/issues/23358


### How to test this PR?

As explained in the [Eclipse Develocity documentation](https://gitlab.eclipse.org/eclipsefdn/it/releng/develocity/develocity-documentation#ci-integration), you can start publishing scans locally if you run the `mvn develocity:provision-access-key` goal, which will take you to [develocity-staging.eclipse.org](https://develocity-staging.eclipse.org), where you can log in with your eclipse account and confirm access key generation. All the subsequent builds will be published. 

Caching can be tested without setting up the Develocity credentials - simply run 2 or more builds (the first one will fill the local cache, next ones can use it).


### PR Checklist

[As the author of this Pull Request I made sure that:](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#pull-request-template-and-its-checklist)

- [x] [The Eclipse Contributor Agreement is valid](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-eclipse-contributor-agreement-is-valid)
- [x] [Code produced is complete](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-produced-is-complete)
- [x] [Code builds without errors](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-builds-without-errors)
- [ ] [Tests are covering the bugfix](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#tests-are-covering-the-bugfix)
- [ ] [The repository devfile is up to date and works](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-repository-devfile-is-up-to-date-and-works)
- [x] [Sections `What issues does this PR fix or reference` and `How to test this PR` completed](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#sections-what-issues-does-this-pr-fix-or-reference-and-how-to-test-this-pr-completed)
- [ ] [Relevant user documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [Relevant contributing documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [x] [CI/CD changes implemented, documented and communicated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#cicd-changes-implemented-documented-and-communicated)

### Release Notes

### Reviewers

Reviewers, please comment how you tested the PR when approving it.
