### PR TITLE
chore(deps): bump com.fasterxml.jackson.version from 2.21.0 to 2.22.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -49,7 +49,7 @@
         <aopalliance.version>1.0</aopalliance.version>
         <ch.qos.logback.version>1.5.28</ch.qos.logback.version>
         <com.auth0.jwks-rsa.version>0.22.1</com.auth0.jwks-rsa.version>
-        <com.fasterxml.jackson.version>2.21.0</com.fasterxml.jackson.version>
+        <com.fasterxml.jackson.version>2.22.0</com.fasterxml.jackson.version>
         <com.github.kirviq.dumbster.version>1.7.1</com.github.kirviq.dumbster.version>
         <com.google.code.guice.version>5.0.1</com.google.code.guice.version>
         <com.google.errorprone>2.42.0</com.google.errorprone>


### PR DESCRIPTION
<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests
-->

### What does this PR do?
Update Jackson library to address security vulnerabilities.
 backports https://github.com/eclipse-che/che-server/pull/1030


