### PR TITLE
Do not generate PAT for Bitbucket Server oAuth token

### DIFF
--- a/wsmaster/che-core-api-factory-bitbucket-server/src/main/java/org/eclipse/che/api/factory/server/bitbucket/HttpBitbucketServerApiClient.java
+++ b/wsmaster/che-core-api-factory-bitbucket-server/src/main/java/org/eclipse/che/api/factory/server/bitbucket/HttpBitbucketServerApiClient.java
@@ -15,6 +15,7 @@ import static com.google.common.base.Strings.isNullOrEmpty;
 import static java.net.HttpURLConnection.HTTP_BAD_REQUEST;
 import static java.net.HttpURLConnection.HTTP_NOT_FOUND;
 import static java.net.HttpURLConnection.HTTP_UNAUTHORIZED;
+import static java.nio.charset.StandardCharsets.UTF_8;
 import static java.time.Duration.ofSeconds;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
@@ -31,6 +32,7 @@ import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.io.UncheckedIOException;
 import java.net.URI;
+import java.net.URLDecoder;
 import java.net.http.HttpClient;
 import java.net.http.HttpRequest;
 import java.net.http.HttpResponse;
@@ -309,7 +311,7 @@ public class HttpBitbucketServerApiClient implements BitbucketServerApiClient {
       throw new ScmCommunicationException(e.getMessage(), e);
     }
 
-    String username = getUsername(response);
+    String username = URLDecoder.decode(getUsername(response), UTF_8);
 
     try {
       List<BitbucketUser> users =

--- a/wsmaster/che-core-api-factory-bitbucket-server/src/test/java/org/eclipse/che/api/factory/server/bitbucket/BitbucketServerPersonalAccessTokenFetcherTest.java
+++ b/wsmaster/che-core-api-factory-bitbucket-server/src/test/java/org/eclipse/che/api/factory/server/bitbucket/BitbucketServerPersonalAccessTokenFetcherTest.java
@@ -157,6 +157,24 @@ public class BitbucketServerPersonalAccessTokenFetcherTest {
   }
 
   @Test
+  public void shouldRefreshPersonalAccessToken() throws Exception {
+    // given
+    when(bitbucketServerApiClient.isConnected(eq(someBitbucketURL))).thenReturn(true);
+    when(bitbucketServerApiClient.getUser()).thenReturn(bitbucketUser);
+    when(oAuthToken.getToken()).thenReturn("token");
+    when(oAuthAPI.refreshToken(eq("bitbucket-server"))).thenReturn(oAuthToken);
+    // when
+    PersonalAccessToken result = fetcher.refreshPersonalAccessToken(subject, someBitbucketURL);
+    // then
+    assertNotNull(result);
+    assertEquals(result.getScmProviderUrl(), someBitbucketURL);
+    assertEquals(result.getCheUserId(), subject.getUserId());
+    assertNull(result.getScmOrganization(), bitbucketUser.getName());
+    assertTrue(result.getScmTokenId().startsWith("id-"));
+    assertEquals(result.getToken(), "token");
+  }
+
+  @Test
   public void shouldSkipToValidateTokensWithUnknownUrls()
       throws ScmUnauthorizedException, ScmCommunicationException, ForbiddenException,
           ServerException, ConflictException, UnauthorizedException, NotFoundException,

--- a/wsmaster/che-core-api-factory-bitbucket-server/src/test/java/org/eclipse/che/api/factory/server/bitbucket/HttpBitbucketServerApiClientTest.java
+++ b/wsmaster/che-core-api-factory-bitbucket-server/src/test/java/org/eclipse/che/api/factory/server/bitbucket/HttpBitbucketServerApiClientTest.java
@@ -137,6 +137,27 @@ public class HttpBitbucketServerApiClientTest {
   }
 
   @Test
+  public void shouldGetUserWithSpecialCharacters()
+      throws ScmItemNotFoundException, ScmUnauthorizedException, ScmCommunicationException {
+    stubFor(
+        get(urlEqualTo("/rest/api/1.0/application-properties"))
+            .willReturn(aResponse().withHeader("x-ausername", "user%40email.com")));
+    stubFor(
+        get(urlEqualTo("/rest/api/1.0/users?start=0&limit=25&filter=user@email.com"))
+            .withHeader(HttpHeaders.AUTHORIZATION, equalTo(AUTHORIZATION_TOKEN))
+            .withQueryParam("start", equalTo("0"))
+            .withQueryParam("limit", equalTo("25"))
+            .withQueryParam("filter", equalTo("user@email.com"))
+            .willReturn(
+                aResponse()
+                    .withHeader("Content-Type", "application/json; charset=utf-8")
+                    .withBodyFile("bitbucket/rest/api/1.0/users/email-user/response.json")));
+
+    BitbucketUser user = bitbucketServer.getUser();
+    assertNotNull(user);
+  }
+
+  @Test
   public void testGetUsers()
       throws ScmCommunicationException, ScmBadRequestException, ScmUnauthorizedException {
     stubFor(

--- a/wsmaster/che-core-api-factory-bitbucket-server/src/test/resources/__files/bitbucket/rest/api/1.0/users/email-user/response.json
+++ b/wsmaster/che-core-api-factory-bitbucket-server/src/test/resources/__files/bitbucket/rest/api/1.0/users/email-user/response.json
@@ -1,0 +1,24 @@
+{
+  "size": 1,
+  "limit": 3,
+  "isLastPage": true,
+  "values": [
+    {
+      "name": "user@email.com",
+      "emailAddress": "user@email.com",
+      "id": 58,
+      "displayName": "user",
+      "active": true,
+      "slug": "user@email.com",
+      "type": "NORMAL",
+      "links": {
+        "self": [
+          {
+            "href": "https://bitbucket-bitbucket.apps.cluster-devtools-c9ac.devtools-c9ac.example.opentlc.com/users/user%40email.com"
+          }
+        ]
+      }
+    }
+  ],
+  "start": 9
+}


### PR DESCRIPTION
<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests
-->

### What does this PR do?
Currently, when we generate a Bitbucket Server oAuth token secret, we create a Personal Access Token in the Bitbucket Server user account, using the oAuth token, and then we use the new PAT token. With this pull request, we remove the redundant PAT generation and store original oAuth token in the token secret.

This fixes the problem when Bitbucket Server user has special characters in its username. When oAuth token is used, we do not store username in the related credentials secret.

### Screenshot/screencast of this PR
<!-- Please include a screenshot or a screencast explaining what is doing this PR -->


### What issues does this PR fix or reference?
<!-- Please include any related issue from eclipse che repository (or from another issue tracker).
     Include link to other pull requests like documentation PR from [the docs repo](https://github.com/eclipse/che-docs)
-->
https://issues.redhat.com/browse/CRW-4560

### How to test this PR?
<!-- Please explain for example :
  - The test platform (openshift, kubernetes, minikube, CodeReady Container, docker-desktop, etc)
  - Installation method: chectl / che-operator
  - steps to reproduce
 -->
1. Deploy che from the pull request image: `quay.io/eclipse/che-server:pr-795`
2. In a Bitbucket Server instance create a user with username in a email format e.g. `user@email.com`
3. Configure [oAuth for the Bitbucket Server](https://eclipse.dev/che/docs/stable/administration-guide/configuring-oauth-2-for-a-bitbucket-server/) instance.
4. Start a workspace from the Bitbucket Server repository, consent the authorization agreement.

See: workspace starts with cloned project, oAuth token is added to the user namespace.

### PR Checklist

[As the author of this Pull Request I made sure that:](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#pull-request-template-and-its-checklist)

- [ ] [The Eclipse Contributor Agreement is valid](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-eclipse-contributor-agreement-is-valid)
- [ ] [Code produced is complete](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-produced-is-complete)
- [ ] [Code builds without errors](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-builds-without-errors)
- [ ] [Tests are covering the bugfix](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#tests-are-covering-the-bugfix)
- [ ] [The repository devfile is up to date and works](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-repository-devfile-is-up-to-date-and-works)
- [ ] [Sections `What issues does this PR fix or reference` and `How to test this PR` completed](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#sections-what-issues-does-this-pr-fix-or-reference-and-how-to-test-this-pr-completed)
- [ ] [Relevant user documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [Relevant contributing documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [CI/CD changes implemented, documented and communicated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#cicd-changes-implemented-documented-and-communicated)

### Release Notes

### Reviewers

Reviewers, please comment how you tested the PR when approving it.
