### PR TITLE
Read self signed certificate from file instead of env variable

### DIFF
--- a/build/dockerfiles/entrypoint.sh
+++ b/build/dockerfiles/entrypoint.sh
@@ -323,9 +323,13 @@ set_truststore_system_variables() {
 }
 
 add_che_cert_to_truststore() {
-  cert_path="/self-signed-cert/ca.crt"
-  if [ -e $cert_path ]; then
-    add_cert_to_truststore "$(cat $cert_path)" "HOSTDOMAIN"
+  # Deprecated, CHE_SELF__SIGNED__CERT environment variable is not used after 7.105.0
+  if [ "${CHE_SELF__SIGNED__CERT}" != "" ]; then
+    add_cert_to_truststore "${CHE_SELF__SIGNED__CERT}" "HOSTDOMAIN"
+  fi
+  CERT_PATH="/self-signed-cert/ca.crt"
+  if [ -e $CERT_PATH ]; then
+    add_cert_to_truststore "$(cat $CERT_PATH)" "HOSTDOMAIN"
   fi
 }
 

--- a/build/dockerfiles/entrypoint.sh
+++ b/build/dockerfiles/entrypoint.sh
@@ -323,8 +323,9 @@ set_truststore_system_variables() {
 }
 
 add_che_cert_to_truststore() {
-  if [ "${CHE_SELF__SIGNED__CERT}" != "" ]; then
-    add_cert_to_truststore "${CHE_SELF__SIGNED__CERT}" "HOSTDOMAIN"
+  cert_path="/self-signed-cert/ca.crt"
+  if [ -e $cert_path ]; then
+    add_cert_to_truststore "$(cat $cert_path)" "HOSTDOMAIN"
   fi
 }
 


### PR DESCRIPTION
<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests
-->

### What does this PR do?
Align with the changes from [che-operator](https://github.com/eclipse-che/che-operator/pull/2007).

### Screenshot/screencast of this PR
<!-- Please include a screenshot or a screencast explaining what is doing this PR -->


### What issues does this PR fix or reference?
<!-- Please include any related issue from eclipse che repository (or from another issue tracker).
     Include link to other pull requests like documentation PR from [the docs repo](https://github.com/eclipse/che-docs)
-->


### How to test this PR?
<!-- Please explain for example :
  - The test platform (openshift, kubernetes, minikube, CodeReady Container, docker-desktop, etc)
  - Installation method: chectl / che-operator
  - steps to reproduce
 -->
1. Deploy che from the pull request image: `quay.io/eclipse/che-server:pr-815` and related operator image: "quay.io/**ivinokur**/che-operator:next".
2. Make sure [self signed certificate](https://eclipse.dev/che/docs/stable/administration-guide/configuring-che-with-self-signed-certificate/) secret is existed in Eclipse Che namespace.
3. When the `che` pod is installed, go to the pod logs and see the message at the beginning of the log:
```
Found a custom cert. Adding it to java trust store /home/user/cacerts based on /usr/lib/jvm/jre/lib/security/cacerts
Trust this certificate? [no]:  Certificate was added to keystore
```
4. Ensure `/self-signed-cert/ca.crt` file exists, and no `${CHE_SELF__SIGNED__CERT}` env variable is present in Che pod.

### PR Checklist

[As the author of this Pull Request I made sure that:](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#pull-request-template-and-its-checklist)

- [ ] [The Eclipse Contributor Agreement is valid](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-eclipse-contributor-agreement-is-valid)
- [ ] [Code produced is complete](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-produced-is-complete)
- [ ] [Code builds without errors](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-builds-without-errors)
- [ ] [Tests are covering the bugfix](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#tests-are-covering-the-bugfix)
- [ ] [The repository devfile is up to date and works](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-repository-devfile-is-up-to-date-and-works)
- [ ] [Sections `What issues does this PR fix or reference` and `How to test this PR` completed](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#sections-what-issues-does-this-pr-fix-or-reference-and-how-to-test-this-pr-completed)
- [ ] [Relevant user documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [Relevant contributing documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [CI/CD changes implemented, documented and communicated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#cicd-changes-implemented-documented-and-communicated)

### Release Notes

### Reviewers

Reviewers, please comment how you tested the PR when approving it.
