### PR TITLE
Make the DtoGenerator deterministic

### DIFF
--- a/core/che-core-api-dto/src/main/java/org/eclipse/che/dto/generator/DtoGenerator.java
+++ b/core/che-core-api-dto/src/main/java/org/eclipse/che/dto/generator/DtoGenerator.java
@@ -170,6 +170,9 @@ public class DtoGenerator {
           new ArrayList<>(reflection.getTypesAnnotatedWith(DTO.class));
       dtosDependencies.removeAll(dtos);
 
+      // We sort alphabetically to ensure deterministic order.
+      Collections.sort(dtosDependencies, new ClassesComparator());
+
       reflection =
           new Reflections(
               new ConfigurationBuilder()
@@ -177,7 +180,10 @@ public class DtoGenerator {
                   .setScanners(new SubTypesScanner()));
 
       for (Class<?> clazz : dtosDependencies) {
-        for (Class impl : reflection.getSubTypesOf(clazz)) {
+        List<Class<?>> impls = new ArrayList<>(reflection.getSubTypesOf(clazz));
+        // We sort alphabetically to ensure deterministic order.
+        Collections.sort(impls, new ClassesComparator());
+        for (Class impl : impls) {
           if (!(impl.isInterface()
               || urls.contains(impl.getProtectionDomain().getCodeSource().getLocation()))) {
             if ("client".equals(dtoTemplate.getImplType())) {

--- a/core/che-core-api-dto/src/main/java/org/eclipse/che/dto/generator/DtoTemplate.java
+++ b/core/che-core-api-dto/src/main/java/org/eclipse/che/dto/generator/DtoTemplate.java
@@ -16,6 +16,8 @@ package org.eclipse.che.dto.generator;
 
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
+import java.util.Comparator;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.LinkedHashSet;
@@ -138,6 +140,7 @@ public class DtoTemplate {
    */
   @Override
   public String toString() {
+    Collections.sort(dtoInterfaces, new DtoImplsComparator());
     StringBuilder builder = new StringBuilder();
     emitPreamble(builder);
     emitDtos(builder);
@@ -335,6 +338,13 @@ public class DtoTemplate {
         builder.append("    });\n");
       }
       builder.append("  }\n\n");
+    }
+  }
+
+  private static class DtoImplsComparator implements Comparator<DtoImpl> {
+    @Override
+    public int compare(DtoImpl o1, DtoImpl o2) {
+      return o1.getImplClassName().compareTo(o2.getImplClassName());
     }
   }
 }


### PR DESCRIPTION
### What does this PR do?
It makes the DtoGenerator generate deterministic files. Currently, the DtoImpl files generated differ between runs, as methods are unordered and are thus added in a nondeterministic order. This is now fixed and generated files from the same source code are now identical.

Looking at the current Che server PR builds [performance](https://develocity-staging.eclipse.org/s/7qtr64lftgkym/performance/execution#cacheable), this fix should shorten the builds where Dtos aren't changed by additional ~3m.

This was highlighted after you've merged PR https://github.com/eclipse-che/che-server/pull/781, which connected the project to [Develocity](https://develocity-staging.eclipse.org/scans?search.rootProjectNames=che*&search.timeZoneId=Europe%2FLjubljana). I have investigated cache misses and saw there are [differences in generated files](https://develocity-staging.eclipse.org/c/oybza5tktr4og/7qtr64lftgkym/goal-inputs?expanded=WyJvNjR3cWJjZHR2N2tvLXRlc3RjbGFzc3BhdGhlbGVtZW50cyIsIm82NHdxYmNkdHY3a28tdGVzdENsYXNzcGF0aEVsZW1lbnRzLTAtMCIsInEzYWN2aDZ6bm42NXUtY29tcGlsZXNvdXJjZXJvb3RzIiwicTNhY3ZoNnpubjY1dS1jb21waWxlU291cmNlUm9vdHMtMC0wIl0#change-q3acvh6znn65u-compileSourceRoots-0-0-0), causing the calculated cache key be different and thus [not getting cache hits](https://develocity-staging.eclipse.org/s/7qtr64lftgkym/performance/execution#cacheable) on all Surefire goals. I was able to [reproduce it locally](https://ge.solutions-team.gradle.com/c/3pwtkj2wlrs26/7ex5iyda7bxec/goal-inputs?cacheability=cacheable&expanded=WyJxM2Fjdmg2em5uNjV1LWNvbXBpbGVzb3VyY2Vyb290cyIsInEzYWN2aDZ6bm42NXUtY29tcGlsZVNvdXJjZVJvb3RzLTAtMCJd#change-q3acvh6znn65u-compileSourceRoots-0-0-0) and fix it. The scan comparison with the fix is visible [here](https://ge.solutions-team.gradle.com/c/3ibk6plgsa5ig/7im3xnfng7awy/goal-inputs?cacheability=cacheable), where no DtoImpls are detected as different - there is one additional cache miss, which is outside of scope of this PR. 

### Screenshot/screencast of this PR
Before:
<img width="1466" alt="Screenshot 2025-03-17 at 12 25 56" src="https://github.com/user-attachments/assets/f152611f-53a5-424a-87e3-47c5cd79d882" />

After:
<img width="1467" alt="Screenshot 2025-03-17 at 12 26 51" src="https://github.com/user-attachments/assets/d0739740-03d1-4709-9290-4534cdbe5180" />

### What issues does this PR fix or reference?
This relates to Issue https://github.com/eclipse-che/che/issues/23358, as it will improve build performance.

### How to test this PR?
Build che-server and observe the generated `Dto*Impls.java` files.


### PR Checklist

[As the author of this Pull Request I made sure that:](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#pull-request-template-and-its-checklist)

- [x] [The Eclipse Contributor Agreement is valid](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-eclipse-contributor-agreement-is-valid)
- [x] [Code produced is complete](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-produced-is-complete)
- [x] [Code builds without errors](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-builds-without-errors)
- [x] [Tests are covering the bugfix](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#tests-are-covering-the-bugfix)
- [x] [The repository devfile is up to date and works](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-repository-devfile-is-up-to-date-and-works)
- [x] [Sections `What issues does this PR fix or reference` and `How to test this PR` completed](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#sections-what-issues-does-this-pr-fix-or-reference-and-how-to-test-this-pr-completed)
- [ ] [Relevant user documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [Relevant contributing documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [CI/CD changes implemented, documented and communicated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#cicd-changes-implemented-documented-and-communicated)

### Release Notes

- Generated `DtoImpls.java` files are now deterministic.

### Reviewers

Reviewers, please comment how you tested the PR when approving it.
