### PR TITLE
Additionally encode Bitbucket Server authentication url state

### DIFF
--- a/wsmaster/che-core-api-auth-bitbucket/src/main/java/org/eclipse/che/security/oauth/BitbucketOAuthAuthenticator.java
+++ b/wsmaster/che-core-api-auth-bitbucket/src/main/java/org/eclipse/che/security/oauth/BitbucketOAuthAuthenticator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012-2024 Red Hat, Inc.
+ * Copyright (c) 2012-2025 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/
@@ -12,6 +12,7 @@
 package org.eclipse.che.security.oauth;
 
 import static com.google.common.base.Strings.isNullOrEmpty;
+import static java.net.URLEncoder.encode;
 import static java.nio.charset.StandardCharsets.UTF_8;
 
 import com.google.api.client.auth.oauth2.AuthorizationCodeRequestUrl;
@@ -49,7 +50,10 @@ public class BitbucketOAuthAuthenticator extends OAuthAuthenticator {
   @Override
   public String getAuthenticateUrl(URL requestUrl, List<String> scopes) {
     AuthorizationCodeRequestUrl url = flow.newAuthorizationUrl().setScopes(scopes);
-    url.setState(prepareState(requestUrl));
+    String state = prepareState(requestUrl);
+    // Although the state is encoded in the OAuthAuthenticator class, we need to additionally encode
+    // it because Bitbucket Server decodes it on callback request.
+    url.setState(BITBUCKET_CLOUD_ENDPOINT.equals(bitbucketEndpoint) ? state : encode(state, UTF_8));
     url.set("redirect_uri", findRedirectUrl(requestUrl));
     return url.build();
   }

--- a/wsmaster/che-core-api-auth-bitbucket/src/test/java/org/eclipse/che/security/BitbucketOAuthAuthenticatorProviderTest.java
+++ b/wsmaster/che-core-api-auth-bitbucket/src/test/java/org/eclipse/che/security/BitbucketOAuthAuthenticatorProviderTest.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright (c) 2012-2025 Red Hat, Inc.
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+package org.eclipse.che.security;
+
+import static java.util.Collections.emptyList;
+import static org.testng.Assert.assertTrue;
+
+import com.google.common.io.Files;
+import java.io.File;
+import java.io.IOException;
+import java.net.URL;
+import java.nio.charset.Charset;
+import org.eclipse.che.security.oauth.BitbucketOAuthAuthenticatorProvider;
+import org.eclipse.che.security.oauth.OAuthAuthenticator;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+public class BitbucketOAuthAuthenticatorProviderTest {
+  private BitbucketOAuthAuthenticatorProvider provider;
+  private File cfgFile;
+
+  @BeforeClass
+  public void setup() throws IOException {
+    cfgFile = File.createTempFile("BitbucketOAuthAuthenticatorProviderTest-", "-cfg");
+    Files.asCharSink(cfgFile, Charset.defaultCharset()).write("tmp-data");
+    cfgFile.deleteOnExit();
+    provider =
+        new BitbucketOAuthAuthenticatorProvider(
+            "http://bitubucket-server.com",
+            cfgFile.getPath(),
+            cfgFile.getPath(),
+            new String[] {"http://che.server.com"},
+            "http://auth.uri",
+            "http://token.uri");
+  }
+
+  @Test
+  public void shouldReturnAuthenticationUrlEncodedOnce() throws Exception {
+    // given
+    BitbucketOAuthAuthenticatorProvider provider =
+        new BitbucketOAuthAuthenticatorProvider(
+            "https://bitbucket.org",
+            cfgFile.getPath(),
+            cfgFile.getPath(),
+            new String[] {"http://che.server.com"},
+            "http://auth.uri",
+            "http://token.uri");
+    OAuthAuthenticator authenticator = provider.get();
+    URL url = new URL("http://che.server.com?query=param");
+    // when
+    String authenticateUrl = authenticator.getAuthenticateUrl(url, emptyList());
+    // then
+    assertTrue(authenticateUrl.endsWith("&state=query%253Dparam"));
+  }
+
+  @Test
+  public void shouldReturnAuthenticationUrlEncodedTwice() throws Exception {
+    // given
+    OAuthAuthenticator authenticator = provider.get();
+    URL url = new URL("http://che.server.com?query=param");
+    // when
+    String authenticateUrl = authenticator.getAuthenticateUrl(url, emptyList());
+    // then
+    assertTrue(authenticateUrl.endsWith("&state=query%25253Dparam"));
+  }
+}


### PR DESCRIPTION
<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests
-->

### What does this PR do?
Encode the Bitbucket Server authentication url twice, because Bitbucket Server Decodes the callback url request.

### Screenshot/screencast of this PR
<!-- Please include a screenshot or a screencast explaining what is doing this PR -->


### What issues does this PR fix or reference?
<!-- Please include any related issue from eclipse che repository (or from another issue tracker).
     Include link to other pull requests like documentation PR from [the docs repo](https://github.com/eclipse/che-docs)
-->
https://issues.redhat.com/browse/CRW-8862

### How to test this PR?
<!-- Please explain for example :
  - The test platform (openshift, kubernetes, minikube, CodeReady Container, docker-desktop, etc)
  - Installation method: chectl / che-operator
  - steps to reproduce
 -->
1. Deploy Che with the pull request image: `quay.io/eclipse/che-server:pr-808`
2. Configure [Oauth 2 for Bitbucket Server](https://eclipse.dev/che/docs/stable/administration-guide/configuring-oauth-2-for-a-bitbucket-server/) 8.19.14 or higher.
3. Logout from the Bitbucket Server account
4. Start a workspace from the Bitbucket Server repository.
5. When Che redirects to the Bitbucket Server login page, input the credentials and consent the authorization request.

See: Bitbucket Server redirects back to the Workspace load page, Bitbucket Server token is added to the user namespace.


### PR Checklist

[As the author of this Pull Request I made sure that:](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#pull-request-template-and-its-checklist)

- [ ] [The Eclipse Contributor Agreement is valid](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-eclipse-contributor-agreement-is-valid)
- [ ] [Code produced is complete](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-produced-is-complete)
- [ ] [Code builds without errors](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-builds-without-errors)
- [ ] [Tests are covering the bugfix](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#tests-are-covering-the-bugfix)
- [ ] [The repository devfile is up to date and works](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-repository-devfile-is-up-to-date-and-works)
- [ ] [Sections `What issues does this PR fix or reference` and `How to test this PR` completed](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#sections-what-issues-does-this-pr-fix-or-reference-and-how-to-test-this-pr-completed)
- [ ] [Relevant user documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [Relevant contributing documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [CI/CD changes implemented, documented and communicated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#cicd-changes-implemented-documented-and-communicated)

### Release Notes

### Reviewers

Reviewers, please comment how you tested the PR when approving it.
