### PR TITLE
Rework the Bitbucket Server getUser request

### DIFF
--- a/wsmaster/che-core-api-factory-bitbucket-server/src/main/java/org/eclipse/che/api/factory/server/bitbucket/HttpBitbucketServerApiClient.java
+++ b/wsmaster/che-core-api-factory-bitbucket-server/src/main/java/org/eclipse/che/api/factory/server/bitbucket/HttpBitbucketServerApiClient.java
@@ -286,6 +286,9 @@ public class HttpBitbucketServerApiClient implements BitbucketServerApiClient {
 
   private BitbucketUser getUser(Optional<String> token)
       throws ScmCommunicationException, ScmUnauthorizedException, ScmItemNotFoundException {
+    // We use the application-properties request to obtain the authenticated username from the
+    // response headers. The request does not fail if no authentication is passed, see:
+    // https://developer.atlassian.com/server/bitbucket/rest/v906/api-group-system-maintenance/#api-api-latest-application-properties-get
     URI uri = serverUri.resolve("/rest/api/1.0/application-properties");
 
     HttpRequest request =

--- a/wsmaster/che-core-api-factory-bitbucket-server/src/main/java/org/eclipse/che/api/factory/server/bitbucket/server/BitbucketApplicationProperties.java
+++ b/wsmaster/che-core-api-factory-bitbucket-server/src/main/java/org/eclipse/che/api/factory/server/bitbucket/server/BitbucketApplicationProperties.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright (c) 2012-2025 Red Hat, Inc.
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+package org.eclipse.che.api.factory.server.bitbucket.server;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import java.util.Objects;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class BitbucketApplicationProperties {
+
+  private String version;
+  private String buildNumber;
+  private String buildDate;
+  private String displayName;
+
+  public BitbucketApplicationProperties() {}
+
+  public BitbucketApplicationProperties(
+      String version, String buildNumber, String buildDate, String displayName) {
+    this.version = version;
+    this.buildNumber = buildNumber;
+    this.buildDate = buildDate;
+    this.displayName = displayName;
+  }
+
+  public String getVersion() {
+    return version;
+  }
+
+  public String getBuildNumber() {
+    return buildNumber;
+  }
+
+  public String getBuildDate() {
+    return buildDate;
+  }
+
+  public String getDisplayName() {
+    return displayName;
+  }
+
+  @Override
+  public String toString() {
+    return "BitbucketApplicationProperties{"
+        + "version='"
+        + version
+        + '\''
+        + ", buildNumber="
+        + buildNumber
+        + ", buildDate="
+        + buildDate
+        + ", displayName='"
+        + displayName
+        + '\''
+        + '}';
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    BitbucketApplicationProperties that = (BitbucketApplicationProperties) o;
+    return buildNumber == that.buildNumber
+        && buildDate == that.buildDate
+        && Objects.equals(version, that.version)
+        && Objects.equals(displayName, that.displayName);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(version, buildNumber, buildDate, displayName);
+  }
+}

--- a/wsmaster/che-core-api-factory-bitbucket-server/src/test/java/org/eclipse/che/api/factory/server/bitbucket/BitbucketServerURLParserTest.java
+++ b/wsmaster/che-core-api-factory-bitbucket-server/src/test/java/org/eclipse/che/api/factory/server/bitbucket/BitbucketServerURLParserTest.java
@@ -117,8 +117,10 @@ public class BitbucketServerURLParserTest {
             null, devfileFilenamesProvider, oAuthAPI, mock(PersonalAccessTokenManager.class));
     String url = wireMockServer.url("/users/user/repos/repo");
     stubFor(
-        get(urlEqualTo("/plugins/servlet/applinks/whoami"))
-            .willReturn(aResponse().withStatus(200)));
+        get(urlEqualTo("/rest/api/1.0/application-properties"))
+            .willReturn(
+                aResponse()
+                    .withBodyFile("bitbucket/rest/api.1.0.application-properties/response.json")));
 
     // when
     boolean result = bitbucketURLParser.isValid(url);
@@ -135,8 +137,10 @@ public class BitbucketServerURLParserTest {
             null, devfileFilenamesProvider, oAuthAPI, mock(PersonalAccessTokenManager.class));
     String url = wireMockServer.url("/user/repo");
     stubFor(
-        get(urlEqualTo("/plugins/servlet/applinks/whoami"))
-            .willReturn(aResponse().withStatus(200)));
+        get(urlEqualTo("/rest/api/1.0/application-properties"))
+            .willReturn(
+                aResponse()
+                    .withBodyFile("bitbucket/rest/api.1.0.application-properties/response.json")));
 
     // when
     boolean result = bitbucketURLParser.isValid(url);
@@ -146,12 +150,51 @@ public class BitbucketServerURLParserTest {
   }
 
   @Test
-  public void shouldNotValidateUrlByApiRequest() {
+  public void shouldNotValidateUrlByApiRequestWithBadRequest() {
     // given
+    bitbucketURLParser =
+        new BitbucketServerURLParser(
+            null, devfileFilenamesProvider, oAuthAPI, mock(PersonalAccessTokenManager.class));
     String url = wireMockServer.url("/users/user/repos/repo");
     stubFor(
-        get(urlEqualTo("/plugins/servlet/applinks/whoami"))
-            .willReturn(aResponse().withStatus(500)));
+        get(urlEqualTo("/rest/api/1.0/application-properties"))
+            .willReturn(aResponse().withStatus(400)));
+
+    // when
+    boolean result = bitbucketURLParser.isValid(url);
+
+    // then
+    assertFalse(result);
+  }
+
+  @Test
+  public void shouldNotValidateUrlByApiRequestWithEmptyData() {
+    // given
+    bitbucketURLParser =
+        new BitbucketServerURLParser(
+            null, devfileFilenamesProvider, oAuthAPI, mock(PersonalAccessTokenManager.class));
+    String url = wireMockServer.url("/users/user/repos/repo");
+    stubFor(
+        get(urlEqualTo("/rest/api/1.0/application-properties"))
+            .willReturn(aResponse().withBody("")));
+
+    // when
+    boolean result = bitbucketURLParser.isValid(url);
+
+    // then
+    assertFalse(result);
+  }
+
+  @Test
+  public void shouldNotValidateUrlByApiRequestWithEmptyHeader() {
+    // given
+    bitbucketURLParser =
+        new BitbucketServerURLParser(
+            null, devfileFilenamesProvider, oAuthAPI, mock(PersonalAccessTokenManager.class));
+    String url = wireMockServer.url("/users/user/repos/repo");
+    stubFor(
+        get(urlEqualTo("/rest/api/1.0/application-properties"))
+            .willReturn(aResponse().withStatus(200)));
 
     // when
     boolean result = bitbucketURLParser.isValid(url);

--- a/wsmaster/che-core-api-factory-bitbucket-server/src/test/java/org/eclipse/che/api/factory/server/bitbucket/HttpBitbucketServerApiClientTest.java
+++ b/wsmaster/che-core-api-factory-bitbucket-server/src/test/java/org/eclipse/che/api/factory/server/bitbucket/HttpBitbucketServerApiClientTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012-2024 Red Hat, Inc.
+ * Copyright (c) 2012-2025 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/
@@ -102,8 +102,8 @@ public class HttpBitbucketServerApiClientTest {
             oAuthAPI,
             apiEndpoint);
     stubFor(
-        get(urlEqualTo("/plugins/servlet/applinks/whoami"))
-            .willReturn(aResponse().withBody("ksmster")));
+        get(urlEqualTo("/rest/api/1.0/application-properties"))
+            .willReturn(aResponse().withHeader("x-ausername", "ksmster")));
   }
 
   @AfterMethod
@@ -354,7 +354,20 @@ public class HttpBitbucketServerApiClientTest {
       throws ScmCommunicationException, ScmUnauthorizedException, ScmItemNotFoundException {
     // given
     stubFor(
-        get(urlEqualTo("/plugins/servlet/applinks/whoami")).willReturn(aResponse().withBody("")));
+        get(urlEqualTo("/rest/api/1.0/application-properties"))
+            .willReturn(
+                aResponse()
+                    .withBodyFile("bitbucket/rest/api.1.0.application-properties/response.json")));
+
+    // when
+    bitbucketServer.getUser();
+  }
+
+  @Test(expectedExceptions = ScmCommunicationException.class)
+  public void shouldBeAbleToThrowScmCommunicationExceptionOnGetUser()
+      throws ScmCommunicationException, ScmUnauthorizedException, ScmItemNotFoundException {
+    // given
+    stubFor(get(urlEqualTo("/rest/api/1.0/application-properties")).willReturn(aResponse()));
 
     // when
     bitbucketServer.getUser();

--- a/wsmaster/che-core-api-factory-bitbucket-server/src/test/resources/__files/bitbucket/rest/api.1.0.application-properties/response.json
+++ b/wsmaster/che-core-api-factory-bitbucket-server/src/test/resources/__files/bitbucket/rest/api.1.0.application-properties/response.json
@@ -1,0 +1,6 @@
+{
+  "version": "8.7.0",
+  "buildNumber": 8007000,
+  "buildDate": 1672975062662,
+  "displayName": "Bitbucket"
+}


### PR DESCRIPTION
<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests
-->

### What does this PR do?
Since Bitbucket Server version 8.19.14, the `/plugins/servlet/applinks/whoami` request does not return username, if PAT is used. Change the `getUser()` request to [/rest/api/1.0/application-properties](https://developer.atlassian.com/server/bitbucket/rest/v906/api-group-system-maintenance/#api-api-latest-application-properties-get) instead and extract the username from the response headers.
Example of an authorized response:
```
< HTTP/1.1 200 
< x-arequestid: @1VT0CNLx453x5668x0
< set-cookie: BITBUCKETSESSIONID=***; Max-Age=1209600; Expires=Mon, 14-Apr-2025 07:33:06 GMT; Path=/; Secure; HttpOnly
< x-auserid: 2
< x-ausername: admin
< x-asessionid: zylcf7
< cache-control: private, no-cache
< pragma: no-cache
< cache-control: no-cache, no-transform
< vary: x-ausername,x-auserid,cookie,accept-encoding
< x-content-type-options: nosniff
< content-type: application/json;charset=UTF-8
< transfer-encoding: chunked
< date: Mon, 31 Mar 2025 07:33:06 GMT
< set-cookie: ***; path=/; HttpOnly; Secure; SameSite=None
< 
* Connection #0 to host bitbucket-bitbucket.apps.ds-airgap-v15.crw-qe.com left intact
{"version":"8.7.0","buildNumber":"8007000","buildDate":"1672975062662","displayName":"Bitbucket"}
```

Example of unauthorized response:
```
* Request completely sent off
< HTTP/1.1 200 
< x-arequestid: @1VT0CNLx454x5669x0
< cache-control: no-cache, no-transform
< vary: x-ausername,x-auserid,cookie,accept-encoding
< x-content-type-options: nosniff
< content-type: application/json;charset=UTF-8
< transfer-encoding: chunked
< date: Mon, 31 Mar 2025 07:34:29 GMT
< set-cookie: ***; path=/; HttpOnly; Secure; SameSite=None
< 
* Connection #0 to host bitbucket-bitbucket.apps.ds-airgap-v15.crw-qe.com left intact
{"version":"8.7.0","buildNumber":"8007000","buildDate":"1672975062662","displayName":"Bitbucket"}
```

### Screenshot/screencast of this PR
<!-- Please include a screenshot or a screencast explaining what is doing this PR -->


### What issues does this PR fix or reference?
<!-- Please include any related issue from eclipse che repository (or from another issue tracker).
     Include link to other pull requests like documentation PR from [the docs repo](https://github.com/eclipse/che-docs)
-->
https://issues.redhat.com/browse/CRW-8246

### How to test this PR?
<!-- Please explain for example :
  - The test platform (openshift, kubernetes, minikube, CodeReady Container, docker-desktop, etc)
  - Installation method: chectl / che-operator
  - steps to reproduce
 -->
1. Deploy Che with the pull request image: `quay.io/eclipse/che-server:pr-790`
2. In the Bitbucket Server version 8.19.14 or higher, create an HTTP access token in the user account page.
3. Go to Che Dashboard -> User Preferences -> Personal Access Tokens -> Add Personal Access Token
4. Choose `Bitbucket Server` as provider, fill in the provider endpoint and the token values.

See: token is added successfully.

### PR Checklist

[As the author of this Pull Request I made sure that:](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#pull-request-template-and-its-checklist)

- [x] [The Eclipse Contributor Agreement is valid](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-eclipse-contributor-agreement-is-valid)
- [x] [Code produced is complete](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-produced-is-complete)
- [x] [Code builds without errors](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-builds-without-errors)
- [x] [Tests are covering the bugfix](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#tests-are-covering-the-bugfix)
- [x] [The repository devfile is up to date and works](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-repository-devfile-is-up-to-date-and-works)
- [x] [Sections `What issues does this PR fix or reference` and `How to test this PR` completed](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#sections-what-issues-does-this-pr-fix-or-reference-and-how-to-test-this-pr-completed)
- [ ] [Relevant user documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [Relevant contributing documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [CI/CD changes implemented, documented and communicated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#cicd-changes-implemented-documented-and-communicated)

### Release Notes

### Reviewers

Reviewers, please comment how you tested the PR when approving it.
