### PR TITLE
Reduce the RAW url resolver to yaml content check only

### DIFF
--- a/.ci/openshift-ci/test-azure-no-pat-oauth-flow-raw-devfile-url.sh
+++ b/.ci/openshift-ci/test-azure-no-pat-oauth-flow-raw-devfile-url.sh
@@ -29,7 +29,7 @@ trap "catchFinish" EXIT SIGINT
 
 setupTestEnvironment ${OCP_NON_ADMIN_USER_NAME}
 testFactoryResolverResponse ${PUBLIC_REPO_RAW_PATH_URL} 200
-testFactoryResolverResponse ${PRIVATE_REPO_RAW_PATH_URL} 500
+testFactoryResolverResponse ${PRIVATE_REPO_RAW_PATH_URL} 400
 
 testCloneGitRepoNoProjectExists ${PUBLIC_REPO_WORKSPACE_NAME} ${PUBLIC_PROJECT_NAME} ${PUBLIC_REPO_RAW_PATH_URL} ${USER_CHE_NAMESPACE}
 deleteTestWorkspace ${PUBLIC_REPO_WORKSPACE_NAME} ${USER_CHE_NAMESPACE}

--- a/wsmaster/che-core-api-factory/src/main/java/org/eclipse/che/api/factory/server/RawDevfileUrlFactoryParameterResolver.java
+++ b/wsmaster/che-core-api-factory/src/main/java/org/eclipse/che/api/factory/server/RawDevfileUrlFactoryParameterResolver.java
@@ -13,7 +13,7 @@ package org.eclipse.che.api.factory.server;
 
 import static com.google.common.base.Strings.isNullOrEmpty;
 import static java.lang.String.format;
-import static org.eclipse.che.api.factory.server.FactoryResolverPriority.LOWEST;
+import static org.eclipse.che.api.factory.server.FactoryResolverPriority.HIGHEST;
 import static org.eclipse.che.api.factory.shared.Constants.URL_PARAMETER_NAME;
 
 import com.fasterxml.jackson.databind.JsonNode;
@@ -24,7 +24,6 @@ import java.net.URI;
 import java.net.URISyntaxException;
 import java.net.URL;
 import java.util.Map;
-import java.util.regex.Pattern;
 import javax.inject.Inject;
 import org.eclipse.che.api.core.ApiException;
 import org.eclipse.che.api.core.BadRequestException;
@@ -45,8 +44,6 @@ public class RawDevfileUrlFactoryParameterResolver extends BaseFactoryParameterR
     implements FactoryParametersResolver {
 
   private static final String PROVIDER_NAME = "raw-devfile-url";
-  private static final Pattern PATTERN =
-      Pattern.compile("^https?://.*\\.ya?ml((\\?token=.*)|(\\?at=refs/heads/.*))?$");
 
   protected final URLFactoryBuilder urlFactoryBuilder;
   protected final URLFetcher urlFetcher;
@@ -71,7 +68,7 @@ public class RawDevfileUrlFactoryParameterResolver extends BaseFactoryParameterR
   @Override
   public boolean accept(Map<String, String> factoryParameters) {
     String url = factoryParameters.get(URL_PARAMETER_NAME);
-    return !isNullOrEmpty(url) && (PATTERN.matcher(url).matches() || containsYaml(url));
+    return !isNullOrEmpty(url) && containsYaml(url);
   }
 
   private boolean containsYaml(String requestURL) {
@@ -128,6 +125,6 @@ public class RawDevfileUrlFactoryParameterResolver extends BaseFactoryParameterR
 
   @Override
   public FactoryResolverPriority priority() {
-    return LOWEST;
+    return HIGHEST;
   }
 }

--- a/wsmaster/che-core-api-factory/src/test/java/org/eclipse/che/api/factory/server/RawDevfileUrlFactoryParameterResolverTest.java
+++ b/wsmaster/che-core-api-factory/src/test/java/org/eclipse/che/api/factory/server/RawDevfileUrlFactoryParameterResolverTest.java
@@ -27,6 +27,7 @@ import static org.testng.AssertJUnit.assertTrue;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import java.io.FileNotFoundException;
+import java.util.Base64;
 import java.util.HashMap;
 import java.util.Map;
 import org.eclipse.che.api.core.BadRequestException;
@@ -114,7 +115,7 @@ public class RawDevfileUrlFactoryParameterResolverTest {
   public void shouldAcceptRawDevfileUrl(String url) throws Exception {
     // given
     JsonNode jsonNode = mock(JsonNode.class);
-    when(urlFetcher.fetch(eq(url))).thenReturn(DEVFILE);
+    when(urlFetcher.fetch(eq(url), eq(null))).thenReturn(DEVFILE);
     when(devfileParser.parseYamlRaw(eq(DEVFILE))).thenReturn(jsonNode);
     when(jsonNode.isEmpty()).thenReturn(false);
 
@@ -130,7 +131,7 @@ public class RawDevfileUrlFactoryParameterResolverTest {
   public void shouldAcceptRawDevfileUrlWithoutExtension(String url) throws Exception {
     // given
     JsonNode jsonNode = mock(JsonNode.class);
-    when(urlFetcher.fetch(eq(url))).thenReturn(DEVFILE);
+    when(urlFetcher.fetch(eq(url), eq(null))).thenReturn(DEVFILE);
     when(devfileParser.parseYamlRaw(eq(DEVFILE))).thenReturn(jsonNode);
     when(jsonNode.isEmpty()).thenReturn(false);
 
@@ -147,7 +148,26 @@ public class RawDevfileUrlFactoryParameterResolverTest {
     // given
     JsonNode jsonNode = mock(JsonNode.class);
     String url = "https://host/path/devfile";
-    when(urlFetcher.fetch(eq(url))).thenReturn(DEVFILE);
+    when(urlFetcher.fetch(eq(url), eq(null))).thenReturn(DEVFILE);
+    when(devfileParser.parseYamlRaw(eq(DEVFILE))).thenReturn(jsonNode);
+    when(jsonNode.isEmpty()).thenReturn(false);
+
+    // when
+    boolean result =
+        rawDevfileUrlFactoryParameterResolver.accept(singletonMap(URL_PARAMETER_NAME, url));
+
+    // then
+    assertTrue(result);
+  }
+
+  @Test
+  public void shouldAcceptRawDevfileUrlWithCredentials() throws Exception {
+    // given
+    JsonNode jsonNode = mock(JsonNode.class);
+    String url = "https://credentials@host/path/devfile";
+    when(urlFetcher.fetch(
+            eq(url), eq("Basic " + Base64.getEncoder().encodeToString("credentials:".getBytes()))))
+        .thenReturn(DEVFILE);
     when(devfileParser.parseYamlRaw(eq(DEVFILE))).thenReturn(jsonNode);
     when(jsonNode.isEmpty()).thenReturn(false);
 
@@ -164,7 +184,7 @@ public class RawDevfileUrlFactoryParameterResolverTest {
     // given
     JsonNode jsonNode = mock(JsonNode.class);
     String gitRepositoryUrl = "https://host/user/repo.git";
-    when(urlFetcher.fetch(eq(gitRepositoryUrl))).thenReturn("unsupported content");
+    when(urlFetcher.fetch(eq(gitRepositoryUrl), eq(null))).thenReturn("unsupported content");
     when(devfileParser.parseYamlRaw(eq("unsupported content"))).thenReturn(jsonNode);
     when(jsonNode.isEmpty()).thenReturn(true);
 
@@ -181,7 +201,7 @@ public class RawDevfileUrlFactoryParameterResolverTest {
   public void shouldNotAcceptPrivateGitRepositoryUrl() throws Exception {
     // given
     String gitRepositoryUrl = "https://host/user/private-repo.git";
-    when(urlFetcher.fetch(eq(gitRepositoryUrl))).thenThrow(new FileNotFoundException());
+    when(urlFetcher.fetch(eq(gitRepositoryUrl), eq(null))).thenThrow(new FileNotFoundException());
 
     // when
     boolean result =

--- a/wsmaster/che-core-api-factory/src/test/java/org/eclipse/che/api/factory/server/RawDevfileUrlFactoryParameterResolverTest.java
+++ b/wsmaster/che-core-api-factory/src/test/java/org/eclipse/che/api/factory/server/RawDevfileUrlFactoryParameterResolverTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012-2024 Red Hat, Inc.
+ * Copyright (c) 2012-2025 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/
@@ -111,7 +111,13 @@ public class RawDevfileUrlFactoryParameterResolverTest {
   }
 
   @Test(dataProvider = "devfileUrls")
-  public void shouldAcceptRawDevfileUrl(String url) {
+  public void shouldAcceptRawDevfileUrl(String url) throws Exception {
+    // given
+    JsonNode jsonNode = mock(JsonNode.class);
+    when(urlFetcher.fetch(eq(url))).thenReturn(DEVFILE);
+    when(devfileParser.parseYamlRaw(eq(DEVFILE))).thenReturn(jsonNode);
+    when(jsonNode.isEmpty()).thenReturn(false);
+
     // when
     boolean result =
         rawDevfileUrlFactoryParameterResolver.accept(singletonMap(URL_PARAMETER_NAME, url));


### PR DESCRIPTION
<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests
-->

### What does this PR do?
Remove the RAW url pattern check from the RAW devfile url resolver, to have only the yaml content check. This is needed to revert the resolver priority to highest, and do not accept urls like `https://github.com/vinokurig/test/blob/master/path/devfile.yaml`. See https://github.com/eclipse-che/che-server/pull/793

### Screenshot/screencast of this PR
<!-- Please include a screenshot or a screencast explaining what is doing this PR -->


### What issues does this PR fix or reference?
<!-- Please include any related issue from eclipse che repository (or from another issue tracker).
     Include link to other pull requests like documentation PR from [the docs repo](https://github.com/eclipse/che-docs)
-->
fixes https://github.com/eclipse-che/che/issues/23433

### How to test this PR?
<!-- Please explain for example :
  - The test platform (openshift, kubernetes, minikube, CodeReady Container, docker-desktop, etc)
  - Installation method: chectl / che-operator
  - steps to reproduce
 -->
1. Deploy che with the pull request image: `quay.io/eclipse/che-server:pr-`
2. Start a workspace from the following urls:
* Gitlab RAW devfile url: `https://gitlab.com/ivinokur/test/-/raw/main/.dfile.yaml`
* Gtilab RAW devfile API request: `<gitlab server url>/api/v4/projects/2/repository/files/devfile.yaml/raw?ref=main&private_token=<Personal Access Token>`
* Github repository devfile url: `https://github.com/vinokurig/test/blob/master/path/devfile.yaml`

See: workspace starts from the devfile.

### PR Checklist

[As the author of this Pull Request I made sure that:](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#pull-request-template-and-its-checklist)

- [ ] [The Eclipse Contributor Agreement is valid](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-eclipse-contributor-agreement-is-valid)
- [ ] [Code produced is complete](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-produced-is-complete)
- [ ] [Code builds without errors](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-builds-without-errors)
- [ ] [Tests are covering the bugfix](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#tests-are-covering-the-bugfix)
- [ ] [The repository devfile is up to date and works](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-repository-devfile-is-up-to-date-and-works)
- [ ] [Sections `What issues does this PR fix or reference` and `How to test this PR` completed](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#sections-what-issues-does-this-pr-fix-or-reference-and-how-to-test-this-pr-completed)
- [ ] [Relevant user documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [Relevant contributing documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [CI/CD changes implemented, documented and communicated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#cicd-changes-implemented-documented-and-communicated)

### Release Notes

### Reviewers

Reviewers, please comment how you tested the PR when approving it.
