### PR TITLE
feat(oauth): expose clientId in OAuthAuthenticatorDescriptor

### DIFF
--- a/wsmaster/che-core-api-auth-shared/src/main/java/org/eclipse/che/security/oauth/shared/dto/OAuthAuthenticatorDescriptor.java
+++ b/wsmaster/che-core-api-auth-shared/src/main/java/org/eclipse/che/security/oauth/shared/dto/OAuthAuthenticatorDescriptor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012-2025 Red Hat, Inc.
+ * Copyright (c) 2012-2026 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/
@@ -38,4 +38,15 @@ public interface OAuthAuthenticatorDescriptor {
   void setLinks(List<Link> links);
 
   OAuthAuthenticatorDescriptor withLinks(List<Link> links);
+
+  /**
+   * The OAuth App client ID. Exposed so clients can initiate flows that require the client ID
+   * directly (e.g. GitHub Device Authorization Flow / RFC 8628) without needing access to the raw
+   * Kubernetes Secret.
+   */
+  String getClientId();
+
+  void setClientId(String clientId);
+
+  OAuthAuthenticatorDescriptor withClientId(String clientId);
 }

--- a/wsmaster/che-core-api-auth/src/main/java/org/eclipse/che/security/oauth/EmbeddedOAuthAPI.java
+++ b/wsmaster/che-core-api-auth/src/main/java/org/eclipse/che/security/oauth/EmbeddedOAuthAPI.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012-2025 Red Hat, Inc.
+ * Copyright (c) 2012-2026 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/
@@ -206,13 +206,16 @@ public class EmbeddedOAuthAPI implements OAuthAPI {
                   .withRequired(true)
                   .withDefaultValue("federated_login")));
       OAuthAuthenticator authenticator = oauth2Providers.getAuthenticator(name);
+      String endpointUrl =
+          authenticator != null
+              ? authenticator.getEndpointUrl()
+              : oauth1Providers.getAuthenticator(name).getEndpointUrl();
+      String clientId = authenticator != null ? authenticator.getClientId() : null;
       result.add(
           newDto(OAuthAuthenticatorDescriptor.class)
               .withName(name)
-              .withEndpointUrl(
-                  authenticator != null
-                      ? authenticator.getEndpointUrl()
-                      : oauth1Providers.getAuthenticator(name).getEndpointUrl())
+              .withEndpointUrl(endpointUrl)
+              .withClientId(clientId)
               .withLinks(links));
     }
     return result;

--- a/wsmaster/che-core-api-auth/src/main/java/org/eclipse/che/security/oauth/OAuthAuthenticator.java
+++ b/wsmaster/che-core-api-auth/src/main/java/org/eclipse/che/security/oauth/OAuthAuthenticator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012-2025 Red Hat, Inc.
+ * Copyright (c) 2012-2026 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/
@@ -51,6 +51,7 @@ public abstract class OAuthAuthenticator {
   private static final Logger LOG = LoggerFactory.getLogger(OAuthAuthenticator.class);
 
   protected AuthorizationCodeFlow flow;
+  private String clientId;
   protected Map<Pattern, String> redirectUrisMap;
 
   /**
@@ -109,6 +110,7 @@ public abstract class OAuthAuthenticator {
         tokenUri,
         dataStoreFactory);
 
+    this.clientId = clientId;
     configure(authorizationFlow, Arrays.asList(redirectUris));
   }
 
@@ -388,6 +390,11 @@ public abstract class OAuthAuthenticator {
    */
   public boolean invalidateToken(String token) throws IOException {
     throw new UnsupportedOperationException("Should be implemented by specific provider");
+  }
+
+  /** Returns the OAuth App client ID (e.g. for GitHub Device Authorization Flow). */
+  public String getClientId() {
+    return clientId;
   }
 
   /**

--- a/wsmaster/che-core-api-auth/src/test/java/org/eclipse/che/security/oauth/EmbeddedOAuthAPITest.java
+++ b/wsmaster/che-core-api-auth/src/test/java/org/eclipse/che/security/oauth/EmbeddedOAuthAPITest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012-2025 Red Hat, Inc.
+ * Copyright (c) 2012-2026 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/
@@ -26,6 +26,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNull;
 import static org.testng.Assert.assertTrue;
 
 import jakarta.ws.rs.core.Response;
@@ -214,5 +215,49 @@ public class EmbeddedOAuthAPITest {
 
     // then
     assertEquals(callback.getLocation().toString(), "https://redirecturl.com?params=%7B%7D");
+  }
+
+  @Test
+  public void shouldIncludeClientIdForOAuth2Providers() throws Exception {
+    // given
+    UriInfo uriInfo = mock(UriInfo.class);
+    when(uriInfo.getBaseUriBuilder()).thenReturn(UriBuilder.fromUri("http://eclipse.che"));
+    when(oauth2Providers.getRegisteredProviderNames()).thenReturn(Set.of("github"));
+    when(oauth1Providers.getRegisteredProviderNames()).thenReturn(Set.of());
+    OAuthAuthenticator authenticator = mock(OAuthAuthenticator.class);
+    when(authenticator.getClientId()).thenReturn("test-client-id");
+    when(oauth2Providers.getAuthenticator("github")).thenReturn(authenticator);
+
+    // when
+    Set<OAuthAuthenticatorDescriptor> descriptors =
+        embeddedOAuthAPI.getRegisteredAuthenticators(uriInfo);
+
+    // then
+    assertEquals(descriptors.size(), 1);
+    OAuthAuthenticatorDescriptor descriptor = descriptors.iterator().next();
+    assertEquals(descriptor.getName(), "github");
+    assertEquals(descriptor.getClientId(), "test-client-id");
+  }
+
+  @Test
+  public void shouldHaveNullClientIdForOAuth1Providers() throws Exception {
+    // given
+    UriInfo uriInfo = mock(UriInfo.class);
+    when(uriInfo.getBaseUriBuilder()).thenReturn(UriBuilder.fromUri("http://eclipse.che"));
+    when(oauth2Providers.getRegisteredProviderNames()).thenReturn(Set.of());
+    when(oauth1Providers.getRegisteredProviderNames()).thenReturn(Set.of("bitbucket"));
+    org.eclipse.che.security.oauth1.OAuthAuthenticator oauth1Authenticator =
+        mock(org.eclipse.che.security.oauth1.OAuthAuthenticator.class);
+    when(oauth1Providers.getAuthenticator("bitbucket")).thenReturn(oauth1Authenticator);
+
+    // when
+    Set<OAuthAuthenticatorDescriptor> descriptors =
+        embeddedOAuthAPI.getRegisteredAuthenticators(uriInfo);
+
+    // then
+    assertEquals(descriptors.size(), 1);
+    OAuthAuthenticatorDescriptor descriptor = descriptors.iterator().next();
+    assertEquals(descriptor.getName(), "bitbucket");
+    assertNull(descriptor.getClientId());
   }
 }


### PR DESCRIPTION
### What does this PR do?

Adds `clientId` to the `OAuthAuthenticatorDescriptor` DTO returned by `GET /api/oauth`, so clients can initiate OAuth flows that require the client ID directly — specifically the **GitHub Device Authorization Flow (RFC 8628)**.

#### Changes

- **`OAuthAuthenticatorDescriptor`** — new `clientId` field (getter / setter / builder)
- **`OAuthAuthenticator`** — stores the `clientId` passed to `configure()` and exposes it via `getClientId()`
- **`EmbeddedOAuthAPI`** — populates `clientId` in the descriptor returned by `GET /api/oauth`

#### Why

The Che Dashboard's **Device Auth Tokens** tab (che-dashboard#1633) needs to call GitHub's device flow API directly, which requires the OAuth App client ID. Currently there is no way for the dashboard to obtain this value without:
- An env var injected by the operator (breaks when using a custom deployment spec for testing)
- Direct K8s Secret access (requires RBAC changes)

With this change, the dashboard calls `GET /api/oauth` with its service account token — the same call it already makes for the **Git Services** tab — and receives the client ID in the response. No additional RBAC, env vars, or volume mounts needed.

#### Backward compatibility

The new `clientId` field is optional in the DTO. Existing consumers of `GET /api/oauth` that don't use `clientId` are unaffected. OAuth1 providers (where `authenticator.getClientId()` would return `null`) simply omit the field.

### What issues does this PR fix or reference?

references https://redhat.atlassian.net/browse/CRW-11582