### PR TITLE
Add SBOM generation and upload workflow

### DIFF
--- a/.github/workflows/generate-maven-sbom.yml
+++ b/.github/workflows/generate-maven-sbom.yml
@@ -1,0 +1,65 @@
+name: Generate Maven SBOM
+
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "Version"
+        default: "main"
+        required: true
+
+env:
+  JAVA_VERSION: '11'
+  JAVA_DISTRO: 'temurin'
+  PRODUCT_PATH: './'
+  PLUGIN_VERSION: '2.7.8'
+  SBOM_TYPE: 'makeAggregateBom'
+
+permissions:
+  contents: read
+
+jobs:
+  generate-sbom:
+    runs-on: ubuntu-latest
+    outputs:
+      project-version: ${{ steps.version.outputs.PROJECT_VERSION }}
+    steps:
+      - name: Extract version
+        id: version
+        run: |
+          VERSION="${{ github.event_name == 'release' && github.event.release.tag_name || github.event.inputs.version }}"
+          echo "PROJECT_VERSION=$VERSION" >> $GITHUB_OUTPUT
+          echo "Product version: $VERSION"
+      - name: Checkout repository
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          fetch-depth: 0
+          ref: ${{ steps.version.outputs.PROJECT_VERSION }}
+
+      - name: Setup Java SDK
+        uses: actions/setup-java@c5195efecf7bdfc987ee8bae7a71cb8b11521c00 # v4.7.1
+        with:
+          java-version: ${{ env.JAVA_VERSION }}
+          distribution: ${{ env.JAVA_DISTRO }}
+
+      - name: Generate sbom
+        run: |
+          mvn org.cyclonedx:cyclonedx-maven-plugin:$PLUGIN_VERSION:$SBOM_TYPE -f "$PRODUCT_PATH/pom.xml"
+
+      - name: Upload sbom
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: sbom
+          path: ${{ env.PRODUCT_PATH }}/target/bom.json
+  
+  store-sbom-data: # stores sbom and metadata in a predefined format for otterdog to pick up
+    needs: ['generate-sbom']
+    uses: eclipse-csi/workflows/.github/workflows/store-sbom-data.yml@main
+    with:
+      projectName: 'che-server'
+      projectVersion: ${{ needs.generate-sbom.outputs.project-version }}
+      bomArtifact: 'sbom'
+      bomFilename: 'bom.json'
+      parentProject: '1ab66138-685e-47bb-9020-feb6ca1fb40c'

--- a/README.md
+++ b/README.md
@@ -50,3 +50,7 @@ Here are additional useful links with the `che-server` builds data:
 - [Trends dashboard](https://develocity-staging.eclipse.org/scans/trends?search.rootProjectNames=che%20server)
 - [Failures dashboard](https://develocity-staging.eclipse.org/scans/failures?search.rootProjectNames=che%20server)
 - Failed and flaky [Tests dashboard](https://develocity-staging.eclipse.org/scans/tests?search.rootProjectNames=che%20server)
+
+## SBOM
+
+To enhance supply chain security and offer users clear insight into project  components, Eclipse Che now generates a Software Bill of Materials (SBOM) for every release. These are published to the Eclipse Foundation SBOM registry, with access instructions and usage details available in this [documentation](https://eclipse-csi.github.io/security-handbook/sbom/registry.html).


### PR DESCRIPTION
<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests
-->

### What does this PR do?
This PR aims to bootstrap the EF Security Team initiative of supporting projects in implementing automated SBOM generation and upload workflows, with the goal of enhancing software supply chain security.

We wanted this to seamlessly integrate with your existing release processes, so we implemented 1 workflow meant to generate an SBOM for the `che-server` product.

Currently the workflow is triggered by new releases being published. A cyclonedx maven plugin (`cyclonedx-maven-plugin`) is used to generate the SBOM, which is then uploaded as an artifact. The `store-sbom-data` reusable workflow stores additional metadata about the project and upon completion, the self service system downloads the SBOM from artifacts and uploads it to our `DependencyTrack` [instance](https://sbom.eclipse.org/), under the `Eclipse Che/che-server` entry. After a successful workflow run, to view the uploaded results, you can log into the instance by using your EF account credentials.

We have tested the SBOM generation separately and everything worked successfully. However, **due to limited permissions, inability to simulate the trigger event and possibly incomplete knowledge of your release processes**, if the changes get merged, we'd ask if you could manually run it once so we can confirm the upload to our instance works as expected (for the version input the latest release tag can be used). 

For any inconsistencies or potential integration issues with existing release processes that we might have missed, please feel free to update the workflow as needed, edits by maintainers are enabled. Additionally, if maintaining multiple parallel branches for releases, a version of the workflow should run on them as well.

Please let us know if you have any questions we can help with.

### Notes for future improvements
The generated SBOM appears to contain a complete dependency graph structure at the moment, which meets our current goal. For future reference, there are a couple minor improvements that can be implemented to improve completeness.

#### Plugin warnings of dependencies that cannot be resolved
There are a couple of warning in the generation step logs such as:
```
Warning:  The following dependencies could not be resolved at this point of the build but seem to be part of the reactor:
...
```
Upon further digging this might stem from some dependencies hosted on private repositories. The SBOM plugin can list a missing dependency's own dependencies by reading its pom file, even if the actual jar cannot be downloaded. However, the plugin still attempts to download the full artifact to enrich metadata in the SBOM. If that is unavailable, the SBOM may be incomplete. A potential fix could be passing the settings.xml file to the plugin ([example](https://github.com/eclipse-syson/syson/blob/main/.github/workflows/generate-maven-sbom.yml#L61)). For this project, the file seems to be dynamically created from secret value and used in the release script, therefore we couldn't test a potential solution to this without causing disruption to existing processes.

### Screenshot/screencast of this PR
<!-- Please include a screenshot or a screencast explaining what is doing this PR -->
More details about our SBOM Early Adopters initiative at EF can be found in our [Security Handbook](https://eclipse-csi.github.io/security-handbook/sbom/index.html), alongside documentation on what is an SBOM, what are they used for, tooling ecosystem and our upload integration. Previous successful early adopters workflow examples are listed in the table at [SBOM Early Adopters](https://eclipse-csi.github.io/security-handbook/sbom/earlyadopters.html)

### What issues does this PR fix or reference?
<!-- Please include any related issue from eclipse che repository (or from another issue tracker).
     Include link to other pull requests like documentation PR from [the docs repo](https://github.com/eclipse/che-docs)
-->


### How to test this PR?
<!-- Please explain for example :
  - The test platform (openshift, kubernetes, minikube, CodeReady Container, docker-desktop, etc)
  - Installation method: chectl / che-operator
  - steps to reproduce
 -->
Manual workflow dispatch with tag number after merge.
Will automatically run after a new Github Release

### PR Checklist

[As the author of this Pull Request I made sure that:](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#pull-request-template-and-its-checklist)

- [X] [The Eclipse Contributor Agreement is valid](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-eclipse-contributor-agreement-is-valid)
- [ ] [Code produced is complete](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-produced-is-complete)
- [ ] [Code builds without errors](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-builds-without-errors)
- [ ] [Tests are covering the bugfix](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#tests-are-covering-the-bugfix)
- [ ] [The repository devfile is up to date and works](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-repository-devfile-is-up-to-date-and-works)
- [X] [Sections `What issues does this PR fix or reference` and `How to test this PR` completed](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#sections-what-issues-does-this-pr-fix-or-reference-and-how-to-test-this-pr-completed)
- [ ] [Relevant user documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [Relevant contributing documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [CI/CD changes implemented, documented and communicated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#cicd-changes-implemented-documented-and-communicated)

### Release Notes

### Reviewers

Reviewers, please comment how you tested the PR when approving it.
