### PR TITLE
Fix error when parsing SSH url without port.

### DIFF
--- a/wsmaster/che-core-api-factory-azure-devops/src/main/java/org/eclipse/che/api/factory/server/azure/devops/AzureDevOpsURLParser.java
+++ b/wsmaster/che-core-api-factory-azure-devops/src/main/java/org/eclipse/che/api/factory/server/azure/devops/AzureDevOpsURLParser.java
@@ -54,7 +54,7 @@ public class AzureDevOpsURLParser {
   private final String azureSSHDevOpsPatternTemplate =
       "^git@ssh\\.%s:v3/(?<organization>.*)/(?<project>.*)/(?<repoName>.*)$";
   private final String azureSSHDevOpsServerPatternTemplate =
-      "^ssh://%s:22/(?<organization>.*)/(?<project>.*)/_git/(?<repoName>.*)$";
+      "^ssh://%s(:\\d*)?/(?<organization>.*)/(?<project>.*)/_git/(?<repoName>.*)$";
   private final String azureDevOpsPatternTemplate =
       "^https?://(?<organizationCanIgnore>[^@]++)?@?%s/(?<organization>[^/]++)/((?<project>[^/]++)/)?_git/"
           + "(?<repoName>[^?]++)"
@@ -119,7 +119,10 @@ public class AzureDevOpsURLParser {
       substring = repositoryUrl.substring(6);
     }
     if (!isNullOrEmpty(substring)) {
-      return Optional.of("https://" + substring.substring(0, substring.indexOf(":")));
+      return Optional.of(
+          "https://"
+              + substring.substring(
+                  0, substring.contains(":") ? substring.indexOf(":") : substring.indexOf("/")));
     }
     // Otherwise, extract the base url from the given repository url by cutting the url after the
     // first slash.

--- a/wsmaster/che-core-api-factory-azure-devops/src/test/java/org/eclipse/che/api/factory/server/azure/devops/AzureDevOpsURLParserTest.java
+++ b/wsmaster/che-core-api-factory-azure-devops/src/test/java/org/eclipse/che/api/factory/server/azure/devops/AzureDevOpsURLParserTest.java
@@ -269,6 +269,14 @@ public class AzureDevOpsURLParserTest {
         null
       },
       {
+        "ssh://dev.azure-server.com/MyOrg/MyProject/_git/MyRepo",
+        "MyOrg",
+        "MyProject",
+        "MyRepo",
+        null,
+        null
+      },
+      {
         "ssh://dev.azure-server.com:22/MyOrg/MyProject/_git/MyRepo",
         "MyOrg",
         "MyProject",

--- a/wsmaster/che-core-api-factory-bitbucket-server/src/main/java/org/eclipse/che/api/factory/server/bitbucket/BitbucketServerURLParser.java
+++ b/wsmaster/che-core-api-factory-bitbucket-server/src/main/java/org/eclipse/che/api/factory/server/bitbucket/BitbucketServerURLParser.java
@@ -57,8 +57,8 @@ public class BitbucketServerURLParser {
           "^(?<scheme>%s)://(?<host>%s)/users/(?<user>[^/]+)/repos/(?<repo>[^/]+)/?",
           "^(?<scheme>%s)://(?<host>%s)/scm/(?<project>[^/~]+)/(?<repo>[^/]+).git",
           "^(?<scheme>%s)://(?<host>%s)/projects/(?<project>[^/]+)/repos/(?<repo>[^/]+)/browse(\\?at=(?<branch>.*))?",
-          "^(?<scheme>%s)://git@(?<host>%s):(?<port>\\d*)/~(?<user>[^/]+)/(?<repo>.*).git$",
-          "^(?<scheme>%s)://git@(?<host>%s):(?<port>\\d*)/(?<project>[^/]+)/(?<repo>.*).git$");
+          "^(?<scheme>%s)://git@(?<host>%s):?(?<port>\\d*)?/~(?<user>[^/]+)/(?<repo>.*).git$",
+          "^(?<scheme>%s)://git@(?<host>%s):?(?<port>\\d*)?/(?<project>[^/]+)/(?<repo>.*).git$");
   private final List<Pattern> bitbucketUrlPatterns = new ArrayList<>();
   private static final String OAUTH_PROVIDER_NAME = "bitbucket-server";
 
@@ -152,7 +152,9 @@ public class BitbucketServerURLParser {
   private String getServerUrl(String repositoryUrl) {
     if (repositoryUrl.startsWith("ssh://git@")) {
       String substring = repositoryUrl.substring(10);
-      return "https://" + substring.substring(0, substring.indexOf(":"));
+      return "https://"
+          + substring.substring(
+              0, substring.contains(":") ? substring.indexOf(":") : substring.indexOf("/"));
     }
     return repositoryUrl.substring(
         0,

--- a/wsmaster/che-core-api-factory-bitbucket-server/src/test/java/org/eclipse/che/api/factory/server/bitbucket/BitbucketServerURLParserTest.java
+++ b/wsmaster/che-core-api-factory-bitbucket-server/src/test/java/org/eclipse/che/api/factory/server/bitbucket/BitbucketServerURLParserTest.java
@@ -215,7 +215,9 @@ public class BitbucketServerURLParserTest {
       {"https://bitbucket.2mcl.com/users/user/repos/repo/"},
       {"https://bbkt.com/scm/project/test1.git"},
       {"ssh://git@bitbucket.2mcl.com:12345/~user/repo.git"},
-      {"ssh://git@bitbucket.2mcl.com:12345/project/test1.git"}
+      {"ssh://git@bitbucket.2mcl.com:12345/project/test1.git"},
+      {"ssh://git@bitbucket.2mcl.com/~user/repo.git"},
+      {"ssh://git@bitbucket.2mcl.com/project/test1.git"}
     };
   }
 


### PR DESCRIPTION
<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests
-->

### What does this PR do?
When we parse SSH urls, we extract the server url from it by extracting the string after `ssh://git@` to `:<port>/...`. If the provider url does not contain port, e.g. `ssh://git@<hostname>/user/repo` an error occurs.

Rework the extract server functions to respect urls without port.

### Screenshot/screencast of this PR
<!-- Please include a screenshot or a screencast explaining what is doing this PR -->


### What issues does this PR fix or reference?
<!-- Please include any related issue from eclipse che repository (or from another issue tracker).
     Include link to other pull requests like documentation PR from [the docs repo](https://github.com/eclipse/che-docs)
-->
https://issues.redhat.com/browse/CRW-8301

### How to test this PR?
<!-- Please explain for example :
  - The test platform (openshift, kubernetes, minikube, CodeReady Container, docker-desktop, etc)
  - Installation method: chectl / che-operator
  - steps to reproduce
 -->
1. Add an SSH key to the user namespace.
2. Start a workspace from an SSH url in format `ssh://git@<hostname>/user/repo` e.g `ssh://git@bitbucket-server/user/repo.git`.

See: the url is resolved and workspace starts.

### PR Checklist

[As the author of this Pull Request I made sure that:](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#pull-request-template-and-its-checklist)

- [ ] [The Eclipse Contributor Agreement is valid](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-eclipse-contributor-agreement-is-valid)
- [ ] [Code produced is complete](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-produced-is-complete)
- [ ] [Code builds without errors](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-builds-without-errors)
- [ ] [Tests are covering the bugfix](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#tests-are-covering-the-bugfix)
- [ ] [The repository devfile is up to date and works](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-repository-devfile-is-up-to-date-and-works)
- [ ] [Sections `What issues does this PR fix or reference` and `How to test this PR` completed](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#sections-what-issues-does-this-pr-fix-or-reference-and-how-to-test-this-pr-completed)
- [ ] [Relevant user documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [Relevant contributing documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [CI/CD changes implemented, documented and communicated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#cicd-changes-implemented-documented-and-communicated)

### Release Notes

### Reviewers

Reviewers, please comment how you tested the PR when approving it.
