### PR TITLE
Fix parameter mismatch mistake in the AbstractGitUserDataFetcher class (#779)

### DIFF
--- a/wsmaster/che-core-api-factory-github/src/test/java/org/eclipse/che/api/factory/server/github/GithubGitUserDataFetcherTest.java
+++ b/wsmaster/che-core-api-factory-github/src/test/java/org/eclipse/che/api/factory/server/github/GithubGitUserDataFetcherTest.java
@@ -93,4 +93,21 @@ public class GithubGitUserDataFetcherTest {
     assertEquals(gitUserData.getScmUsername(), "Github User");
     assertEquals(gitUserData.getScmUserEmail(), "github-user@acme.com");
   }
+
+  @Test
+  public void shouldFetchGitUserDataByUrl() throws Exception {
+    // given
+    PersonalAccessToken token = mock(PersonalAccessToken.class);
+    when(token.getToken()).thenReturn(githubOauthToken);
+    when(personalAccessTokenManager.get(any(Subject.class), eq("github"), eq(null), eq(null)))
+        .thenReturn(Optional.empty());
+    when(personalAccessTokenManager.get(
+            any(Subject.class), eq(null), eq(wireMockServer.baseUrl()), eq(null)))
+        .thenReturn(Optional.of(token));
+    // when
+    GitUserData gitUserData = githubGUDFetcher.fetchGitUserData(null);
+    // then
+    assertEquals(gitUserData.getScmUsername(), "Github User");
+    assertEquals(gitUserData.getScmUserEmail(), "github-user@acme.com");
+  }
 }

--- a/wsmaster/che-core-api-factory-gitlab-common/src/main/java/org/eclipse/che/api/factory/server/gitlab/AbstractGitlabUserDataFetcher.java
+++ b/wsmaster/che-core-api-factory-gitlab-common/src/main/java/org/eclipse/che/api/factory/server/gitlab/AbstractGitlabUserDataFetcher.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012-2024 Red Hat, Inc.
+ * Copyright (c) 2012-2025 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/
@@ -39,8 +39,11 @@ public class AbstractGitlabUserDataFetcher extends AbstractGitUserDataFetcher {
       String apiEndpoint,
       PersonalAccessTokenManager personalAccessTokenManager,
       String providerName) {
-    super(providerName, serverUrl, personalAccessTokenManager);
-    this.serverUrl = isNullOrEmpty(serverUrl) ? GITLAB_SAAS_ENDPOINT : serverUrl;
+    super(
+        providerName,
+        isNullOrEmpty(serverUrl) ? GITLAB_SAAS_ENDPOINT : serverUrl,
+        personalAccessTokenManager);
+    this.serverUrl = super.oAuthProviderUrl;
     this.apiEndpoint = apiEndpoint;
     this.providerName = providerName;
   }

--- a/wsmaster/che-core-api-factory-gitlab/src/test/java/org/eclipse/che/api/factory/server/gitlab/GitlabUserDataFetcherTest.java
+++ b/wsmaster/che-core-api-factory-gitlab/src/test/java/org/eclipse/che/api/factory/server/gitlab/GitlabUserDataFetcherTest.java
@@ -33,7 +33,6 @@ import org.eclipse.che.api.factory.server.scm.GitUserData;
 import org.eclipse.che.api.factory.server.scm.PersonalAccessToken;
 import org.eclipse.che.api.factory.server.scm.PersonalAccessTokenManager;
 import org.eclipse.che.commons.subject.Subject;
-import org.eclipse.che.security.oauth.OAuthAPI;
 import org.mockito.Mock;
 import org.mockito.testng.MockitoTestNGListener;
 import org.testng.annotations.AfterMethod;
@@ -44,7 +43,6 @@ import org.testng.annotations.Test;
 @Listeners(MockitoTestNGListener.class)
 public class GitlabUserDataFetcherTest {
 
-  @Mock OAuthAPI oAuthTokenFetcher;
   @Mock PersonalAccessTokenManager personalAccessTokenManager;
 
   GitlabUserDataFetcher gitlabUserDataFetcher;
@@ -86,6 +84,23 @@ public class GitlabUserDataFetcherTest {
         .thenReturn(Optional.of(token));
 
     GitUserData gitUserData = gitlabUserDataFetcher.fetchGitUserData(null);
+    assertEquals(gitUserData.getScmUsername(), "John Smith");
+    assertEquals(gitUserData.getScmUserEmail(), "john@example.com");
+  }
+
+  @Test
+  public void shouldFetchGitUserDataByUrl() throws Exception {
+    // given
+    PersonalAccessToken token = mock(PersonalAccessToken.class);
+    when(token.getToken()).thenReturn("oauthtoken");
+    when(personalAccessTokenManager.get(any(Subject.class), eq("gitlab"), eq(null), eq(null)))
+        .thenReturn(Optional.empty());
+    when(personalAccessTokenManager.get(
+            any(Subject.class), eq(null), eq(wireMockServer.url("/")), eq(null)))
+        .thenReturn(Optional.of(token));
+    // when
+    GitUserData gitUserData = gitlabUserDataFetcher.fetchGitUserData(null);
+    // then
     assertEquals(gitUserData.getScmUsername(), "John Smith");
     assertEquals(gitUserData.getScmUserEmail(), "john@example.com");
   }

--- a/wsmaster/che-core-api-factory/src/main/java/org/eclipse/che/api/factory/server/scm/AbstractGitUserDataFetcher.java
+++ b/wsmaster/che-core-api-factory/src/main/java/org/eclipse/che/api/factory/server/scm/AbstractGitUserDataFetcher.java
@@ -24,7 +24,7 @@ import org.eclipse.che.commons.subject.Subject;
  */
 public abstract class AbstractGitUserDataFetcher implements GitUserDataFetcher {
   protected final String oAuthProviderName;
-  private final String oAuthProviderUrl;
+  protected final String oAuthProviderUrl;
   protected final PersonalAccessTokenManager personalAccessTokenManager;
 
   public AbstractGitUserDataFetcher(
@@ -46,7 +46,7 @@ public abstract class AbstractGitUserDataFetcher implements GitUserDataFetcher {
       return fetchGitUserDataWithPersonalAccessToken(tokenOptional.get());
     } else {
       Optional<PersonalAccessToken> oAuthTokenOptional =
-          personalAccessTokenManager.get(cheSubject, oAuthProviderUrl, null, namespaceName);
+          personalAccessTokenManager.get(cheSubject, null, oAuthProviderUrl, namespaceName);
       if (oAuthTokenOptional.isPresent()) {
         return fetchGitUserDataWithOAuthToken(oAuthTokenOptional.get().getToken());
       }


### PR DESCRIPTION
Fix the parameter mismatch mistake in the AbstractGitUserDataFetcher class. The personalAccessTokenManager.get() function has scmServerUrl as third parameter

<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests
-->

### What does this PR do?
backport from https://github.com/eclipse-che/che-server/pull/779

### Screenshot/screencast of this PR
<!-- Please include a screenshot or a screencast explaining what is doing this PR -->


### What issues does this PR fix or reference?
<!-- Please include any related issue from eclipse che repository (or from another issue tracker).
     Include link to other pull requests like documentation PR from [the docs repo](https://github.com/eclipse/che-docs)
-->


### How to test this PR?
<!-- Please explain for example :
  - The test platform (openshift, kubernetes, minikube, CodeReady Container, docker-desktop, etc)
  - Installation method: chectl / che-operator
  - steps to reproduce
 -->


### PR Checklist

[As the author of this Pull Request I made sure that:](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#pull-request-template-and-its-checklist)

- [ ] [The Eclipse Contributor Agreement is valid](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-eclipse-contributor-agreement-is-valid)
- [ ] [Code produced is complete](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-produced-is-complete)
- [ ] [Code builds without errors](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-builds-without-errors)
- [ ] [Tests are covering the bugfix](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#tests-are-covering-the-bugfix)
- [ ] [The repository devfile is up to date and works](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-repository-devfile-is-up-to-date-and-works)
- [ ] [Sections `What issues does this PR fix or reference` and `How to test this PR` completed](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#sections-what-issues-does-this-pr-fix-or-reference-and-how-to-test-this-pr-completed)
- [ ] [Relevant user documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [Relevant contributing documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [CI/CD changes implemented, documented and communicated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#cicd-changes-implemented-documented-and-communicated)

### Release Notes

### Reviewers

Reviewers, please comment how you tested the PR when approving it.
