### PR TITLE
[DO NOT MERGE] fix: Handle "NULL" string as unconfigured OAuth identity provider

### DIFF
--- a/infrastructures/openshift/src/main/java/org/eclipse/che/workspace/infrastructure/openshift/project/OpenShiftProjectFactory.java
+++ b/infrastructures/openshift/src/main/java/org/eclipse/che/workspace/infrastructure/openshift/project/OpenShiftProjectFactory.java
@@ -119,10 +119,12 @@ public class OpenShiftProjectFactory extends KubernetesNamespaceFactory {
     Map<String, String> namespaceAnnotationsEvaluated =
         evaluateAnnotationPlaceholders(resolutionCtx);
 
-    // Use Che server SA when initWithCheServerSa is true and OAuth is not configured.
+    // Use Che server SA when initWithCheServerSa is true and OAuth is configured.
     // The string "NULL" is treated as "not configured" to handle property placeholder defaults.
-    boolean isOAuthConfigured = !isNullOrEmpty(oAuthIdentityProvider) && !"NULL".equals(oAuthIdentityProvider);
-    boolean useServerSa = initWithCheServerSa && !isOAuthConfigured;
+    boolean useServerSa =
+        initWithCheServerSa
+            && !isNullOrEmpty(oAuthIdentityProvider)
+            && !"NULL".equals(oAuthIdentityProvider);
 
     osProject.prepare(
         canCreateNamespace(),

--- a/infrastructures/openshift/src/main/java/org/eclipse/che/workspace/infrastructure/openshift/project/OpenShiftProjectFactory.java
+++ b/infrastructures/openshift/src/main/java/org/eclipse/che/workspace/infrastructure/openshift/project/OpenShiftProjectFactory.java
@@ -119,9 +119,14 @@ public class OpenShiftProjectFactory extends KubernetesNamespaceFactory {
     Map<String, String> namespaceAnnotationsEvaluated =
         evaluateAnnotationPlaceholders(resolutionCtx);
 
+    // Use Che server SA when initWithCheServerSa is true and OAuth is not configured.
+    // The string "NULL" is treated as "not configured" to handle property placeholder defaults.
+    boolean isOAuthConfigured = !isNullOrEmpty(oAuthIdentityProvider) && !"NULL".equals(oAuthIdentityProvider);
+    boolean useServerSa = initWithCheServerSa && !isOAuthConfigured;
+
     osProject.prepare(
         canCreateNamespace(),
-        initWithCheServerSa && !isNullOrEmpty(oAuthIdentityProvider),
+        useServerSa,
         labelNamespaces ? namespaceLabels : emptyMap(),
         annotateNamespaces ? namespaceAnnotationsEvaluated : emptyMap());
 

--- a/infrastructures/openshift/src/test/java/org/eclipse/che/workspace/infrastructure/openshift/project/OpenShiftProjectFactoryTest.java
+++ b/infrastructures/openshift/src/test/java/org/eclipse/che/workspace/infrastructure/openshift/project/OpenShiftProjectFactoryTest.java
@@ -102,6 +102,7 @@ public class OpenShiftProjectFactoryTest {
   private static final String USER_ID = "2342-2559-234";
   private static final String USER_NAME = "johndoe";
   private static final String NO_OAUTH_IDENTITY_PROVIDER = null;
+  private static final String NULL_STRING_OAUTH_IDENTITY_PROVIDER = "NULL";
   private static final String OAUTH_IDENTITY_PROVIDER = "openshift-v4";
   private static final String NAMESPACE_LABEL_NAME = "component";
   private static final String NAMESPACE_LABELS = NAMESPACE_LABEL_NAME + "=workspace";
@@ -546,7 +547,8 @@ public class OpenShiftProjectFactoryTest {
 
     // then
     assertEquals(toReturnProject, project);
-    verify(toReturnProject).prepare(eq(true), eq(false), any(), any());
+    // When OAuth is NOT configured (null), use Che server SA (true)
+    verify(toReturnProject).prepare(eq(true), eq(true), any(), any());
   }
 
   @Test
@@ -676,6 +678,44 @@ public class OpenShiftProjectFactoryTest {
 
     // then
     verify(serviceAccount).prepare();
+    // When OAuth IS configured, use user credentials (false) to create projects
+    verify(toReturnProject).prepare(eq(true), eq(false), any(), any());
+  }
+
+  @Test
+  public void shouldUseCheServerSAWhenOAuthIdentityProviderIsNullString() throws Exception {
+    // given - when oAuthIdentityProvider is the string "NULL" (property placeholder default),
+    // it should be treated as if OAuth is not configured and Che server SA should be used
+    projectFactory =
+        spy(
+            new OpenShiftProjectFactory(
+                "<userid>-che",
+                true,
+                true,
+                true,
+                NAMESPACE_LABELS,
+                NAMESPACE_ANNOTATIONS,
+                true,
+                emptySet(),
+                openShiftClientFactory,
+                cheServerKubernetesClientFactory,
+                cheServerOpenshiftClientFactory,
+                preferenceManager,
+                pool,
+                authorizationChecker,
+                permissionsCleaner,
+                NULL_STRING_OAUTH_IDENTITY_PROVIDER));
+    OpenShiftProject toReturnProject = mock(OpenShiftProject.class);
+    prepareProject(toReturnProject);
+    doReturn(toReturnProject).when(projectFactory).doCreateProjectAccess(any(), any());
+
+    // when
+    RuntimeIdentity identity =
+        new RuntimeIdentityImpl("workspace123", null, USER_ID, "workspace123");
+    projectFactory.getOrCreate(identity);
+
+    // then - should use Che server SA (true) when oAuthIdentityProvider="NULL"
+    verify(toReturnProject).prepare(eq(true), eq(true), any(), any());
   }
 
   @Ignore

--- a/infrastructures/openshift/src/test/java/org/eclipse/che/workspace/infrastructure/openshift/project/OpenShiftProjectFactoryTest.java
+++ b/infrastructures/openshift/src/test/java/org/eclipse/che/workspace/infrastructure/openshift/project/OpenShiftProjectFactoryTest.java
@@ -547,8 +547,8 @@ public class OpenShiftProjectFactoryTest {
 
     // then
     assertEquals(toReturnProject, project);
-    // When OAuth is NOT configured (null), use Che server SA (true)
-    verify(toReturnProject).prepare(eq(true), eq(true), any(), any());
+    // When OAuth is NOT configured (null), don't use Che server SA (false)
+    verify(toReturnProject).prepare(eq(true), eq(false), any(), any());
   }
 
   @Test
@@ -678,14 +678,14 @@ public class OpenShiftProjectFactoryTest {
 
     // then
     verify(serviceAccount).prepare();
-    // When OAuth IS configured, use user credentials (false) to create projects
-    verify(toReturnProject).prepare(eq(true), eq(false), any(), any());
+    // When OAuth IS configured, use Che server SA (true) to create projects
+    verify(toReturnProject).prepare(eq(true), eq(true), any(), any());
   }
 
   @Test
   public void shouldUseCheServerSAWhenOAuthIdentityProviderIsNullString() throws Exception {
     // given - when oAuthIdentityProvider is the string "NULL" (property placeholder default),
-    // it should be treated as if OAuth is not configured and Che server SA should be used
+    // it should be treated as if OAuth is not configured (same as null)
     projectFactory =
         spy(
             new OpenShiftProjectFactory(
@@ -714,8 +714,9 @@ public class OpenShiftProjectFactoryTest {
         new RuntimeIdentityImpl("workspace123", null, USER_ID, "workspace123");
     projectFactory.getOrCreate(identity);
 
-    // then - should use Che server SA (true) when oAuthIdentityProvider="NULL"
-    verify(toReturnProject).prepare(eq(true), eq(true), any(), any());
+    // then - should NOT use Che server SA (false) when oAuthIdentityProvider="NULL"
+    // because "NULL" is treated the same as null (unconfigured)
+    verify(toReturnProject).prepare(eq(true), eq(false), any(), any());
   }
 
   @Ignore


### PR DESCRIPTION
### What does this PR do?
Treat the string "NULL" as equivalent to an unconfigured OAuth identity provider. This fixes the case where property placeholder defaults result in "NULL" being passed instead of null or empty string, which previously caused incorrect service account selection when initializing projects.

https://redhat.atlassian.net/browse/CRW-10656

related property - https://github.com/eclipse-che/che-server/blob/ff937cae6d89984710ef40bde8b69aa819b8c58f/assembly/assembly-wsmaster-war/src/main/webapp/WEB-INF/classes/che/multiuser.properties#L76 

### Screenshot/screencast of this PR
[<!-- Please include a screenshot or a screencast explaining what is doing this PR -->
](https://redhat.atlassian.net/browse/CRW-10656)

### What issues does this PR fix or reference?
<!-- Please include any related issue from eclipse che repository (or from another issue tracker).
     Include link to other pull requests like documentation PR from [the docs repo](https://github.com/eclipse/che-docs)
-->


### How to test this PR?
<!-- Please explain for example :
  - The test platform (openshift, kubernetes, minikube, CodeReady Container, docker-desktop, etc)
  - Installation method: chectl / che-operator
  - steps to reproduce
 -->


### PR Checklist

[As the author of this Pull Request I made sure that:](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#pull-request-template-and-its-checklist)

- [ ] [The Eclipse Contributor Agreement is valid](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-eclipse-contributor-agreement-is-valid)
- [ ] [Code produced is complete](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-produced-is-complete)
- [ ] [Code builds without errors](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-builds-without-errors)
- [ ] [Tests are covering the bugfix](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#tests-are-covering-the-bugfix)
- [ ] [The repository devfile is up to date and works](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-repository-devfile-is-up-to-date-and-works)
- [ ] [Sections `What issues does this PR fix or reference` and `How to test this PR` completed](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#sections-what-issues-does-this-pr-fix-or-reference-and-how-to-test-this-pr-completed)
- [ ] [Relevant user documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [Relevant contributing documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [CI/CD changes implemented, documented and communicated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#cicd-changes-implemented-documented-and-communicated)

### Release Notes

### Reviewers

Reviewers, please comment how you tested the PR when approving it.
