### PR TITLE
Enable Che Server Build Support on s390x Architecture

### DIFF
--- a/.github/workflows/build-pr-check.yml
+++ b/.github/workflows/build-pr-check.yml
@@ -55,4 +55,4 @@ jobs:
         DEVELOCITY_ACCESS_KEY: ${{ secrets.DEVELOCITY_API_TOKEN }}
     - name: Build and push images
       if: ${{ github.event_name == 'pull_request' && ! github.event.pull_request.head.repo.fork }}
-      run: ./build/build.sh --tag:${{ env.PR_IMAGE_TAG }} --build-platforms:linux/amd64,linux/ppc64le,linux/arm64 --builder:podman --push-image
+      run: ./build/build.sh --tag:${{ env.PR_IMAGE_TAG }} --build-platforms:linux/amd64,linux/ppc64le,linux/arm64,linux/s390x --builder:podman --push-image

--- a/.github/workflows/next-build.yml
+++ b/.github/workflows/next-build.yml
@@ -50,7 +50,7 @@ jobs:
       id: build
       run: |
           echo "short_sha1=$(git rev-parse --short HEAD)" >> $GITHUB_OUTPUT
-          ./build/build.sh --tag:next --sha-tag --build-platforms:linux/amd64,linux/ppc64le,linux/arm64 --builder:podman --push-image
+          ./build/build.sh --tag:next --sha-tag --build-platforms:linux/amd64,linux/ppc64le,linux/arm64,linux/s390x --builder:podman --push-image
     - name: Create failure MM message
       if: ${{ failure() }}
       run: |

--- a/make-release.sh
+++ b/make-release.sh
@@ -7,7 +7,7 @@ REGISTRY="quay.io"
 ORGANIZATION="eclipse"
 
 IMAGE="quay.io/eclipse/che-server"
-BUILD_PLATFORMS="linux/amd64,linux/ppc64le,linux/arm64"
+BUILD_PLATFORMS="linux/amd64,linux/ppc64le,linux/arm64,linux/s390x"
 
 sed_in_place() {
     SHORT_UNAME=$(uname -s)


### PR DESCRIPTION
<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests
-->

### What does this PR do?

This PR enables support for building the Che Server on the `s390x` architecture.  
It updates and refines architecture compatibility logic and ensures successful builds on IBM Z running RHEL 9.4 (s390x).

### Screenshot/screencast of this PR

<img width="649" alt="Screenshot 2025-06-11 at 5 45 50 PM" src="https://github.com/user-attachments/assets/f85c57b5-1227-4c52-8363-f937f511ecd8" />


### What issues does this PR fix or reference?

This is part of internal enablement for Che on `s390x` (IBM Z).  

### How to test this PR?

- **Platform**: RHEL 9.4 on `s390x` (IBM Z or QEMU emulated environment)
- **Prerequisites**:
  - Install OpenJDK (version 11 recommended)
  - Install Maven and dependencies
- **Steps**:
  1. Clone the repository and checkout this branch
  2. Run: `mvn clean install -Dfmt.skip=true`  
  3. Ensure `BUILD SUCCESS` is shown for all modules (as in the attached screenshot)

### PR Checklist

- [x] [The Eclipse Contributor Agreement is valid](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-eclipse-contributor-agreement-is-valid)
- [x] Code builds without errors on `s390x`
- [x] Verified on actual VM (IBM Z RHEL 9.4)
- [x] `What issues does this PR fix or reference` and `How to test this PR` sections completed
- [x] Tests are not required as this is architecture build compatibility only
- [ ] No devfile changes necessary
- [ ] No CI/CD changes
- [ ] Documentation not required yet; will follow once support is officialized

### Release Notes

Added support for building Che Server on the `s390x` (IBM Z) architecture.

### Reviewers

Please review the build output screenshot attached and test on `s390x` hardware if possible.
