### PR TITLE
Rework the Bitbucket Server getUser request (#790)

### DIFF
--- a/assembly/assembly-wsmaster-war/src/main/webapp/WEB-INF/classes/che/che.properties
+++ b/assembly/assembly-wsmaster-war/src/main/webapp/WEB-INF/classes/che/che.properties
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2012-2024 Red Hat, Inc.
+# Copyright (c) 2012-2025 Red Hat, Inc.
 # This program and the accompanying materials are made
 # available under the terms of the Eclipse Public License 2.0
 # which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/wsmaster/che-core-api-factory-bitbucket-server/src/main/java/org/eclipse/che/api/factory/server/bitbucket/HttpBitbucketServerApiClient.java
+++ b/wsmaster/che-core-api-factory-bitbucket-server/src/main/java/org/eclipse/che/api/factory/server/bitbucket/HttpBitbucketServerApiClient.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012-2024 Red Hat, Inc.
+ * Copyright (c) 2012-2025 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/
@@ -48,6 +48,7 @@ import org.eclipse.che.api.core.ForbiddenException;
 import org.eclipse.che.api.core.NotFoundException;
 import org.eclipse.che.api.core.ServerException;
 import org.eclipse.che.api.core.UnauthorizedException;
+import org.eclipse.che.api.factory.server.bitbucket.server.BitbucketApplicationProperties;
 import org.eclipse.che.api.factory.server.bitbucket.server.BitbucketPersonalAccessToken;
 import org.eclipse.che.api.factory.server.bitbucket.server.BitbucketServerApiClient;
 import org.eclipse.che.api.factory.server.bitbucket.server.BitbucketUser;
@@ -77,6 +78,8 @@ public class HttpBitbucketServerApiClient implements BitbucketServerApiClient {
 
   private static final Logger LOG = LoggerFactory.getLogger(HttpBitbucketServerApiClient.class);
   private static final Duration DEFAULT_HTTP_TIMEOUT = ofSeconds(10);
+  private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
+  public static final String USERNAME_HEADER = "x-ausername";
   private final URI serverUri;
   private final OAuthAuthenticator authenticator;
   private final OAuthAPI oAuthAPI;
@@ -166,10 +169,10 @@ public class HttpBitbucketServerApiClient implements BitbucketServerApiClient {
       executeRequest(
           httpClient,
           request,
-          inputStream -> {
+          response -> {
             try {
               String result =
-                  CharStreams.toString(new InputStreamReader(inputStream, Charsets.UTF_8));
+                  CharStreams.toString(new InputStreamReader(response.body(), Charsets.UTF_8));
               return OM.readValue(result, String.class);
             } catch (IOException e) {
               throw new UncheckedIOException(e);
@@ -210,10 +213,10 @@ public class HttpBitbucketServerApiClient implements BitbucketServerApiClient {
       return executeRequest(
           httpClient,
           request,
-          inputStream -> {
+          response -> {
             try {
               String result =
-                  CharStreams.toString(new InputStreamReader(inputStream, Charsets.UTF_8));
+                  CharStreams.toString(new InputStreamReader(response.body(), Charsets.UTF_8));
               return OM.readValue(result, BitbucketPersonalAccessToken.class);
             } catch (IOException e) {
               throw new UncheckedIOException(e);
@@ -262,10 +265,10 @@ public class HttpBitbucketServerApiClient implements BitbucketServerApiClient {
       return executeRequest(
           httpClient,
           request,
-          inputStream -> {
+          response -> {
             try {
               String result =
-                  CharStreams.toString(new InputStreamReader(inputStream, Charsets.UTF_8));
+                  CharStreams.toString(new InputStreamReader(response.body(), Charsets.UTF_8));
               return OM.readValue(result, BitbucketPersonalAccessToken.class);
             } catch (IOException e) {
               throw new UncheckedIOException(e);
@@ -283,13 +286,10 @@ public class HttpBitbucketServerApiClient implements BitbucketServerApiClient {
 
   private BitbucketUser getUser(Optional<String> token)
       throws ScmCommunicationException, ScmUnauthorizedException, ScmItemNotFoundException {
-    URI uri;
-    try {
-      uri = serverUri.resolve("./plugins/servlet/applinks/whoami");
-    } catch (IllegalArgumentException e) {
-      // if the slug contains invalid characters (space for example) then the URI will be invalid
-      throw new ScmCommunicationException(e.getMessage(), e);
-    }
+    // We use the application-properties request to obtain the authenticated username from the
+    // response headers. The request does not fail if no authentication is passed, see:
+    // https://developer.atlassian.com/server/bitbucket/rest/v906/api-group-system-maintenance/#api-api-latest-application-properties-get
+    URI uri = serverUri.resolve("/rest/api/1.0/application-properties");
 
     HttpRequest request =
         HttpRequest.newBuilder(uri)
@@ -301,29 +301,15 @@ public class HttpBitbucketServerApiClient implements BitbucketServerApiClient {
             .timeout(DEFAULT_HTTP_TIMEOUT)
             .build();
 
-    String username;
+    HttpResponse<InputStream> response;
     try {
       LOG.trace("executeRequest={}", request);
-      username =
-          executeRequest(
-              httpClient,
-              request,
-              inputStream -> {
-                try {
-                  return CharStreams.toString(new InputStreamReader(inputStream, Charsets.UTF_8));
-                } catch (IOException e) {
-                  throw new UncheckedIOException(e);
-                }
-              });
+      response = executeRequest(httpClient, request, r -> r);
     } catch (ScmBadRequestException e) {
       throw new ScmCommunicationException(e.getMessage(), e);
     }
 
-    // Only authenticated users can do the request below, so we must ensure that the username is not
-    // empty
-    if (isNullOrEmpty(username)) {
-      throw buildScmUnauthorizedException();
-    }
+    String username = getUsername(response);
 
     try {
       List<BitbucketUser> users =
@@ -337,6 +323,26 @@ public class HttpBitbucketServerApiClient implements BitbucketServerApiClient {
               () -> new ScmItemNotFoundException("User '" + username + "' not found in Bitbucket"));
     } catch (ScmBadRequestException e) {
       throw new ScmCommunicationException(e.getMessage(), e);
+    }
+  }
+
+  private String getUsername(HttpResponse<InputStream> response)
+      throws ScmCommunicationException, ScmUnauthorizedException {
+    try {
+      // Try to get the username from the response header.
+      if (response.headers().firstValue(USERNAME_HEADER).isPresent()) {
+        return response.headers().firstValue(USERNAME_HEADER).get();
+      } else {
+        String result =
+            CharStreams.toString(new InputStreamReader(response.body(), Charsets.UTF_8));
+        // Convert the response data to the Bitbucket Server info object.
+        OBJECT_MAPPER.readValue(result, BitbucketApplicationProperties.class);
+        // Throw the unauthorized exception if the response contains the Bitbucket info.
+        throw buildScmUnauthorizedException();
+      }
+    } catch (IOException e) {
+      // The response does not contain the Bitbucket Server info
+      throw new ScmCommunicationException("Bad request");
     }
   }
 
@@ -377,10 +383,10 @@ public class HttpBitbucketServerApiClient implements BitbucketServerApiClient {
     return executeRequest(
         httpClient,
         request,
-        inputStream -> {
+        response -> {
           try {
             String result =
-                CharStreams.toString(new InputStreamReader(inputStream, Charsets.UTF_8));
+                CharStreams.toString(new InputStreamReader(response.body(), Charsets.UTF_8));
             return OM.readValue(result, typeReference);
           } catch (IOException e) {
             throw new UncheckedIOException(e);
@@ -389,7 +395,9 @@ public class HttpBitbucketServerApiClient implements BitbucketServerApiClient {
   }
 
   private <T> T executeRequest(
-      HttpClient httpClient, HttpRequest request, Function<InputStream, T> bodyConverter)
+      HttpClient httpClient,
+      HttpRequest request,
+      Function<HttpResponse<InputStream>, T> bodyConverter)
       throws ScmBadRequestException, ScmItemNotFoundException, ScmCommunicationException,
           ScmUnauthorizedException {
     try {
@@ -397,7 +405,7 @@ public class HttpBitbucketServerApiClient implements BitbucketServerApiClient {
           httpClient.send(request, HttpResponse.BodyHandlers.ofInputStream());
       LOG.trace("executeRequest={} response {}", request, response.statusCode());
       if (response.statusCode() == 200) {
-        return bodyConverter.apply(response.body());
+        return bodyConverter.apply(response);
       } else if (response.statusCode() == 204) {
         return null;
       } else {

--- a/wsmaster/che-core-api-factory-bitbucket-server/src/main/java/org/eclipse/che/api/factory/server/bitbucket/server/BitbucketApplicationProperties.java
+++ b/wsmaster/che-core-api-factory-bitbucket-server/src/main/java/org/eclipse/che/api/factory/server/bitbucket/server/BitbucketApplicationProperties.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright (c) 2012-2025 Red Hat, Inc.
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+package org.eclipse.che.api.factory.server.bitbucket.server;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import java.util.Objects;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class BitbucketApplicationProperties {
+
+  private String version;
+  private String buildNumber;
+  private String buildDate;
+  private String displayName;
+
+  public BitbucketApplicationProperties() {}
+
+  public BitbucketApplicationProperties(
+      String version, String buildNumber, String buildDate, String displayName) {
+    this.version = version;
+    this.buildNumber = buildNumber;
+    this.buildDate = buildDate;
+    this.displayName = displayName;
+  }
+
+  public String getVersion() {
+    return version;
+  }
+
+  public String getBuildNumber() {
+    return buildNumber;
+  }
+
+  public String getBuildDate() {
+    return buildDate;
+  }
+
+  public String getDisplayName() {
+    return displayName;
+  }
+
+  @Override
+  public String toString() {
+    return "BitbucketApplicationProperties{"
+        + "version='"
+        + version
+        + '\''
+        + ", buildNumber="
+        + buildNumber
+        + ", buildDate="
+        + buildDate
+        + ", displayName='"
+        + displayName
+        + '\''
+        + '}';
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    BitbucketApplicationProperties that = (BitbucketApplicationProperties) o;
+    return buildNumber == that.buildNumber
+        && buildDate == that.buildDate
+        && Objects.equals(version, that.version)
+        && Objects.equals(displayName, that.displayName);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(version, buildNumber, buildDate, displayName);
+  }
+}

--- a/wsmaster/che-core-api-factory-bitbucket-server/src/test/java/org/eclipse/che/api/factory/server/bitbucket/BitbucketServerURLParserTest.java
+++ b/wsmaster/che-core-api-factory-bitbucket-server/src/test/java/org/eclipse/che/api/factory/server/bitbucket/BitbucketServerURLParserTest.java
@@ -117,8 +117,10 @@ public class BitbucketServerURLParserTest {
             null, devfileFilenamesProvider, oAuthAPI, mock(PersonalAccessTokenManager.class));
     String url = wireMockServer.url("/users/user/repos/repo");
     stubFor(
-        get(urlEqualTo("/plugins/servlet/applinks/whoami"))
-            .willReturn(aResponse().withStatus(200)));
+        get(urlEqualTo("/rest/api/1.0/application-properties"))
+            .willReturn(
+                aResponse()
+                    .withBodyFile("bitbucket/rest/api.1.0.application-properties/response.json")));
 
     // when
     boolean result = bitbucketURLParser.isValid(url);
@@ -135,8 +137,10 @@ public class BitbucketServerURLParserTest {
             null, devfileFilenamesProvider, oAuthAPI, mock(PersonalAccessTokenManager.class));
     String url = wireMockServer.url("/user/repo");
     stubFor(
-        get(urlEqualTo("/plugins/servlet/applinks/whoami"))
-            .willReturn(aResponse().withStatus(200)));
+        get(urlEqualTo("/rest/api/1.0/application-properties"))
+            .willReturn(
+                aResponse()
+                    .withBodyFile("bitbucket/rest/api.1.0.application-properties/response.json")));
 
     // when
     boolean result = bitbucketURLParser.isValid(url);
@@ -146,12 +150,51 @@ public class BitbucketServerURLParserTest {
   }
 
   @Test
-  public void shouldNotValidateUrlByApiRequest() {
+  public void shouldNotValidateUrlByApiRequestWithBadRequest() {
     // given
+    bitbucketURLParser =
+        new BitbucketServerURLParser(
+            null, devfileFilenamesProvider, oAuthAPI, mock(PersonalAccessTokenManager.class));
     String url = wireMockServer.url("/users/user/repos/repo");
     stubFor(
-        get(urlEqualTo("/plugins/servlet/applinks/whoami"))
-            .willReturn(aResponse().withStatus(500)));
+        get(urlEqualTo("/rest/api/1.0/application-properties"))
+            .willReturn(aResponse().withStatus(400)));
+
+    // when
+    boolean result = bitbucketURLParser.isValid(url);
+
+    // then
+    assertFalse(result);
+  }
+
+  @Test
+  public void shouldNotValidateUrlByApiRequestWithEmptyData() {
+    // given
+    bitbucketURLParser =
+        new BitbucketServerURLParser(
+            null, devfileFilenamesProvider, oAuthAPI, mock(PersonalAccessTokenManager.class));
+    String url = wireMockServer.url("/users/user/repos/repo");
+    stubFor(
+        get(urlEqualTo("/rest/api/1.0/application-properties"))
+            .willReturn(aResponse().withBody("")));
+
+    // when
+    boolean result = bitbucketURLParser.isValid(url);
+
+    // then
+    assertFalse(result);
+  }
+
+  @Test
+  public void shouldNotValidateUrlByApiRequestWithEmptyHeader() {
+    // given
+    bitbucketURLParser =
+        new BitbucketServerURLParser(
+            null, devfileFilenamesProvider, oAuthAPI, mock(PersonalAccessTokenManager.class));
+    String url = wireMockServer.url("/users/user/repos/repo");
+    stubFor(
+        get(urlEqualTo("/rest/api/1.0/application-properties"))
+            .willReturn(aResponse().withStatus(200)));
 
     // when
     boolean result = bitbucketURLParser.isValid(url);

--- a/wsmaster/che-core-api-factory-bitbucket-server/src/test/java/org/eclipse/che/api/factory/server/bitbucket/HttpBitbucketServerApiClientTest.java
+++ b/wsmaster/che-core-api-factory-bitbucket-server/src/test/java/org/eclipse/che/api/factory/server/bitbucket/HttpBitbucketServerApiClientTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012-2024 Red Hat, Inc.
+ * Copyright (c) 2012-2025 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/
@@ -102,8 +102,8 @@ public class HttpBitbucketServerApiClientTest {
             oAuthAPI,
             apiEndpoint);
     stubFor(
-        get(urlEqualTo("/plugins/servlet/applinks/whoami"))
-            .willReturn(aResponse().withBody("ksmster")));
+        get(urlEqualTo("/rest/api/1.0/application-properties"))
+            .willReturn(aResponse().withHeader("x-ausername", "ksmster")));
   }
 
   @AfterMethod
@@ -354,7 +354,20 @@ public class HttpBitbucketServerApiClientTest {
       throws ScmCommunicationException, ScmUnauthorizedException, ScmItemNotFoundException {
     // given
     stubFor(
-        get(urlEqualTo("/plugins/servlet/applinks/whoami")).willReturn(aResponse().withBody("")));
+        get(urlEqualTo("/rest/api/1.0/application-properties"))
+            .willReturn(
+                aResponse()
+                    .withBodyFile("bitbucket/rest/api.1.0.application-properties/response.json")));
+
+    // when
+    bitbucketServer.getUser();
+  }
+
+  @Test(expectedExceptions = ScmCommunicationException.class)
+  public void shouldBeAbleToThrowScmCommunicationExceptionOnGetUser()
+      throws ScmCommunicationException, ScmUnauthorizedException, ScmItemNotFoundException {
+    // given
+    stubFor(get(urlEqualTo("/rest/api/1.0/application-properties")).willReturn(aResponse()));
 
     // when
     bitbucketServer.getUser();

--- a/wsmaster/che-core-api-factory-bitbucket-server/src/test/resources/__files/bitbucket/rest/api.1.0.application-properties/response.json
+++ b/wsmaster/che-core-api-factory-bitbucket-server/src/test/resources/__files/bitbucket/rest/api.1.0.application-properties/response.json
@@ -1,0 +1,6 @@
+{
+  "version": "8.7.0",
+  "buildNumber": 8007000,
+  "buildDate": 1672975062662,
+  "displayName": "Bitbucket"
+}


### PR DESCRIPTION
Since Bitbucket Server version 8.19.14, the /plugins/servlet/applinks/whoami request does not return username, if PAT is used. Change the getUser() request to /rest/api/1.0/application-properties instead and extract the username from the response headers.

<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests
-->

### What does this PR do?
backport from https://github.com/eclipse-che/che-server/pull/790

### Screenshot/screencast of this PR
<!-- Please include a screenshot or a screencast explaining what is doing this PR -->


### What issues does this PR fix or reference?
<!-- Please include any related issue from eclipse che repository (or from another issue tracker).
     Include link to other pull requests like documentation PR from [the docs repo](https://github.com/eclipse/che-docs)
-->


### How to test this PR?
<!-- Please explain for example :
  - The test platform (openshift, kubernetes, minikube, CodeReady Container, docker-desktop, etc)
  - Installation method: chectl / che-operator
  - steps to reproduce
 -->


### PR Checklist

[As the author of this Pull Request I made sure that:](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#pull-request-template-and-its-checklist)

- [ ] [The Eclipse Contributor Agreement is valid](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-eclipse-contributor-agreement-is-valid)
- [ ] [Code produced is complete](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-produced-is-complete)
- [ ] [Code builds without errors](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-builds-without-errors)
- [ ] [Tests are covering the bugfix](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#tests-are-covering-the-bugfix)
- [ ] [The repository devfile is up to date and works](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-repository-devfile-is-up-to-date-and-works)
- [ ] [Sections `What issues does this PR fix or reference` and `How to test this PR` completed](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#sections-what-issues-does-this-pr-fix-or-reference-and-how-to-test-this-pr-completed)
- [ ] [Relevant user documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [Relevant contributing documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [CI/CD changes implemented, documented and communicated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#cicd-changes-implemented-documented-and-communicated)

### Release Notes

### Reviewers

Reviewers, please comment how you tested the PR when approving it.
