### PR TITLE
Move bitbucket token name check to GitCredentialsManager

### DIFF
--- a/infrastructures/infrastructure-factory/src/main/java/org/eclipse/che/api/factory/server/scm/kubernetes/KubernetesGitCredentialManager.java
+++ b/infrastructures/infrastructure-factory/src/main/java/org/eclipse/che/api/factory/server/scm/kubernetes/KubernetesGitCredentialManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012-2023 Red Hat, Inc.
+ * Copyright (c) 2012-2025 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/
@@ -177,6 +177,11 @@ public class KubernetesGitCredentialManager implements GitCredentialManager {
     // Special characters are not allowed in URL username segment, so we need to escape them.
     PercentEscaper percentEscaper = new PercentEscaper("", false);
     return personalAccessToken.getScmTokenName().startsWith(OAUTH_2_PREFIX)
+            // Most of the git providers work with git credentials with OAuth token in format
+            // "ouath2:<oauth token>"
+            // but bitbucket requires username to be explicitly set: "<username>:<oauth token>
+            // TODO: needs to be moved to the specific bitbucket implementation.
+            && !personalAccessToken.getScmProviderName().equals("bitbucket")
         ? "oauth2"
         : isNullOrEmpty(personalAccessToken.getScmOrganization())
             ? percentEscaper.escape(personalAccessToken.getScmUserName())

--- a/infrastructures/infrastructure-factory/src/test/java/org/eclipse/che/api/factory/server/scm/kubernetes/KubernetesGitCredentialManagerTest.java
+++ b/infrastructures/infrastructure-factory/src/test/java/org/eclipse/che/api/factory/server/scm/kubernetes/KubernetesGitCredentialManagerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012-2024 Red Hat, Inc.
+ * Copyright (c) 2012-2025 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/
@@ -196,6 +196,42 @@ public class KubernetesGitCredentialManagerTest {
     assertEquals(
         new String(Base64.getDecoder().decode(createdSecret.getData().get("credentials"))),
         "https://oauth2:token123@bitbucket.com");
+    assertTrue(createdSecret.getMetadata().getName().startsWith(NAME_PATTERN));
+    assertFalse(createdSecret.getMetadata().getName().contains(token.getScmUserName()));
+  }
+
+  @Test
+  public void testCreateAndSaveNewBitbucketOAuthGitCredential() throws Exception {
+    KubernetesNamespaceMeta meta = new KubernetesNamespaceMetaImpl("test");
+    when(namespaceFactory.list()).thenReturn(Collections.singletonList(meta));
+
+    when(cheServerKubernetesClientFactory.create()).thenReturn(kubeClient);
+    when(kubeClient.secrets()).thenReturn(secretsMixedOperation);
+    when(secretsMixedOperation.inNamespace(eq(meta.getName()))).thenReturn(nonNamespaceOperation);
+    when(nonNamespaceOperation.withLabels(anyMap())).thenReturn(filterWatchDeletable);
+    when(filterWatchDeletable.list()).thenReturn(secretList);
+    when(secretList.getItems()).thenReturn(emptyList());
+    ArgumentCaptor<Secret> captor = ArgumentCaptor.forClass(Secret.class);
+
+    PersonalAccessToken token =
+        new PersonalAccessToken(
+            "https://bitbucket.com",
+            "bitbucket",
+            "cheUser",
+            "username",
+            "oauth2-token-name",
+            "tid-23434",
+            "token123");
+
+    // when
+    kubernetesGitCredentialManager.createOrReplace(token);
+    // then
+    verify(nonNamespaceOperation).createOrReplace(captor.capture());
+    Secret createdSecret = captor.getValue();
+    assertNotNull(createdSecret);
+    assertEquals(
+        new String(Base64.getDecoder().decode(createdSecret.getData().get("credentials"))),
+        "https://username:token123@bitbucket.com");
     assertTrue(createdSecret.getMetadata().getName().startsWith(NAME_PATTERN));
     assertFalse(createdSecret.getMetadata().getName().contains(token.getScmUserName()));
   }

--- a/wsmaster/che-core-api-auth/src/main/java/org/eclipse/che/security/oauth/EmbeddedOAuthAPI.java
+++ b/wsmaster/che-core-api-auth/src/main/java/org/eclipse/che/security/oauth/EmbeddedOAuthAPI.java
@@ -114,7 +114,7 @@ public class EmbeddedOAuthAPI implements OAuthAPI {
               EnvironmentContext.getCurrent().getSubject().getUserId(),
               null,
               null,
-              generateTokenName(providerName),
+              NameGenerator.generate(OAUTH_2_PREFIX, 5),
               NameGenerator.generate("id-", 5),
               token));
     } catch (OAuthAuthenticationException e) {
@@ -159,18 +159,6 @@ public class EmbeddedOAuthAPI implements OAuthAPI {
       redirectAfterLogin += String.format("&%s=%s", ERROR_QUERY_NAME, errorCode);
     }
     return redirectAfterLogin;
-  }
-
-  /*
-   * This value is used for generating git credentials. Most of the git providers work with git
-   * credentials with OAuth token in format "ouath2:<oauth token>" but bitbucket requires username
-   * to be explicitly set: "<username>:<oauth token>, see {@link
-   * GitCredentialManager#createOrReplace}
-   * TODO: needs to be moved to the specific bitbucket implementation.
-   */
-  private String generateTokenName(String providerName) {
-    return NameGenerator.generate(
-        "bitbucket".equals(providerName) ? providerName + "-" : OAUTH_2_PREFIX, 5);
   }
 
   /**

--- a/wsmaster/che-core-api-auth/src/test/java/org/eclipse/che/security/oauth/EmbeddedOAuthAPITest.java
+++ b/wsmaster/che-core-api-auth/src/test/java/org/eclipse/che/security/oauth/EmbeddedOAuthAPITest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012-2024 Red Hat, Inc.
+ * Copyright (c) 2012-2025 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/
@@ -167,35 +167,6 @@ public class EmbeddedOAuthAPITest {
     assertEquals(token.getCheUserId(), "0000-00-0000");
     assertTrue(token.getScmTokenId().startsWith("id-"));
     assertTrue(token.getScmTokenName().startsWith(OAUTH_2_PREFIX));
-    assertEquals(token.getToken(), "token");
-  }
-
-  @Test
-  public void shouldStoreBitbucketTokenOnCallback() throws Exception {
-    // given
-    UriInfo uriInfo = mock(UriInfo.class);
-    OAuthAuthenticator authenticator = mock(OAuthAuthenticator.class);
-    when(authenticator.getEndpointUrl()).thenReturn("http://eclipse.che");
-    when(authenticator.callback(any(URL.class), anyList())).thenReturn("token");
-    when(uriInfo.getRequestUri())
-        .thenReturn(
-            new URI(
-                "http://eclipse.che?state=oauth_provider%3Dbitbucket%26redirect_after_login%3DredirectUrl"));
-    when(oauth2Providers.getAuthenticator("bitbucket")).thenReturn(authenticator);
-    ArgumentCaptor<PersonalAccessToken> tokenCapture =
-        ArgumentCaptor.forClass(PersonalAccessToken.class);
-
-    // when
-    embeddedOAuthAPI.callback(uriInfo, emptyList());
-
-    // then
-    verify(personalAccessTokenManager).store(tokenCapture.capture());
-    PersonalAccessToken token = tokenCapture.getValue();
-    assertEquals(token.getScmProviderUrl(), "http://eclipse.che");
-    assertEquals(token.getScmProviderName(), "bitbucket");
-    assertEquals(token.getCheUserId(), "0000-00-0000");
-    assertTrue(token.getScmTokenId().startsWith("id-"));
-    assertTrue(token.getScmTokenName().startsWith("bitbucket-"));
     assertEquals(token.getToken(), "token");
   }
 


### PR DESCRIPTION
<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests
-->

### What does this PR do?
Fix the bug when the authorization icon is inactive on first token from Bitbucket.

Remove the Bitbucket token name check from the `EmbeddedOAuthAPI.java` class. Instead, add the check to the `KubernetesGitCredentialManager.java` class. With this change a Bitbucket oauth token will be generated with `oauth2-` name prefix, but the related git credentials secret will have have the token in format `https://<username>:<token>@<hostname>. This is Bitbucket specific git credentials format, other providers can work with `oauth2` instead of username.  

### Screenshot/screencast of this PR
<!-- Please include a screenshot or a screencast explaining what is doing this PR -->


### What issues does this PR fix or reference?
<!-- Please include any related issue from eclipse che repository (or from another issue tracker).
     Include link to other pull requests like documentation PR from [the docs repo](https://github.com/eclipse/che-docs)
-->
https://issues.redhat.com/browse/CRW-8253

### How to test this PR?
<!-- Please explain for example :
  - The test platform (openshift, kubernetes, minikube, CodeReady Container, docker-desktop, etc)
  - Installation method: chectl / che-operator
  - steps to reproduce
 -->
1. Deploy CHE from the pull request image: `quay.io/eclipse/che-server:pr-825`
2. Apply [Bitbucket SAAS oauth](https://eclipse.dev/che/docs/stable/administration-guide/configuring-oauth-2-for-the-bitbucket-cloud/) configuration.
3. Start a workspace from a Bitbucket SAAS repository with a devfile.
4. Go to dashboard user preferences -> Git Services

See: The authorization status icon is active for the Bitbucket item

### PR Checklist

[As the author of this Pull Request I made sure that:](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#pull-request-template-and-its-checklist)

- [ ] [The Eclipse Contributor Agreement is valid](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-eclipse-contributor-agreement-is-valid)
- [ ] [Code produced is complete](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-produced-is-complete)
- [ ] [Code builds without errors](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-builds-without-errors)
- [ ] [Tests are covering the bugfix](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#tests-are-covering-the-bugfix)
- [ ] [The repository devfile is up to date and works](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-repository-devfile-is-up-to-date-and-works)
- [ ] [Sections `What issues does this PR fix or reference` and `How to test this PR` completed](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#sections-what-issues-does-this-pr-fix-or-reference-and-how-to-test-this-pr-completed)
- [ ] [Relevant user documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [Relevant contributing documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [CI/CD changes implemented, documented and communicated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#cicd-changes-implemented-documented-and-communicated)

### Release Notes

### Reviewers

Reviewers, please comment how you tested the PR when approving it.
