### PR TITLE
feat(factory): detect `devcontainer.json` when no devfile is present

### DIFF
--- a/wsmaster/che-core-api-factory/src/main/java/org/eclipse/che/api/factory/server/urlfactory/URLFactoryBuilder.java
+++ b/wsmaster/che-core-api-factory/src/main/java/org/eclipse/che/api/factory/server/urlfactory/URLFactoryBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012-2024 Red Hat, Inc.
+ * Copyright (c) 2012-2026 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/
@@ -15,10 +15,15 @@ import static com.google.common.base.Strings.isNullOrEmpty;
 import static org.eclipse.che.api.factory.server.ApiExceptionMapper.toApiException;
 import static org.eclipse.che.api.factory.server.scm.exception.ExceptionMessages.getDevfileConnectionErrorMessage;
 import static org.eclipse.che.api.factory.shared.Constants.CURRENT_VERSION;
+import static org.eclipse.che.api.factory.shared.Constants.DEFAULT_DEVFILE;
 import static org.eclipse.che.dto.server.DtoFactory.newDto;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import java.io.IOException;
+import java.io.InputStream;
+import java.io.UncheckedIOException;
+import java.nio.charset.StandardCharsets;
+import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
 import javax.inject.Inject;
@@ -49,6 +54,24 @@ public class URLFactoryBuilder {
   private static final Logger LOG = LoggerFactory.getLogger(URLFactoryBuilder.class);
 
   public static final String DEVFILE_FILENAME = "devfileFilename";
+
+  private static final String[] DEVCONTAINER_LOCATIONS = {
+    ".devcontainer/devcontainer.json", ".devcontainer.json"
+  };
+
+  private static final String DEVCONTAINER_DEVFILE_TEMPLATE;
+
+  static {
+    try (InputStream is =
+        URLFactoryBuilder.class.getResourceAsStream("/devcontainer-devfile-template.yaml")) {
+      if (is == null) {
+        throw new IOException("devcontainer-devfile-template.yaml not found on classpath");
+      }
+      DEVCONTAINER_DEVFILE_TEMPLATE = new String(is.readAllBytes(), StandardCharsets.UTF_8);
+    } catch (IOException e) {
+      throw new UncheckedIOException("Failed to load devcontainer devfile template", e);
+    }
+  }
 
   private final String defaultCheEditor;
   private final String defaultChePlugins;
@@ -140,6 +163,46 @@ public class URLFactoryBuilder {
         throw toApiException(e, location);
       }
     }
+
+    // No devfile found — probe for devcontainer.json
+    for (String devcontainerPath : DEVCONTAINER_LOCATIONS) {
+      String devcontainerLocation = remoteFactoryUrl.rawFileLocation(devcontainerPath);
+      if (devcontainerLocation == null) {
+        break;
+      }
+      try {
+        Optional<String> credentialsOptional = remoteFactoryUrl.getCredentials();
+        if (skipAuthentication) {
+          fileContentProvider.fetchContentWithoutAuthentication(devcontainerLocation);
+        } else if (credentialsOptional.isPresent()) {
+          fileContentProvider.fetchContent(devcontainerLocation, credentialsOptional.get());
+        } else {
+          fileContentProvider.fetchContent(devcontainerLocation);
+        }
+      } catch (IOException ex) {
+        LOG.debug("No devcontainer at: {}. Error: {}", devcontainerLocation, ex.getMessage());
+        continue;
+      } catch (DevfileException e) {
+        LOG.debug("Unexpected exception probing devcontainer: {}", e.getMessage());
+        continue;
+      }
+
+      LOG.info("Devcontainer detected at {}; generating devfile", devcontainerLocation);
+      try {
+        JsonNode additions = devfileParser.parseYamlRaw(DEVCONTAINER_DEVFILE_TEMPLATE);
+        Map<String, Object> devfileMap = new HashMap<>(DEFAULT_DEVFILE);
+        devfileMap.putAll(devfileParser.convertYamlToMap(additions));
+        return Optional.of(
+            newDto(FactoryDevfileV2Dto.class)
+                .withV(CURRENT_VERSION)
+                .withDevfile(devfileMap)
+                .withSource(devcontainerPath));
+      } catch (DevfileException e) {
+        LOG.error("Failed to parse devcontainer devfile template", e);
+        break;
+      }
+    }
+
     return Optional.empty();
   }
 

--- a/wsmaster/che-core-api-factory/src/main/java/org/eclipse/che/api/factory/server/urlfactory/URLFactoryBuilder.java
+++ b/wsmaster/che-core-api-factory/src/main/java/org/eclipse/che/api/factory/server/urlfactory/URLFactoryBuilder.java
@@ -168,22 +168,30 @@ public class URLFactoryBuilder {
     for (String devcontainerPath : DEVCONTAINER_LOCATIONS) {
       String devcontainerLocation = remoteFactoryUrl.rawFileLocation(devcontainerPath);
       if (devcontainerLocation == null) {
-        break;
+        continue;
       }
+      String devcontainerContent;
       try {
         Optional<String> credentialsOptional = remoteFactoryUrl.getCredentials();
         if (skipAuthentication) {
-          fileContentProvider.fetchContentWithoutAuthentication(devcontainerLocation);
+          devcontainerContent =
+              fileContentProvider.fetchContentWithoutAuthentication(devcontainerLocation);
         } else if (credentialsOptional.isPresent()) {
-          fileContentProvider.fetchContent(devcontainerLocation, credentialsOptional.get());
+          devcontainerContent =
+              fileContentProvider.fetchContent(devcontainerLocation, credentialsOptional.get());
         } else {
-          fileContentProvider.fetchContent(devcontainerLocation);
+          devcontainerContent = fileContentProvider.fetchContent(devcontainerLocation);
         }
       } catch (IOException ex) {
         LOG.debug("No devcontainer at: {}. Error: {}", devcontainerLocation, ex.getMessage());
         continue;
       } catch (DevfileException e) {
-        LOG.debug("Unexpected exception probing devcontainer: {}", e.getMessage());
+        LOG.warn("Unexpected exception probing devcontainer: {}", e.getMessage());
+        continue;
+      }
+
+      if (!looksLikeJson(devcontainerContent)) {
+        LOG.debug("Ignoring non-JSON content from {}", devcontainerLocation);
         continue;
       }
 
@@ -217,5 +225,36 @@ public class URLFactoryBuilder {
         .withV(CURRENT_VERSION)
         .withDevfile(devfileParser.convertYamlToMap(devfileJson))
         .withSource(location.filename().isPresent() ? location.filename().get() : null);
+  }
+
+  /**
+   * Cheap probe: returns true when content is non-empty and starts with '{' after skipping
+   * whitespace and JSONC single-line comments. Does not parse the file.
+   */
+  static boolean looksLikeJson(String content) {
+    if (isNullOrEmpty(content)) {
+      return false;
+    }
+    boolean inBlockComment = false;
+    for (String line : content.split("\n")) {
+      String trimmed = line.trim();
+      if (inBlockComment) {
+        if (trimmed.contains("*/")) {
+          inBlockComment = false;
+        }
+        continue;
+      }
+      if (trimmed.isEmpty() || trimmed.startsWith("//")) {
+        continue;
+      }
+      if (trimmed.startsWith("/*")) {
+        if (!trimmed.contains("*/")) {
+          inBlockComment = true;
+        }
+        continue;
+      }
+      return trimmed.startsWith("{");
+    }
+    return false;
   }
 }

--- a/wsmaster/che-core-api-factory/src/main/resources/devcontainer-devfile-template.yaml
+++ b/wsmaster/che-core-api-factory/src/main/resources/devcontainer-devfile-template.yaml
@@ -1,0 +1,455 @@
+#
+# Copyright (c) 2012-2026 Red Hat, Inc.
+# This program and the accompanying materials are made
+# available under the terms of the Eclipse Public License 2.0
+# which is available at https://www.eclipse.org/legal/epl-2.0/
+#
+# SPDX-License-Identifier: EPL-2.0
+#
+# Contributors:
+#   Red Hat, Inc. - initial API and implementation
+#
+
+commands:
+  - id: start-devcontainer
+    exec:
+      component: universal-developer-image
+      label: Start dev container
+      workingDir: ${PROJECTS_ROOT}
+      commandLine: |
+        cat > /tmp/start-devcontainer.sh <<'DEVCONTAINER_SCRIPT_EOF'
+        #!/usr/bin/env bash
+        #
+        # Outer editor + inner devcontainer.
+        # che-code stays in the UDI container; the repo's devcontainer.json is built and run as a
+        # nested rootless-podman container. Terminals, lifecycle commands and file ownership are
+        # wired so the inner container behaves like the project's real environment.
+        #
+        # Env overrides:
+        #   CONTAINER_NAME     nested container name           (default: devcontainer)
+        #   IMAGE_NAME         built image tag                 (default: localhost/devcontainer:latest)
+        #   REUSE_CONTAINER=1  reuse a running container instead of rebuilding
+        #   REBUILD=1          force rebuild (remove existing container and image)
+        #   NO_CACHE=1         rebuild without cache (passes --no-cache to devcontainer build)
+        #   STRICT_LIFECYCLE=1 exit non-zero if any lifecycle command fails
+        #   NO_KEEP_ID=1       skip --userns=keep-id (debugging)
+        #
+        set -uo pipefail
+
+        PROJECTS_ROOT="${PROJECTS_ROOT:-/projects}"
+        # Project: explicit arg > DWO's PROJECT_SOURCE > the only directory under PROJECTS_ROOT.
+        if [ "$#" -ge 1 ] && [ -n "${1:-}" ]; then
+          PROJECT_DIR="${PROJECTS_ROOT}/${1}"
+        elif [ -n "${PROJECT_SOURCE:-}" ] && [ -d "${PROJECT_SOURCE}" ]; then
+          PROJECT_DIR="$PROJECT_SOURCE"
+        else
+          mapfile -t _dirs < <(find "$PROJECTS_ROOT" -mindepth 1 -maxdepth 1 -type d 2>/dev/null | sort)
+          if [ "${#_dirs[@]}" -eq 1 ]; then
+            PROJECT_DIR="${_dirs[0]}"
+          else
+            echo "specify a project: $(basename "$0") <name>" >&2
+            [ "${#_dirs[@]}" -gt 1 ] && printf '  %s\n' "${_dirs[@]##*/}" >&2
+            exit 1
+          fi
+        fi
+        [ -d "$PROJECT_DIR" ] || { echo "no such project: $PROJECT_DIR" >&2; exit 1; }
+        PROJECT_NAME="$(basename "$PROJECT_DIR")"
+        CONTAINER_NAME="${CONTAINER_NAME:-devcontainer}"
+        IMAGE_NAME="${IMAGE_NAME:-localhost/devcontainer:latest}"
+        REUSE_CONTAINER="${REUSE_CONTAINER:-0}"
+        REBUILD="${REBUILD:-0}"
+        NO_CACHE="${NO_CACHE:-0}"
+        STRICT_LIFECYCLE="${STRICT_LIFECYCLE:-0}"
+        LIFECYCLE_FAILURES=0
+
+        # --- phase timing ---------------------------------------------------------
+        # Cold start is the main operational cost of this approach (CLI install + base image pull +
+        # build). Record where the time actually goes so it can be reported rather than guessed at.
+        T_START=$(date +%s); PHASE_T=$T_START; CURRENT_PHASE=""; PHASE_LOG=()
+        _close_phase(){ local now; now=$(date +%s)
+          [ -n "$CURRENT_PHASE" ] && PHASE_LOG+=("$((now-PHASE_T))|$CURRENT_PHASE"); PHASE_T=$now; }
+        step(){ _close_phase; CURRENT_PHASE="$2"; echo "[$1] $2"; return 0; }
+
+        echo "=== devcontainer (outer editor): ${PROJECT_NAME} ==="
+
+        # ---------------------------------------------------------------------------
+        # 1. Container engine
+        # ---------------------------------------------------------------------------
+        # UDI moves the real podman to podman.orig and puts a symlink on PATH that becomes the
+        # KUBEDOCK WRAPPER when KUBEDOCK_ENABLED=true. The wrapper sends run/exec to kubedock — a
+        # separate pod — while build stays local, so the image would be built somewhere the runtime
+        # cannot see it and --network=host would no longer be the pod's netns.
+        PODMAN="${ORIGINAL_PODMAN_PATH:-/usr/bin/podman.orig}"
+        [ -x "$PODMAN" ] || PODMAN="$(command -v podman 2>/dev/null)"
+        [ -n "$PODMAN" ] || { echo "podman not found" >&2; exit 1; }
+        step "1/8" "engine: $PODMAN"
+
+        # ---------------------------------------------------------------------------
+        # 2. Storage + subuid
+        # ---------------------------------------------------------------------------
+        # Keep the image store OFF the PVC: subuid-owned files there break DWO's cleanup job and
+        # wedge the workspace in Error on teardown. Prefer overlay+fuse-overlayfs when /dev/fuse
+        # exists — VFS is much slower and rules out --userns=keep-id.
+        mkdir -p /tmp/podman/storage ~/.config/containers
+        if [ -c /dev/fuse ] && [ -x /usr/bin/fuse-overlayfs ]; then
+          printf '[storage]\ndriver = "overlay"\ngraphroot = "/tmp/podman/storage"\n[storage.options.overlay]\nmount_program = "/usr/bin/fuse-overlayfs"\n' > ~/.config/containers/storage.conf
+        else
+          printf '[storage]\ndriver = "vfs"\ngraphroot = "/tmp/podman/storage"\n' > ~/.config/containers/storage.conf
+        fi
+
+        # Derive the range instead of hardcoding a uid — UDI's entrypoint computes this from the
+        # actual uid, and a hardcoded "user:1001:..." maps the wrong host range on a uid-1000 pod.
+        # NOTE: a 65536-ID userns cannot map container ID 65534 (nobody) however the ranges are
+        # split, because our own UID consumes one. apt's sandbox may still need disabling.
+        SU_USER="$(id -un 2>/dev/null || echo user)"; SU_UID="$(id -u)"
+        if [ "$SU_UID" -gt 0 ] && [ "$SU_UID" -lt 65536 ]; then
+          RANGES="$(printf '%s:1:%s\n%s:%s:%s\n' "$SU_USER" "$((SU_UID-1))" \
+                                                  "$SU_USER" "$((SU_UID+1))" "$((65535-SU_UID))")"
+          printf '%s\n' "$RANGES" > /etc/subuid 2>/dev/null &&
+          printf '%s\n' "$RANGES" > /etc/subgid 2>/dev/null &&
+          "$PODMAN" system migrate >/dev/null 2>&1 &&
+          step "2/8" "storage=$("$PODMAN" info --format json 2>/dev/null | jq -r '.store.graphDriverName') subuid=${SU_USER}(${SU_UID})" ||
+          step "2/8" "storage=$("$PODMAN" info --format json 2>/dev/null | jq -r '.store.graphDriverName') subuid=unchanged"
+        fi
+
+        # ---------------------------------------------------------------------------
+        # 3. devcontainer CLI + pre-build config
+        # ---------------------------------------------------------------------------
+        DEVCONTAINER_BIN="${DEVCONTAINER_BIN:-$(command -v devcontainer || echo /home/user/.devcontainers/bin/devcontainer)}"
+        if ! "$DEVCONTAINER_BIN" --version >/dev/null 2>&1; then
+          step "3/8" "installing devcontainer CLI..."
+          npm install -g @devcontainers/cli >/dev/null 2>&1 ||
+            curl -fsSL https://raw.githubusercontent.com/devcontainers/cli/main/scripts/install.sh | sh
+          DEVCONTAINER_BIN="$(command -v devcontainer || echo /home/user/.devcontainers/bin/devcontainer)"
+        else
+          step "3/8" "devcontainer CLI present."
+        fi
+
+        # read-configuration shells out to `docker ps` before doing anything, so WITHOUT
+        # --docker-path it exits 1 with no output and we would silently fall back to a
+        # comment-stripping regex. Point it at the real engine.
+        CONFIG_JSON=""
+        raw="$("$DEVCONTAINER_BIN" read-configuration --docker-path "$PODMAN" \
+                --workspace-folder "$PROJECT_DIR" 2>/dev/null || true)"
+        [ -n "$raw" ] && CONFIG_JSON="$(printf '%s\n' "$raw" | grep -E '^\{' | tail -1 \
+          | jq -c '.configuration // empty' 2>/dev/null || true)"
+        if [ -z "$CONFIG_JSON" ]; then
+          DC=""
+          for c in "$PROJECT_DIR/.devcontainer/devcontainer.json" "$PROJECT_DIR/.devcontainer.json"; do
+            [ -f "$c" ] && { DC="$c"; break; }
+          done
+          [ -n "$DC" ] || DC="$(find "$PROJECT_DIR/.devcontainer" -mindepth 2 -maxdepth 2 \
+            -name devcontainer.json 2>/dev/null | sort | head -1)"
+          [ -n "$DC" ] || { echo "  no devcontainer.json found" >&2; exit 0; }
+          echo "  read-configuration failed; using fallback parser on $DC" >&2
+          # whole-line comments only, so a URL inside a string survives
+          CONFIG_JSON="$(sed -e 's@^[[:space:]]*//.*$@@' "$DC" | jq -c '.' 2>/dev/null)"
+          [ -n "$CONFIG_JSON" ] || { echo "  could not parse $DC" >&2; exit 1; }
+        fi
+
+        # ---------------------------------------------------------------------------
+        # 4. initializeCommand (runs OUTSIDE the container, per spec)
+        # ---------------------------------------------------------------------------
+        JQ_NORMALIZE='
+        def norm($name):
+          if . == null then empty
+          elif type == "string" then {name:$name, argv:["/bin/sh","-c",.]}
+          elif type == "array"  then {name:$name, argv:.}
+          elif type == "object" then to_entries[] | .key as $k | (.value | norm($k))
+          else empty end;
+        norm("")'
+
+        run_outer() {
+          local spec="$1" line label; [ -z "$spec" ] || [ "$spec" = "null" ] && return 0
+          while IFS= read -r line; do
+            [ -z "$line" ] && continue
+            label="$(printf '%s' "$line" | jq -r '.name')"
+            local -a argv=(); mapfile -t argv < <(printf '%s' "$line" | jq -r '.argv[]')
+            [ "${#argv[@]}" -eq 0 ] && continue
+            echo "  -> initializeCommand${label:+ [$label]}: ${argv[*]}"
+            ( cd "$PROJECT_DIR" && "${argv[@]}" ) || {
+              echo "  !! initializeCommand failed" >&2; LIFECYCLE_FAILURES=$((LIFECYCLE_FAILURES+1)); }
+          done < <(printf '%s' "$spec" | jq -c "$JQ_NORMALIZE")
+        }
+        step "4/8" "initializeCommand..."
+        run_outer "$(printf '%s' "$CONFIG_JSON" | jq -c '.initializeCommand // null')"
+
+        # ---------------------------------------------------------------------------
+        # 5. Build
+        # ---------------------------------------------------------------------------
+        REUSING=0
+        if [ "$REBUILD" = "1" ]; then
+          "$PODMAN" rm -f "$CONTAINER_NAME" >/dev/null 2>&1 || true
+          "$PODMAN" rmi -f "$IMAGE_NAME" >/dev/null 2>&1 || true
+        fi
+        if [ "$REBUILD" != "1" ] && [ "$REUSE_CONTAINER" = "1" ] && "$PODMAN" container exists "$CONTAINER_NAME" 2>/dev/null; then
+          REUSING=1; echo "[5/8] reusing existing container."; "$PODMAN" start "$CONTAINER_NAME" >/dev/null 2>&1 || true
+        else
+          step "5/8" "building image (slow part)..."
+          BUILD_ARGS=(--docker-path="$PODMAN" --workspace-folder "$PROJECT_DIR" --image-name "$IMAGE_NAME")
+          [ "$NO_CACHE" = "1" ] && BUILD_ARGS+=(--no-cache)
+          "$DEVCONTAINER_BIN" build "${BUILD_ARGS[@]}" || {
+              echo "  build failed" >&2; exit 1; }
+        fi
+
+        # ---------------------------------------------------------------------------
+        # 6. Merged metadata from the built image
+        # ---------------------------------------------------------------------------
+        # `devcontainer build` writes a devcontainer.metadata LABEL containing the FULLY MERGED
+        # config — the base image's metadata, every Feature's contributions, and devcontainer.json.
+        # This is where remoteUser actually lives for most real repos (vscode-remote-try-node has
+        # its remoteUser line commented out, but the image metadata says "node"). Reading only
+        # devcontainer.json means lifecycle commands run as root and write root-owned node_modules
+        # into the bind mount. Using --include-merged-configuration instead would need a registry
+        # round-trip; the label is local and already merged.
+        JQ_MERGE='
+        def last_of($k): [ .[] | .[$k] // empty ] | last // null;
+        def all_of($k):  [ .[] | .[$k] // empty ];
+        { remoteUser: last_of("remoteUser"), containerUser: last_of("containerUser"),
+          workspaceFolder: last_of("workspaceFolder"),
+          remoteEnv:    ( [ .[] | .remoteEnv    // {} ] | add // {} ),
+          containerEnv: ( [ .[] | .containerEnv // {} ] | add // {} ),
+          extensions:   ( [ .[] | .customizations.vscode.extensions // [] ] | add // [] | unique ),
+          settings:     ( [ .[] | .customizations.vscode.settings   // {} ] | add // {} ),
+          onCreateCommand: all_of("onCreateCommand"), updateContentCommand: all_of("updateContentCommand"),
+          postCreateCommand: all_of("postCreateCommand"), postStartCommand: all_of("postStartCommand"),
+          postAttachCommand: all_of("postAttachCommand") }'
+
+        META='{}'
+        label="$("$PODMAN" inspect --format json "$IMAGE_NAME" 2>/dev/null \
+          | jq -r '.[0].Config.Labels["devcontainer.metadata"] // ""')"
+        if [ -n "$label" ] && [ "$label" != "<no value>" ]; then
+          META="$(printf '%s' "$label" | jq -c "$JQ_MERGE" 2>/dev/null || echo '{}')"
+        fi
+        # Fall back to devcontainer.json for anything the label did not provide.
+        META="$(jq -n --argjson m "$META" --argjson c "$CONFIG_JSON" '
+          { remoteUser: ($m.remoteUser // $c.remoteUser // $c.containerUser // null),
+            workspaceFolder: ($m.workspaceFolder // $c.workspaceFolder // "/workspace"),
+            remoteEnv: (($c.remoteEnv // {}) + ($m.remoteEnv // {})),
+            containerEnv: (($c.containerEnv // {}) + ($m.containerEnv // {})),
+            extensions: ($m.extensions // ($c.customizations.vscode.extensions // [])),
+            settings: (($c.customizations.vscode.settings // {}) + ($m.settings // {})),
+            hooks: { onCreateCommand: ($m.onCreateCommand // []), updateContentCommand: ($m.updateContentCommand // []),
+                     postCreateCommand: ($m.postCreateCommand // []), postStartCommand: ($m.postStartCommand // []),
+                     postAttachCommand: ($m.postAttachCommand // []) } }')"
+
+        REMOTE_USER="$(printf '%s' "$META" | jq -r '.remoteUser // empty')"
+        WORKSPACE_FOLDER="$(printf '%s' "$META" | jq -r '.workspaceFolder')"
+        echo "  remoteUser=${REMOTE_USER:-<image default>}  workspaceFolder=${WORKSPACE_FOLDER}"
+
+        env_args() {  # $1 = remoteEnv|containerEnv
+          printf '%s' "$META" | jq -r --arg k "$1" '(.[$k] // {}) | to_entries[]
+            | select(.value | tostring | test("\\$\\{") | not) | "-e", "\(.key)=\(.value)"'
+        }
+        CONTAINER_ENV=(); mapfile -t CONTAINER_ENV < <(env_args containerEnv)
+        REMOTE_ENV=();    mapfile -t REMOTE_ENV    < <(env_args remoteEnv)
+        skipped="$(printf '%s' "$META" | jq -r '[(.remoteEnv//{}),(.containerEnv//{})] | add | to_entries[]
+          | select(.value|tostring|test("\\$\\{")) | .key' | paste -sd, -)"
+        [ -n "$skipped" ] && echo "  NOTE: env with \${...} substitution skipped: $skipped" >&2
+
+        # ---------------------------------------------------------------------------
+        # 7. Run the container, with UID parity
+        # ---------------------------------------------------------------------------
+        # The whole point of outer-editor is "edit outside, run inside" — so the two sides must agree
+        # on file ownership. Without keep-id, anything created inside (node_modules, build output,
+        # .venv) is owned by a subuid and the editor cannot modify or delete it, which is what forced
+        # the chmod 777 workaround. keep-id:uid=,gid= maps our uid to the remoteUser inside, so files
+        # created either way are owned by us. Requires overlay (fuse) — VFS cannot chown.
+        KEEP_ID_ARGS=()
+        if [ "$REUSING" = "0" ] && [ "${NO_KEEP_ID:-0}" != "1" ] && [ -c /dev/fuse ]; then
+          IN_UID=""; IN_GID=""
+          if [ -n "$REMOTE_USER" ]; then
+            IN_UID="$("$PODMAN" run --rm "$IMAGE_NAME" id -u "$REMOTE_USER" 2>/dev/null | tr -dc '0-9')"
+            IN_GID="$("$PODMAN" run --rm "$IMAGE_NAME" id -g "$REMOTE_USER" 2>/dev/null | tr -dc '0-9')"
+          fi
+          if [ -n "$IN_UID" ] && [ -n "$IN_GID" ]; then
+            KEEP_ID_ARGS=(--userns="keep-id:uid=${IN_UID},gid=${IN_GID}")
+          else
+            KEEP_ID_ARGS=(--userns=keep-id)
+          fi
+        fi
+
+        start_container() {   # $1 = extra args array name
+          local -n extra="$1"
+          "$PODMAN" run -d --name "$CONTAINER_NAME" --network=host \
+            "${extra[@]}" \
+            -v "$PROJECT_DIR:${WORKSPACE_FOLDER}" \
+            -v /var/run/secrets/kubernetes.io/serviceaccount:/var/run/secrets/kubernetes.io/serviceaccount:ro \
+            -e KUBERNETES_SERVICE_HOST="${KUBERNETES_SERVICE_HOST:-}" \
+            -e KUBERNETES_SERVICE_PORT="${KUBERNETES_SERVICE_PORT:-}" \
+            "${CONTAINER_ENV[@]}" \
+            "$IMAGE_NAME" sleep infinity
+        }
+
+        KEEP_ID_OK=0
+        if [ "$REUSING" = "0" ]; then
+          step "6/8" "starting container..."
+          "$PODMAN" rm -f "$CONTAINER_NAME" >/dev/null 2>&1 || true
+          if [ "${#KEEP_ID_ARGS[@]}" -gt 0 ] && start_container KEEP_ID_ARGS >/dev/null 2>&1; then
+            KEEP_ID_OK=1; echo "  uid parity: ${KEEP_ID_ARGS[*]}"
+          else
+            [ "${#KEEP_ID_ARGS[@]}" -gt 0 ] && echo "  keep-id unavailable; falling back (files created inside will be subuid-owned)" >&2
+            "$PODMAN" rm -f "$CONTAINER_NAME" >/dev/null 2>&1 || true
+            NONE=(); start_container NONE >/dev/null || { echo "  could not start container" >&2; exit 1; }
+          fi
+        else
+          step "6/8" "container already running."
+        fi
+
+        # Only widen permissions when uid parity failed. a+rwX (not 777) so the execute bit is not
+        # set on every tracked file, which would make git report the whole repo as modified.
+        if [ "$KEEP_ID_OK" = "0" ]; then
+          "$PODMAN" exec --user 0 "$CONTAINER_NAME" chmod -R a+rwX "$WORKSPACE_FOLDER" 2>/dev/null || true
+        fi
+        "$PODMAN" exec "$CONTAINER_NAME" git config --global --replace-all safe.directory "$WORKSPACE_FOLDER" 2>/dev/null || true
+
+        # ---------------------------------------------------------------------------
+        # 8. Lifecycle commands, then editor wiring
+        # ---------------------------------------------------------------------------
+        EXEC_USER=(); [ -n "$REMOTE_USER" ] && EXEC_USER=(-u "$REMOTE_USER")
+        CREATE_MARKER=/tmp/.devcontainer-create-hooks-done
+
+        run_hook() {   # $1 = hook name
+          local hook="$1" entries line label rc
+          entries="$(printf '%s' "$META" | jq -c --arg k "$hook" '.hooks[$k][]?')"
+          [ -n "$entries" ] || return 0
+          while IFS= read -r spec; do
+            [ -z "$spec" ] && continue
+            while IFS= read -r line; do
+              [ -z "$line" ] && continue
+              label="$(printf '%s' "$line" | jq -r '.name')"
+              local -a argv=(); mapfile -t argv < <(printf '%s' "$line" | jq -r '.argv[]')
+              [ "${#argv[@]}" -eq 0 ] && continue
+              echo "  -> ${hook}${label:+ [$label]}: ${argv[*]}"
+              rc=0
+              "$PODMAN" exec "${EXEC_USER[@]}" "${REMOTE_ENV[@]}" -w "$WORKSPACE_FOLDER" \
+                "$CONTAINER_NAME" "${argv[@]}" || rc=$?
+              [ "$rc" -ne 0 ] && { echo "  !! ${hook} exited ${rc}" >&2
+                                   LIFECYCLE_FAILURES=$((LIFECYCLE_FAILURES+1)); }
+            done < <(printf '%s' "$spec" | jq -c "$JQ_NORMALIZE")
+          done <<< "$entries"
+        }
+
+        step "7/8" "lifecycle commands..."
+        if "$PODMAN" exec "$CONTAINER_NAME" test -f "$CREATE_MARKER" 2>/dev/null; then
+          echo "  creation hooks already ran for this container."
+        else
+          run_hook onCreateCommand; run_hook updateContentCommand; run_hook postCreateCommand
+          "$PODMAN" exec "$CONTAINER_NAME" touch "$CREATE_MARKER" 2>/dev/null || true
+        fi
+        run_hook postStartCommand
+        run_hook postAttachCommand
+
+        step "8/8" "editor wiring..."
+        INNER_SHELL=/bin/sh
+        "$PODMAN" exec "$CONTAINER_NAME" sh -c 'command -v bash' >/dev/null 2>&1 && INNER_SHELL=bash
+
+        merge_into() {   # $1 = file, $2.. = json objects
+          local file="$1"; shift
+          local cur='{}' obj
+          [ -f "$file" ] && cur="$(sed -e 's@^[[:space:]]*//.*$@@' "$file" | jq -c '.' 2>/dev/null || echo '{}')"
+          for obj in "$@"; do cur="$(jq -n --argjson a "$cur" --argjson b "$obj" '$a * $b')"; done
+          mkdir -p "$(dirname "$file")"; printf '%s\n' "$cur" | jq '.' > "$file"
+        }
+
+        profile=(exec -it)
+        [ -n "$REMOTE_USER" ] && profile+=(-u "$REMOTE_USER")
+        profile+=("${REMOTE_ENV[@]}" -w "$WORKSPACE_FOLDER" "$CONTAINER_NAME" "$INNER_SHELL")
+        profile_json="$(printf '%s\n' "${profile[@]}" | jq -R . | jq -s -c .)"
+        terminal="$(jq -n --argjson a "$profile_json" --arg p "$PODMAN" '{
+          "terminal.integrated.profiles.linux": {
+            "devcontainer": { "path": $p, "args": $a, "icon": "container" },
+            "outer (UDI)":  { "path": "/bin/bash" } },
+          "terminal.integrated.defaultProfile.linux": "devcontainer" }')"
+
+        # terminal.integrated.profiles.* and defaultProfile.* are declared `restricted: true` in
+        # VS Code. Restricted settings coming from WORKSPACE settings are silently discarded in an
+        # untrusted workspace, so they must go to MACHINE settings — which is also the file che-code's
+        # launcher merges the vscode-editor-configurations ConfigMap into, and it keeps the repo clean.
+        MACHINE_SETTINGS="${CHE_MACHINE_SETTINGS:-/checode/remote/data/Machine/settings.json}"
+        if mkdir -p "$(dirname "$MACHINE_SETTINGS")" 2>/dev/null; then
+          merge_into "$MACHINE_SETTINGS" "$terminal"
+          echo "  terminal profile -> ${MACHINE_SETTINGS} (reload the window if it does not appear)"
+        else
+          echo "  WARNING: ${MACHINE_SETTINGS} unwritable; terminal profile will not apply." >&2
+        fi
+
+        # Editor-safe settings are unrestricted, so the workspace file is fine for those.
+        SAFE='editor.|files.|workbench.|search.|explorer.|diffEditor.|breadcrumbs.|scm.|outline.|problems.|output.|window.|comments.'
+        editor_settings="$(printf '%s' "$META" | jq -c --arg p "$SAFE" '(.settings // {})
+          | with_entries(select(.key as $k | ($p|split("|")|any(. as $x | $k|startswith($x)))))')"
+        [ "$(printf '%s' "$editor_settings" | jq 'length')" -gt 0 ] &&
+          merge_into "${PROJECT_DIR}/.vscode/settings.json" "$editor_settings" &&
+          echo "  editor settings -> .vscode/settings.json"
+
+        # Surface the extensions the devcontainer asks for (including Feature-contributed ones) as
+        # workspace recommendations. che-code cannot auto-install them, but this at least tells the
+        # user what the repo expects instead of silently dropping the list.
+        exts="$(printf '%s' "$META" | jq -c '.extensions // []')"
+        if [ "$(printf '%s' "$exts" | jq 'length')" -gt 0 ]; then
+          merge_into "${PROJECT_DIR}/.vscode/extensions.json" \
+            "$(jq -n --argjson e "$exts" '{recommendations: $e}')"
+          echo "  recommended extensions -> .vscode/extensions.json: $(printf '%s' "$exts" | jq -r 'join(", ")')"
+        fi
+
+        _close_phase
+        echo
+        echo "=== ready ==="
+        printf '  timing: total %ss' "$(( $(date +%s) - T_START ))"
+        for e in "${PHASE_LOG[@]}"; do
+          d="${e%%|*}"; l="${e#*|}"; [ "$d" -ge 2 ] && printf ' | %s %ss' "${l%% *}" "$d"
+        done
+        echo
+        echo "  Terminals open inside the container (profile 'devcontainer')."
+        echo "  Files:  ${PROJECT_DIR} <-> ${WORKSPACE_FOLDER}"
+        [ "$KEEP_ID_OK" = "1" ] && echo "  UID parity ON — files created inside are owned by you." \
+                                || echo "  UID parity OFF — files created inside are subuid-owned."
+        echo "  Shell:  ${PODMAN} exec -it ${CONTAINER_NAME} ${INNER_SHELL}"
+        if [ "$LIFECYCLE_FAILURES" -gt 0 ]; then
+          echo; echo "  WARNING: ${LIFECYCLE_FAILURES} lifecycle command(s) failed."
+          [ "$STRICT_LIFECYCLE" = "1" ] && exit 1
+        fi
+        exit 0
+        DEVCONTAINER_SCRIPT_EOF
+        chmod +x /tmp/start-devcontainer.sh
+        # Run in the FOREGROUND so che-code keeps the task terminal alive and streams progress.
+        # A backgrounded (setsid/nohup &) process is reaped when the task's foreground shell exits,
+        # so it never survived. tee keeps /tmp/devcontainer.log for anyone who wants to tail it.
+        bash /tmp/start-devcontainer.sh 2>&1 | tee /tmp/devcontainer.log
+  - id: rebuild-devcontainer
+    exec:
+      component: universal-developer-image
+      label: Rebuild dev container
+      workingDir: ${PROJECTS_ROOT}
+      commandLine: |
+        [ -f /tmp/start-devcontainer.sh ] || { echo "run the start-devcontainer task first"; exit 1; }
+        REBUILD=1 bash /tmp/start-devcontainer.sh
+  - id: rebuild-devcontainer-no-cache
+    exec:
+      component: universal-developer-image
+      label: Rebuild dev container (no cache)
+      workingDir: ${PROJECTS_ROOT}
+      commandLine: |
+        [ -f /tmp/start-devcontainer.sh ] || { echo "run the start-devcontainer task first"; exit 1; }
+        REBUILD=1 NO_CACHE=1 bash /tmp/start-devcontainer.sh
+  - id: show-devcontainer-log
+    exec:
+      component: universal-developer-image
+      label: Show dev container log
+      workingDir: ${PROJECTS_ROOT}
+      commandLine: |
+        touch /tmp/devcontainer.log
+        tail -n 200 -f /tmp/devcontainer.log
+  - id: clean-devcontainer-images
+    exec:
+      component: universal-developer-image
+      label: Clean up dev container images
+      workingDir: ${PROJECTS_ROOT}
+      commandLine: |
+        PODMAN="${ORIGINAL_PODMAN_PATH:-/usr/bin/podman.orig}"
+        [ -x "$PODMAN" ] || PODMAN=podman
+        "$PODMAN" system prune -af
+        "$PODMAN" system df
+events:
+  postStart:
+    - start-devcontainer

--- a/wsmaster/che-core-api-factory/src/main/resources/devcontainer-devfile-template.yaml
+++ b/wsmaster/che-core-api-factory/src/main/resources/devcontainer-devfile-template.yaml
@@ -20,6 +20,18 @@ commands:
         cat > /tmp/start-devcontainer.sh <<'DEVCONTAINER_SCRIPT_EOF'
         #!/usr/bin/env bash
         #
+        # Copyright (c) 2012-2026 Red Hat, Inc.
+        # This program and the accompanying materials are made
+        # available under the terms of the Eclipse Public License 2.0
+        # which is available at https://www.eclipse.org/legal/epl-2.0/
+        #
+        # SPDX-License-Identifier: EPL-2.0
+        #
+        # Contributors:
+        #   Red Hat, Inc. - initial API and implementation
+        #
+
+        #
         # Outer editor + inner devcontainer.
         # che-code stays in the UDI container; the repo's devcontainer.json is built and run as a
         # nested rootless-podman container. Terminals, lifecycle commands and file ownership are
@@ -34,6 +46,28 @@ commands:
         #   NO_KEEP_ID=1       skip --userns=keep-id (debugging)
         #
         set -uo pipefail
+
+        # Only one instance may touch the container and the podman store at a time. postStart runs this
+        # while the user can also launch the start/rebuild task, and both would race on `podman rm -f`.
+        LOCK_FILE="${LOCK_FILE:-/tmp/.devcontainer-setup.lock}"
+        if command -v flock >/dev/null 2>&1; then
+          exec 9>"$LOCK_FILE" || true
+          if ! flock -n 9; then
+            HOLDER="$(cat "$LOCK_FILE" 2>/dev/null | tr -dc '0-9')"
+            if [ "${REBUILD:-0}" != "1" ]; then
+              echo "another devcontainer setup is in progress (pid ${HOLDER:-?}); exiting (not a rebuild)."
+              exit 0
+            fi
+            echo "rebuild requested; killing in-progress setup (pid ${HOLDER:-?})..."
+            [ -n "$HOLDER" ] && kill "$HOLDER" 2>/dev/null && sleep 1
+            # After killing, the lock should be free — try once more
+            if ! flock -n 9; then
+              [ -n "$HOLDER" ] && kill -9 "$HOLDER" 2>/dev/null && sleep 1
+              flock -w 30 9 || { echo "could not acquire lock after killing previous run" >&2; exit 1; }
+            fi
+          fi
+          echo $$ > "$LOCK_FILE"
+        fi
 
         PROJECTS_ROOT="${PROJECTS_ROOT:-/projects}"
         # Project: explicit arg > DWO's PROJECT_SOURCE > the only directory under PROJECTS_ROOT.
@@ -82,6 +116,21 @@ commands:
         [ -n "$PODMAN" ] || { echo "podman not found" >&2; exit 1; }
         step "1/8" "engine: $PODMAN"
 
+        # ---------------------------------------------------------------------------
+        # 2. Subuid ranges
+        # ---------------------------------------------------------------------------
+        # No storage.conf is written here. UDI's entrypoint (base/ubi*/entrypoint.sh) already selects
+        # overlay+fuse-overlayfs when /dev/fuse is present and falls back to vfs otherwise, so the
+        # driver choice is not ours to repeat, and the graphroot is left at podman's rootless default
+        # (${XDG_DATA_HOME:-$HOME/.local/share}/containers/storage).
+        # CAVEAT: with devEnvironments.persistUserHome enabled (the Che default) $HOME is PVC-backed,
+        # so the image store lands on the workspace PVC. Under DWO's common storage strategy
+        # (including Che's per-user strategy), the cleanup Job removes the workspace directory on
+        # deletion and subuid-owned files can wedge the workspace in Error:
+        # https://github.com/eclipse-che/che/issues/23924. On CRC (2026-09-08), the PVC-backed image
+        # build store was deleted cleanly with another workspace running. Full devcontainer teardown
+        # remains unverified there because nested-container startup failed.
+
         # Derive the range instead of hardcoding a uid — UDI's entrypoint computes this from the
         # actual uid, and a hardcoded "user:1001:..." maps the wrong host range on a uid-1000 pod.
         # NOTE: a 65536-ID userns cannot map container ID 65534 (nobody) however the ranges are
@@ -98,7 +147,7 @@ commands:
         fi
 
         # ---------------------------------------------------------------------------
-        # 2. devcontainer CLI + pre-build config
+        # 3. devcontainer CLI + pre-build config
         # ---------------------------------------------------------------------------
         DEVCONTAINER_BIN="${DEVCONTAINER_BIN:-$(command -v devcontainer || echo /home/user/.devcontainers/bin/devcontainer)}"
         if ! "$DEVCONTAINER_BIN" --version >/dev/null 2>&1; then
@@ -139,7 +188,7 @@ commands:
         CONFIG_FINGERPRINT="$(printf '%s' "$CONFIG_JSON" | sha256sum | cut -d' ' -f1)"
 
         # ---------------------------------------------------------------------------
-        # 3. initializeCommand (runs OUTSIDE the container, per spec)
+        # 4. initializeCommand (runs OUTSIDE the container, per spec)
         # ---------------------------------------------------------------------------
         JQ_NORMALIZE='
         def norm($name):
@@ -166,7 +215,7 @@ commands:
         run_outer "$(printf '%s' "$CONFIG_JSON" | jq -c '.initializeCommand // null')"
 
         # ---------------------------------------------------------------------------
-        # 4. Build
+        # 5. Build
         # ---------------------------------------------------------------------------
         REUSING=0
         if [ "$REBUILD" = "1" ]; then
@@ -194,7 +243,7 @@ commands:
         fi
 
         # ---------------------------------------------------------------------------
-        # 5. Merged metadata from the built image
+        # 6. Merged metadata from the built image
         # ---------------------------------------------------------------------------
         # `devcontainer build` writes a devcontainer.metadata LABEL containing the FULLY MERGED
         # config — the base image's metadata, every Feature's contributions, and devcontainer.json.
@@ -249,7 +298,7 @@ commands:
         [ -n "$skipped" ] && echo "  NOTE: env with \${...} substitution skipped: $skipped" >&2
 
         # ---------------------------------------------------------------------------
-        # 6. Run the container, with UID parity
+        # 7. Run the container, with UID parity
         # ---------------------------------------------------------------------------
         # The whole point of outer-editor is "edit outside, run inside" — so the two sides must agree
         # on file ownership. Without keep-id, anything created inside (node_modules, build output,
@@ -307,7 +356,7 @@ commands:
         "$PODMAN" exec "$CONTAINER_NAME" git config --global --replace-all safe.directory "$WORKSPACE_FOLDER" 2>/dev/null || true
 
         # ---------------------------------------------------------------------------
-        # 7. Lifecycle commands, then editor wiring
+        # 8. Lifecycle commands, then editor wiring
         # ---------------------------------------------------------------------------
         EXEC_USER=(); [ -n "$REMOTE_USER" ] && EXEC_USER=(-u "$REMOTE_USER")
         CREATE_MARKER=/tmp/.devcontainer-create-hooks-done
@@ -355,6 +404,20 @@ commands:
           mkdir -p "$(dirname "$file")"; printf '%s\n' "$cur" | jq '.' > "$file"
         }
 
+        # .vscode/extensions.json is the one generated file that must live in the repo — VS Code reads
+        # recommendations only from there. Keep it out of `git status` via .git/info/exclude, which is
+        # local to the clone and never committed. Ignore rules do not apply to files git already tracks,
+        # so a repo that commits its own .vscode/extensions.json is left completely alone.
+        safe_to_write() {   # $1 = path relative to the project root; returns 0 when writing is OK
+          local rel="$1" gitdir ex
+          gitdir="$(git -C "$PROJECT_DIR" rev-parse --absolute-git-dir 2>/dev/null)" || return 0
+          git -C "$PROJECT_DIR" ls-files --error-unmatch "$rel" >/dev/null 2>&1 && return 1
+          ex="$gitdir/info/exclude"
+          mkdir -p "$(dirname "$ex")" 2>/dev/null || return 0
+          grep -qxF "$rel" "$ex" 2>/dev/null || printf '%s\n' "$rel" >> "$ex"
+          return 0
+        }
+
         profile=(exec -it)
         [ -n "$REMOTE_USER" ] && profile+=(-u "$REMOTE_USER")
         profile+=("${REMOTE_ENV[@]}" -w "$WORKSPACE_FOLDER" "$CONTAINER_NAME" "$INNER_SHELL")
@@ -370,29 +433,46 @@ commands:
         # untrusted workspace, so they must go to MACHINE settings — which is also the file che-code's
         # launcher merges the vscode-editor-configurations ConfigMap into, and it keeps the repo clean.
         MACHINE_SETTINGS="${CHE_MACHINE_SETTINGS:-/checode/remote/data/Machine/settings.json}"
-        if mkdir -p "$(dirname "$MACHINE_SETTINGS")" 2>/dev/null; then
+        MACHINE_OK=0
+        mkdir -p "$(dirname "$MACHINE_SETTINGS")" 2>/dev/null && MACHINE_OK=1
+
+        if [ "$MACHINE_OK" = 1 ]; then
           merge_into "$MACHINE_SETTINGS" "$terminal"
           echo "  terminal profile -> ${MACHINE_SETTINGS} (reload the window if it does not appear)"
         else
           echo "  WARNING: ${MACHINE_SETTINGS} unwritable; terminal profile will not apply." >&2
         fi
 
-        # Editor-safe settings are unrestricted, so the workspace file is fine for those.
+        # Editor settings go to MACHINE settings too, not the repo: the user should not find unexplained
+        # modifications in a tree they did not touch. /checode is recreated on each workspace start, so
+        # nothing written here survives into a later session with a different project.
+        # NOTE: machine scope is editor-wide, not per-folder. With one project — the normal case for a
+        # factory workspace — that is indistinguishable from workspace scope; with several projects under
+        # $PROJECTS_ROOT the last run wins.
         SAFE='editor.|files.|workbench.|search.|explorer.|diffEditor.|breadcrumbs.|scm.|outline.|problems.|output.|window.|comments.'
         editor_settings="$(printf '%s' "$META" | jq -c --arg p "$SAFE" '(.settings // {})
           | with_entries(select(.key as $k | ($p|split("|")|any(. as $x | $k|startswith($x)))))')"
-        [ "$(printf '%s' "$editor_settings" | jq 'length')" -gt 0 ] &&
-          merge_into "${PROJECT_DIR}/.vscode/settings.json" "$editor_settings" &&
-          echo "  editor settings -> .vscode/settings.json"
+        if [ "$(printf '%s' "$editor_settings" | jq 'length')" -gt 0 ]; then
+          if [ "$MACHINE_OK" = 1 ]; then
+            merge_into "$MACHINE_SETTINGS" "$editor_settings"
+            echo "  editor settings -> ${MACHINE_SETTINGS}"
+          else
+            echo "  WARNING: ${MACHINE_SETTINGS} unwritable; editor settings not applied." >&2
+          fi
+        fi
 
         # Surface the extensions the devcontainer asks for (including Feature-contributed ones) as
         # workspace recommendations. che-code cannot auto-install them, but this at least tells the
         # user what the repo expects instead of silently dropping the list.
         exts="$(printf '%s' "$META" | jq -c '.extensions // []')"
         if [ "$(printf '%s' "$exts" | jq 'length')" -gt 0 ]; then
-          merge_into "${PROJECT_DIR}/.vscode/extensions.json" \
-            "$(jq -n --argjson e "$exts" '{recommendations: $e}')"
-          echo "  recommended extensions -> .vscode/extensions.json: $(printf '%s' "$exts" | jq -r 'join(", ")')"
+          if safe_to_write .vscode/extensions.json; then
+            merge_into "${PROJECT_DIR}/.vscode/extensions.json" \
+              "$(jq -n --argjson e "$exts" '{recommendations: $e}')"
+            echo "  recommended extensions -> .vscode/extensions.json: $(printf '%s' "$exts" | jq -r 'join(", ")')"
+          else
+            echo "  recommended extensions (not written, .vscode/extensions.json is tracked): $(printf '%s' "$exts" | jq -r 'join(", ")')"
+          fi
         fi
 
         _close_phase

--- a/wsmaster/che-core-api-factory/src/main/resources/devcontainer-devfile-template.yaml
+++ b/wsmaster/che-core-api-factory/src/main/resources/devcontainer-devfile-template.yaml
@@ -44,31 +44,34 @@ commands:
         #   NO_CACHE=1         rebuild without cache (passes --no-cache to devcontainer build)
         #   STRICT_LIFECYCLE=1 exit non-zero if any lifecycle command fails
         #   NO_KEEP_ID=1       skip --userns=keep-id (debugging)
+        #   CHE_DEVCONTAINER_RUNTIME  terminal description (default: /tmp/che-devcontainer/runtime.json)
+        #   PREFLIGHT_IMAGE    runnable probe image (default: quay.io/podman/hello:latest; override for a registry mirror)
         #
         set -uo pipefail
 
-        # Only one instance may touch the container and the podman store at a time. postStart runs this
-        # while the user can also launch the start/rebuild task, and both would race on `podman rm -f`.
+        # Serialize setup and rebuild without interrupting an active build. Opening in append mode
+        # preserves the current owner's PID for the extension while another invocation waits.
         LOCK_FILE="${LOCK_FILE:-/tmp/.devcontainer-setup.lock}"
+        LOCK_HELD=0
         if command -v flock >/dev/null 2>&1; then
-          exec 9>"$LOCK_FILE" || true
+          exec 9>>"$LOCK_FILE" || { echo "cannot open setup lock: $LOCK_FILE" >&2; exit 1; }
           if ! flock -n 9; then
-            HOLDER="$(cat "$LOCK_FILE" 2>/dev/null | tr -dc '0-9')"
-            if [ "${REBUILD:-0}" != "1" ]; then
-              echo "another devcontainer setup is in progress (pid ${HOLDER:-?}); exiting (not a rebuild)."
-              exit 0
-            fi
-            echo "rebuild requested; killing in-progress setup (pid ${HOLDER:-?})..."
-            [ -n "$HOLDER" ] && kill "$HOLDER" 2>/dev/null && sleep 1
-            # After killing, the lock should be free — try once more
-            if ! flock -n 9; then
-              [ -n "$HOLDER" ] && kill -9 "$HOLDER" 2>/dev/null && sleep 1
-              flock -w 30 9 || { echo "could not acquire lock after killing previous run" >&2; exit 1; }
-            fi
+            echo "another devcontainer setup is in progress; waiting..."
+            flock -w 900 9 || { echo "timed out waiting for the in-progress setup" >&2; exit 1; }
           fi
-          echo $$ > "$LOCK_FILE"
+          LOCK_HELD=1
+          printf '%s\n' "$$" > "$LOCK_FILE"
         fi
 
+        # The parent owns the lock and stays alive for the extension's PID-based build detection.
+        # Close the descriptor in the setup child so conmon, fuse-overlayfs, and lifecycle processes
+        # cannot retain it after setup finishes.
+        (
+        exec 9>&-
+        RUNTIME_FILE="${CHE_DEVCONTAINER_RUNTIME:-/tmp/che-devcontainer/runtime.json}"
+        # Invalidate the previous terminal configuration while holding the setup lock. A failed
+        # setup must never leave a description that the extension could mistake for a ready result.
+        rm -f -- "$RUNTIME_FILE" || exit 1
         PROJECTS_ROOT="${PROJECTS_ROOT:-/projects}"
         # Project: explicit arg > DWO's PROJECT_SOURCE > the only directory under PROJECTS_ROOT.
         if [ "$#" -ge 1 ] && [ -n "${1:-}" ]; then
@@ -115,6 +118,33 @@ commands:
         [ -x "$PODMAN" ] || PODMAN="$(command -v podman 2>/dev/null)"
         [ -n "$PODMAN" ] || { echo "podman not found" >&2; exit 1; }
         step "1/8" "engine: $PODMAN"
+
+        # ---------------------------------------------------------------------------
+        # 1b. Preflight: can this workspace run nested containers at all?
+        # ---------------------------------------------------------------------------
+        # Exercise the same engine and host networking used by start_container. Podman info's
+        # capability and UID-map fields do not prove that a container can actually start.
+        # This checks basic execution only, not project builds, bind mounts, or keep-id mappings.
+        PREFLIGHT_IMAGE="${PREFLIGHT_IMAGE:-quay.io/podman/hello:latest}"
+        PREFLIGHT_CONTAINER="che-devcontainer-preflight-$$"
+        step "1b" "checking nested container execution (timeout: 120s)..."
+        PREFLIGHT_RC=0
+        timeout --kill-after=5s 120s "$PODMAN" run --rm --network=host \
+          --name "$PREFLIGHT_CONTAINER" "$PREFLIGHT_IMAGE" 9>&- || PREFLIGHT_RC=$?
+        if [ "$PREFLIGHT_RC" -ne 0 ]; then
+          # A timeout or runtime failure may leave a partially created container. Only remove
+          # this probe's container, and bound cleanup as well. Preserve the original failure.
+          timeout --kill-after=5s 10s "$PODMAN" rm -f "$PREFLIGHT_CONTAINER" \
+            >/dev/null 2>&1 9>&- || true
+          if [ "$PREFLIGHT_RC" -eq 124 ] || [ "$PREFLIGHT_RC" -eq 137 ]; then
+            echo "Nested-container preflight timed out; devcontainer setup stopped." >&2
+          else
+            echo "Nested-container preflight failed (exit ${PREFLIGHT_RC}); devcontainer setup stopped." >&2
+          fi
+          echo "See the Podman error above for the cause (for example, image pull or container runtime failure)." >&2
+          exit "$PREFLIGHT_RC"
+        fi
+        step "1b" "nested container execution succeeded"
 
         # ---------------------------------------------------------------------------
         # 2. Subuid ranges
@@ -322,7 +352,7 @@ commands:
         # The dev container does NOT receive cluster credentials. It runs arbitrary repository
         # code and with --network=host already reaches che-code (:3100) and machine-exec (:3333).
         # VS Code dev containers do not expose Kubernetes service-account tokens; cluster tooling
-        # lives in UDI — use the "outer (UDI)" terminal profile for kubectl/oc.
+        # lives in UDI — use a regular editor terminal for kubectl/oc.
         start_container() {   # $1 = extra args array name
           local -n extra="$1"
           "$PODMAN" run -d --name "$CONTAINER_NAME" --network=host \
@@ -418,30 +448,10 @@ commands:
           return 0
         }
 
-        profile=(exec -it)
-        [ -n "$REMOTE_USER" ] && profile+=(-u "$REMOTE_USER")
-        profile+=("${REMOTE_ENV[@]}" -w "$WORKSPACE_FOLDER" "$CONTAINER_NAME" "$INNER_SHELL")
-        profile_json="$(printf '%s\n' "${profile[@]}" | jq -R . | jq -s -c .)"
-        terminal="$(jq -n --argjson a "$profile_json" --arg p "$PODMAN" '{
-          "terminal.integrated.profiles.linux": {
-            "devcontainer": { "path": $p, "args": $a, "icon": "container" },
-            "outer (UDI)":  { "path": "/bin/bash" } },
-          "terminal.integrated.defaultProfile.linux": "devcontainer" }')"
-
-        # terminal.integrated.profiles.* and defaultProfile.* are declared `restricted: true` in
-        # VS Code. Restricted settings coming from WORKSPACE settings are silently discarded in an
-        # untrusted workspace, so they must go to MACHINE settings — which is also the file che-code's
-        # launcher merges the vscode-editor-configurations ConfigMap into, and it keeps the repo clean.
+        # Terminal configuration is owned by the extension; only editor settings belong here.
         MACHINE_SETTINGS="${CHE_MACHINE_SETTINGS:-/checode/remote/data/Machine/settings.json}"
         MACHINE_OK=0
         mkdir -p "$(dirname "$MACHINE_SETTINGS")" 2>/dev/null && MACHINE_OK=1
-
-        if [ "$MACHINE_OK" = 1 ]; then
-          merge_into "$MACHINE_SETTINGS" "$terminal"
-          echo "  terminal profile -> ${MACHINE_SETTINGS} (reload the window if it does not appear)"
-        else
-          echo "  WARNING: ${MACHINE_SETTINGS} unwritable; terminal profile will not apply." >&2
-        fi
 
         # Editor settings go to MACHINE settings too, not the repo: the user should not find unexplained
         # modifications in a tree they did not touch. /checode is recreated on each workspace start, so
@@ -475,6 +485,41 @@ commands:
           fi
         fi
 
+        if [ "$LIFECYCLE_FAILURES" -gt 0 ]; then
+          echo; echo "  WARNING: ${LIFECYCLE_FAILURES} lifecycle command(s) failed."
+          [ "$STRICT_LIFECYCLE" = "1" ] && exit 1
+        fi
+
+        # Publish only a successful, running container. The ID binds these resolved values to
+        # this instance, so a replacement container cannot reuse an obsolete terminal description.
+        publish_runtime() (
+          umask 077
+          local runtime_dir runtime_tmp container_id remote_env_json
+          runtime_dir="$(dirname "$RUNTIME_FILE")"
+          mkdir -p "$runtime_dir" || return 1
+          container_id="$("$PODMAN" inspect --format json "$CONTAINER_NAME" | jq -er \
+            '.[0] | select(.State.Running == true) | .Id | select(type == "string" and length > 0)')" || return 1
+          # Use exactly the already-resolved environment arguments passed to lifecycle commands.
+          remote_env_json='{}'
+          local i entry key value
+          for ((i=1; i<${#REMOTE_ENV[@]}; i+=2)); do
+            entry="${REMOTE_ENV[i]}"; key="${entry%%=*}"; value="${entry#*=}"
+            remote_env_json="$(jq -cn --argjson env "$remote_env_json" --arg k "$key" --arg v "$value" '$env + {($k): $v}')" || return 1
+          done
+          runtime_tmp="$(mktemp "$runtime_dir/.runtime.XXXXXX")" || return 1
+          trap 'rm -f -- "$runtime_tmp"' EXIT
+          jq -n --arg containerName "$CONTAINER_NAME" --arg containerId "$container_id" \
+            --arg podmanPath "$PODMAN" --arg image "$IMAGE_NAME" --arg remoteUser "$REMOTE_USER" \
+            --arg workspaceFolder "$WORKSPACE_FOLDER" --arg shell "$INNER_SHELL" \
+            --arg fingerprint "$CONFIG_FINGERPRINT" --argjson remoteEnv "$remote_env_json" \
+            '{version: 1, containerName: $containerName, containerId: $containerId,
+              podmanPath: $podmanPath, image: $image, remoteUser: $remoteUser,
+              workspaceFolder: $workspaceFolder, shell: $shell, remoteEnv: $remoteEnv,
+              fingerprint: $fingerprint}' > "$runtime_tmp" || return 1
+          mv -f -- "$runtime_tmp" "$RUNTIME_FILE"
+        )
+        publish_runtime || { echo "could not publish devcontainer terminal configuration" >&2; exit 1; }
+
         _close_phase
         echo
         echo "=== ready ==="
@@ -483,22 +528,26 @@ commands:
           d="${e%%|*}"; l="${e#*|}"; [ "$d" -ge 2 ] && printf ' | %s %ss' "${l%% *}" "$d"
         done
         echo
-        echo "  Terminals open inside the container (profile 'devcontainer')."
+        echo "  Use the extension action: Open Terminal in Dev Container."
         echo "  Files:  ${PROJECT_DIR} <-> ${WORKSPACE_FOLDER}"
         [ "$KEEP_ID_OK" = "1" ] && echo "  UID parity ON — files created inside are owned by you." \
                                 || echo "  UID parity OFF — files created inside are subuid-owned."
         echo "  Shell:  ${PODMAN} exec -it ${CONTAINER_NAME} ${INNER_SHELL}"
-        if [ "$LIFECYCLE_FAILURES" -gt 0 ]; then
-          echo; echo "  WARNING: ${LIFECYCLE_FAILURES} lifecycle command(s) failed."
-          [ "$STRICT_LIFECYCLE" = "1" ] && exit 1
-        fi
         exit 0
+        )
+        SETUP_RC=$?
+        # Clear the published PID while we still own the lock, before another run can acquire it.
+        if [ "$LOCK_HELD" = 1 ]; then
+          : > "$LOCK_FILE"
+        fi
+        exit "$SETUP_RC"
         DEVCONTAINER_SCRIPT_EOF
         chmod +x /tmp/start-devcontainer.sh
         # Run in the FOREGROUND so che-code keeps the task terminal alive and streams progress.
         # A backgrounded (setsid/nohup &) process is reaped when the task's foreground shell exits,
         # so it never survived. tee keeps /tmp/devcontainer.log for anyone who wants to tail it.
-        bash /tmp/start-devcontainer.sh 2>&1 | tee /tmp/devcontainer.log
+        # Preserve setup failures through tee so the extension receives the task's exit code.
+        bash -o pipefail -c 'bash /tmp/start-devcontainer.sh 2>&1 | tee /tmp/devcontainer.log'
   - id: rebuild-devcontainer
     exec:
       component: universal-developer-image

--- a/wsmaster/che-core-api-factory/src/main/resources/devcontainer-devfile-template.yaml
+++ b/wsmaster/che-core-api-factory/src/main/resources/devcontainer-devfile-template.yaml
@@ -533,6 +533,3 @@ commands:
         [ -x "$PODMAN" ] || PODMAN=podman
         "$PODMAN" system prune -af
         "$PODMAN" system df
-events:
-  postStart:
-    - start-devcontainer

--- a/wsmaster/che-core-api-factory/src/main/resources/devcontainer-devfile-template.yaml
+++ b/wsmaster/che-core-api-factory/src/main/resources/devcontainer-devfile-template.yaml
@@ -28,8 +28,7 @@ commands:
         # Env overrides:
         #   CONTAINER_NAME     nested container name           (default: devcontainer)
         #   IMAGE_NAME         built image tag                 (default: localhost/devcontainer:latest)
-        #   REUSE_CONTAINER=1  reuse a running container instead of rebuilding
-        #   REBUILD=1          force rebuild (remove existing container and image)
+        #   REBUILD=1          force rebuild (remove existing container and image; default: auto-rebuild when config changes)
         #   NO_CACHE=1         rebuild without cache (passes --no-cache to devcontainer build)
         #   STRICT_LIFECYCLE=1 exit non-zero if any lifecycle command fails
         #   NO_KEEP_ID=1       skip --userns=keep-id (debugging)
@@ -56,7 +55,6 @@ commands:
         PROJECT_NAME="$(basename "$PROJECT_DIR")"
         CONTAINER_NAME="${CONTAINER_NAME:-devcontainer}"
         IMAGE_NAME="${IMAGE_NAME:-localhost/devcontainer:latest}"
-        REUSE_CONTAINER="${REUSE_CONTAINER:-0}"
         REBUILD="${REBUILD:-0}"
         NO_CACHE="${NO_CACHE:-0}"
         STRICT_LIFECYCLE="${STRICT_LIFECYCLE:-0}"
@@ -84,19 +82,6 @@ commands:
         [ -n "$PODMAN" ] || { echo "podman not found" >&2; exit 1; }
         step "1/8" "engine: $PODMAN"
 
-        # ---------------------------------------------------------------------------
-        # 2. Storage + subuid
-        # ---------------------------------------------------------------------------
-        # Keep the image store OFF the PVC: subuid-owned files there break DWO's cleanup job and
-        # wedge the workspace in Error on teardown. Prefer overlay+fuse-overlayfs when /dev/fuse
-        # exists — VFS is much slower and rules out --userns=keep-id.
-        mkdir -p /tmp/podman/storage ~/.config/containers
-        if [ -c /dev/fuse ] && [ -x /usr/bin/fuse-overlayfs ]; then
-          printf '[storage]\ndriver = "overlay"\ngraphroot = "/tmp/podman/storage"\n[storage.options.overlay]\nmount_program = "/usr/bin/fuse-overlayfs"\n' > ~/.config/containers/storage.conf
-        else
-          printf '[storage]\ndriver = "vfs"\ngraphroot = "/tmp/podman/storage"\n' > ~/.config/containers/storage.conf
-        fi
-
         # Derive the range instead of hardcoding a uid — UDI's entrypoint computes this from the
         # actual uid, and a hardcoded "user:1001:..." maps the wrong host range on a uid-1000 pod.
         # NOTE: a 65536-ID userns cannot map container ID 65534 (nobody) however the ranges are
@@ -108,16 +93,20 @@ commands:
           printf '%s\n' "$RANGES" > /etc/subuid 2>/dev/null &&
           printf '%s\n' "$RANGES" > /etc/subgid 2>/dev/null &&
           "$PODMAN" system migrate >/dev/null 2>&1 &&
-          step "2/8" "storage=$("$PODMAN" info --format json 2>/dev/null | jq -r '.store.graphDriverName') subuid=${SU_USER}(${SU_UID})" ||
-          step "2/8" "storage=$("$PODMAN" info --format json 2>/dev/null | jq -r '.store.graphDriverName') subuid=unchanged"
+          step "2/8" "store=$("$PODMAN" info --format json 2>/dev/null | jq -r '.store.graphDriverName + " @ " + .store.graphRoot') subuid=${SU_USER}(${SU_UID})" ||
+          step "2/8" "store=$("$PODMAN" info --format json 2>/dev/null | jq -r '.store.graphDriverName + " @ " + .store.graphRoot') subuid=unchanged"
         fi
 
         # ---------------------------------------------------------------------------
-        # 3. devcontainer CLI + pre-build config
+        # 2. devcontainer CLI + pre-build config
         # ---------------------------------------------------------------------------
         DEVCONTAINER_BIN="${DEVCONTAINER_BIN:-$(command -v devcontainer || echo /home/user/.devcontainers/bin/devcontainer)}"
         if ! "$DEVCONTAINER_BIN" --version >/dev/null 2>&1; then
           step "3/8" "installing devcontainer CLI..."
+          # TODO: remove once the devcontainer CLI is bundled in the Universal Developer Image.
+          # Tracking: https://github.com/devfile/developer-images/pull/267
+          # Until then the CLI is installed at workspace start, which requires network access to
+          # npm/GitHub and is a blocker for airgapped clusters.
           npm install -g @devcontainers/cli >/dev/null 2>&1 ||
             curl -fsSL https://raw.githubusercontent.com/devcontainers/cli/main/scripts/install.sh | sh
           DEVCONTAINER_BIN="$(command -v devcontainer || echo /home/user/.devcontainers/bin/devcontainer)"
@@ -147,8 +136,10 @@ commands:
           [ -n "$CONFIG_JSON" ] || { echo "  could not parse $DC" >&2; exit 1; }
         fi
 
+        CONFIG_FINGERPRINT="$(printf '%s' "$CONFIG_JSON" | sha256sum | cut -d' ' -f1)"
+
         # ---------------------------------------------------------------------------
-        # 4. initializeCommand (runs OUTSIDE the container, per spec)
+        # 3. initializeCommand (runs OUTSIDE the container, per spec)
         # ---------------------------------------------------------------------------
         JQ_NORMALIZE='
         def norm($name):
@@ -175,16 +166,26 @@ commands:
         run_outer "$(printf '%s' "$CONFIG_JSON" | jq -c '.initializeCommand // null')"
 
         # ---------------------------------------------------------------------------
-        # 5. Build
+        # 4. Build
         # ---------------------------------------------------------------------------
         REUSING=0
         if [ "$REBUILD" = "1" ]; then
           "$PODMAN" rm -f "$CONTAINER_NAME" >/dev/null 2>&1 || true
-          "$PODMAN" rmi -f "$IMAGE_NAME" >/dev/null 2>&1 || true
+          [ "$NO_CACHE" = "1" ] && { "$PODMAN" rmi -f "$IMAGE_NAME" >/dev/null 2>&1 || true; }
+        elif "$PODMAN" container exists "$CONTAINER_NAME" 2>/dev/null; then
+          STORED_FP="$("$PODMAN" inspect --format json "$CONTAINER_NAME" 2>/dev/null \
+            | jq -r '.[0].Config.Labels["che.devcontainer.config"] // ""' 2>/dev/null || echo "")"
+          if [ "$STORED_FP" = "$CONFIG_FINGERPRINT" ]; then
+            REUSING=1; step "5/8" "reusing existing container (config unchanged)."
+            "$PODMAN" start "$CONTAINER_NAME" >/dev/null 2>&1 || true
+          else
+            REUSING=1; step "5/8" "reusing existing container (config STALE)."
+            echo "  WARNING: devcontainer.json changed since this container was built."
+            echo "  Run the 'Rebuild dev container' task to apply changes."
+            "$PODMAN" start "$CONTAINER_NAME" >/dev/null 2>&1 || true
+          fi
         fi
-        if [ "$REBUILD" != "1" ] && [ "$REUSE_CONTAINER" = "1" ] && "$PODMAN" container exists "$CONTAINER_NAME" 2>/dev/null; then
-          REUSING=1; echo "[5/8] reusing existing container."; "$PODMAN" start "$CONTAINER_NAME" >/dev/null 2>&1 || true
-        else
+        if [ "$REUSING" = "0" ]; then
           step "5/8" "building image (slow part)..."
           BUILD_ARGS=(--docker-path="$PODMAN" --workspace-folder "$PROJECT_DIR" --image-name "$IMAGE_NAME")
           [ "$NO_CACHE" = "1" ] && BUILD_ARGS+=(--no-cache)
@@ -193,7 +194,7 @@ commands:
         fi
 
         # ---------------------------------------------------------------------------
-        # 6. Merged metadata from the built image
+        # 5. Merged metadata from the built image
         # ---------------------------------------------------------------------------
         # `devcontainer build` writes a devcontainer.metadata LABEL containing the FULLY MERGED
         # config — the base image's metadata, every Feature's contributions, and devcontainer.json.
@@ -248,7 +249,7 @@ commands:
         [ -n "$skipped" ] && echo "  NOTE: env with \${...} substitution skipped: $skipped" >&2
 
         # ---------------------------------------------------------------------------
-        # 7. Run the container, with UID parity
+        # 6. Run the container, with UID parity
         # ---------------------------------------------------------------------------
         # The whole point of outer-editor is "edit outside, run inside" — so the two sides must agree
         # on file ownership. Without keep-id, anything created inside (node_modules, build output,
@@ -269,14 +270,16 @@ commands:
           fi
         fi
 
+        # The dev container does NOT receive cluster credentials. It runs arbitrary repository
+        # code and with --network=host already reaches che-code (:3100) and machine-exec (:3333).
+        # VS Code dev containers do not expose Kubernetes service-account tokens; cluster tooling
+        # lives in UDI — use the "outer (UDI)" terminal profile for kubectl/oc.
         start_container() {   # $1 = extra args array name
           local -n extra="$1"
           "$PODMAN" run -d --name "$CONTAINER_NAME" --network=host \
+            --label "che.devcontainer.config=${CONFIG_FINGERPRINT}" \
             "${extra[@]}" \
             -v "$PROJECT_DIR:${WORKSPACE_FOLDER}" \
-            -v /var/run/secrets/kubernetes.io/serviceaccount:/var/run/secrets/kubernetes.io/serviceaccount:ro \
-            -e KUBERNETES_SERVICE_HOST="${KUBERNETES_SERVICE_HOST:-}" \
-            -e KUBERNETES_SERVICE_PORT="${KUBERNETES_SERVICE_PORT:-}" \
             "${CONTAINER_ENV[@]}" \
             "$IMAGE_NAME" sleep infinity
         }
@@ -304,7 +307,7 @@ commands:
         "$PODMAN" exec "$CONTAINER_NAME" git config --global --replace-all safe.directory "$WORKSPACE_FOLDER" 2>/dev/null || true
 
         # ---------------------------------------------------------------------------
-        # 8. Lifecycle commands, then editor wiring
+        # 7. Lifecycle commands, then editor wiring
         # ---------------------------------------------------------------------------
         EXEC_USER=(); [ -n "$REMOTE_USER" ] && EXEC_USER=(-u "$REMOTE_USER")
         CREATE_MARKER=/tmp/.devcontainer-create-hooks-done

--- a/wsmaster/che-core-api-factory/src/test/java/org/eclipse/che/api/factory/server/urlfactory/URLFactoryBuilderTest.java
+++ b/wsmaster/che-core-api-factory/src/test/java/org/eclipse/che/api/factory/server/urlfactory/URLFactoryBuilderTest.java
@@ -702,6 +702,301 @@ public class URLFactoryBuilderTest {
     assertFalse(result.isPresent());
   }
 
+  @Test
+  public void testDevcontainerEmptyContentReturnsEmpty() throws Exception {
+    String devfileLocation = "http://repo/raw/devfile.yaml";
+    String devcontainerLocation = "http://repo/raw/.devcontainer/devcontainer.json";
+    String devcontainerLocation2 = "http://repo/raw/.devcontainer.json";
+
+    RemoteFactoryUrl remoteUrl =
+        new RemoteFactoryUrl() {
+          @Override
+          public String getProviderName() {
+            return "test";
+          }
+
+          @Override
+          public List<DevfileLocation> devfileFileLocations() {
+            return singletonList(
+                new DevfileLocation() {
+                  @Override
+                  public Optional<String> filename() {
+                    return Optional.of("devfile.yaml");
+                  }
+
+                  @Override
+                  public String location() {
+                    return devfileLocation;
+                  }
+                });
+          }
+
+          @Override
+          public String rawFileLocation(String filename) {
+            return "http://repo/raw/" + filename;
+          }
+
+          @Override
+          public String getHostName() {
+            return "repo";
+          }
+
+          @Override
+          public String getProviderUrl() {
+            return "http://repo";
+          }
+
+          @Override
+          public String getBranch() {
+            return null;
+          }
+
+          @Override
+          public Optional<String> getCredentials() {
+            return Optional.empty();
+          }
+
+          @Override
+          public void setDevfileFilename(String devfileName) {}
+        };
+
+    when(fileContentProvider.fetchContent(eq(devfileLocation)))
+        .thenThrow(new IOException("not found"));
+    when(fileContentProvider.fetchContent(eq(devcontainerLocation))).thenReturn("");
+    when(fileContentProvider.fetchContent(eq(devcontainerLocation2))).thenReturn("");
+
+    Optional<FactoryMetaDto> result =
+        urlFactoryBuilder.createFactoryFromDevfile(
+            remoteUrl, fileContentProvider, emptyMap(), false);
+
+    assertFalse(result.isPresent());
+  }
+
+  @Test
+  public void testDevcontainerHtmlContentReturnsEmpty() throws Exception {
+    String devfileLocation = "http://repo/raw/devfile.yaml";
+    String devcontainerLocation = "http://repo/raw/.devcontainer/devcontainer.json";
+    String devcontainerLocation2 = "http://repo/raw/.devcontainer.json";
+
+    RemoteFactoryUrl remoteUrl =
+        new RemoteFactoryUrl() {
+          @Override
+          public String getProviderName() {
+            return "test";
+          }
+
+          @Override
+          public List<DevfileLocation> devfileFileLocations() {
+            return singletonList(
+                new DevfileLocation() {
+                  @Override
+                  public Optional<String> filename() {
+                    return Optional.of("devfile.yaml");
+                  }
+
+                  @Override
+                  public String location() {
+                    return devfileLocation;
+                  }
+                });
+          }
+
+          @Override
+          public String rawFileLocation(String filename) {
+            return "http://repo/raw/" + filename;
+          }
+
+          @Override
+          public String getHostName() {
+            return "repo";
+          }
+
+          @Override
+          public String getProviderUrl() {
+            return "http://repo";
+          }
+
+          @Override
+          public String getBranch() {
+            return null;
+          }
+
+          @Override
+          public Optional<String> getCredentials() {
+            return Optional.empty();
+          }
+
+          @Override
+          public void setDevfileFilename(String devfileName) {}
+        };
+
+    when(fileContentProvider.fetchContent(eq(devfileLocation)))
+        .thenThrow(new IOException("not found"));
+    when(fileContentProvider.fetchContent(eq(devcontainerLocation)))
+        .thenReturn("<!DOCTYPE html><html><body>Access denied</body></html>");
+    when(fileContentProvider.fetchContent(eq(devcontainerLocation2)))
+        .thenReturn("<!DOCTYPE html><html><body>Access denied</body></html>");
+
+    Optional<FactoryMetaDto> result =
+        urlFactoryBuilder.createFactoryFromDevfile(
+            remoteUrl, fileContentProvider, emptyMap(), false);
+
+    assertFalse(result.isPresent());
+  }
+
+  @Test
+  public void testDevcontainerJsoncWithLeadingCommentDetected() throws Exception {
+    String devfileLocation = "http://repo/raw/devfile.yaml";
+    String devcontainerLocation = "http://repo/raw/.devcontainer/devcontainer.json";
+
+    RemoteFactoryUrl remoteUrl =
+        new RemoteFactoryUrl() {
+          @Override
+          public String getProviderName() {
+            return "test";
+          }
+
+          @Override
+          public List<DevfileLocation> devfileFileLocations() {
+            return singletonList(
+                new DevfileLocation() {
+                  @Override
+                  public Optional<String> filename() {
+                    return Optional.of("devfile.yaml");
+                  }
+
+                  @Override
+                  public String location() {
+                    return devfileLocation;
+                  }
+                });
+          }
+
+          @Override
+          public String rawFileLocation(String filename) {
+            return "http://repo/raw/" + filename;
+          }
+
+          @Override
+          public String getHostName() {
+            return "repo";
+          }
+
+          @Override
+          public String getProviderUrl() {
+            return "http://repo";
+          }
+
+          @Override
+          public String getBranch() {
+            return null;
+          }
+
+          @Override
+          public Optional<String> getCredentials() {
+            return Optional.empty();
+          }
+
+          @Override
+          public void setDevfileFilename(String devfileName) {}
+        };
+
+    Map<String, Object> templateAdditions =
+        Map.of("commands", List.of(Map.of("id", "start-devcontainer")));
+
+    when(fileContentProvider.fetchContent(eq(devfileLocation)))
+        .thenThrow(new IOException("not found"));
+    when(fileContentProvider.fetchContent(eq(devcontainerLocation)))
+        .thenReturn("// This is a JSONC comment\n{\"name\": \"test\"}");
+    JsonNode templateNode = new ObjectNode(JsonNodeFactory.instance);
+    when(devfileParser.parseYamlRaw(anyString())).thenReturn(templateNode);
+    when(devfileParser.convertYamlToMap(templateNode)).thenReturn(templateAdditions);
+
+    Optional<FactoryMetaDto> result =
+        urlFactoryBuilder.createFactoryFromDevfile(
+            remoteUrl, fileContentProvider, emptyMap(), false);
+
+    assertTrue(result.isPresent());
+    assertEquals(result.get().getSource(), ".devcontainer/devcontainer.json");
+    assertTrue(result.get() instanceof FactoryDevfileV2Dto);
+  }
+
+  @Test
+  public void testDevcontainerJsoncWithBlockCommentDetected() throws Exception {
+    String devfileLocation = "http://repo/raw/devfile.yaml";
+    String devcontainerLocation = "http://repo/raw/.devcontainer/devcontainer.json";
+
+    RemoteFactoryUrl remoteUrl =
+        new RemoteFactoryUrl() {
+          @Override
+          public String getProviderName() {
+            return "test";
+          }
+
+          @Override
+          public List<DevfileLocation> devfileFileLocations() {
+            return singletonList(
+                new DevfileLocation() {
+                  @Override
+                  public Optional<String> filename() {
+                    return Optional.of("devfile.yaml");
+                  }
+
+                  @Override
+                  public String location() {
+                    return devfileLocation;
+                  }
+                });
+          }
+
+          @Override
+          public String rawFileLocation(String filename) {
+            return "http://repo/raw/" + filename;
+          }
+
+          @Override
+          public String getHostName() {
+            return "repo";
+          }
+
+          @Override
+          public String getProviderUrl() {
+            return "http://repo";
+          }
+
+          @Override
+          public String getBranch() {
+            return null;
+          }
+
+          @Override
+          public Optional<String> getCredentials() {
+            return Optional.empty();
+          }
+
+          @Override
+          public void setDevfileFilename(String devfileName) {}
+        };
+
+    Map<String, Object> templateAdditions =
+        Map.of("commands", List.of(Map.of("id", "start-devcontainer")));
+
+    when(fileContentProvider.fetchContent(eq(devfileLocation)))
+        .thenThrow(new IOException("not found"));
+    when(fileContentProvider.fetchContent(eq(devcontainerLocation)))
+        .thenReturn("/*\n * Generated config\n */\n{\"name\": \"test\"}");
+    JsonNode templateNode = new ObjectNode(JsonNodeFactory.instance);
+    when(devfileParser.parseYamlRaw(anyString())).thenReturn(templateNode);
+    when(devfileParser.convertYamlToMap(templateNode)).thenReturn(templateAdditions);
+
+    Optional<FactoryMetaDto> result =
+        urlFactoryBuilder.createFactoryFromDevfile(
+            remoteUrl, fileContentProvider, emptyMap(), false);
+
+    assertTrue(result.isPresent());
+    assertEquals(result.get().getSource(), ".devcontainer/devcontainer.json");
+  }
+
   @DataProvider
   public static Object[][] devfileExceptions() {
     return new Object[][] {

--- a/wsmaster/che-core-api-factory/src/test/java/org/eclipse/che/api/factory/server/urlfactory/URLFactoryBuilderTest.java
+++ b/wsmaster/che-core-api-factory/src/test/java/org/eclipse/che/api/factory/server/urlfactory/URLFactoryBuilderTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012-2025 Red Hat, Inc.
+ * Copyright (c) 2012-2026 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/
@@ -18,8 +18,11 @@ import static org.eclipse.che.api.workspace.server.devfile.Constants.KUBERNETES_
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
 import static org.testng.Assert.assertNotNull;
 import static org.testng.Assert.assertNull;
 import static org.testng.Assert.assertTrue;
@@ -408,6 +411,295 @@ public class URLFactoryBuilderTest {
         fileContentProvider,
         emptyMap(),
         false);
+  }
+
+  @Test
+  public void testDevfileFoundSoDevcontainerProbeNeverRuns() throws Exception {
+    String devfileLocation = "http://repo/raw/devfile.yaml";
+    String devcontainerLocation = "http://repo/raw/.devcontainer/devcontainer.json";
+
+    RemoteFactoryUrl remoteUrl =
+        new RemoteFactoryUrl() {
+          @Override
+          public String getProviderName() {
+            return "test";
+          }
+
+          @Override
+          public List<DevfileLocation> devfileFileLocations() {
+            return singletonList(
+                new DevfileLocation() {
+                  @Override
+                  public Optional<String> filename() {
+                    return Optional.of("devfile.yaml");
+                  }
+
+                  @Override
+                  public String location() {
+                    return devfileLocation;
+                  }
+                });
+          }
+
+          @Override
+          public String rawFileLocation(String filename) {
+            return "http://repo/raw/" + filename;
+          }
+
+          @Override
+          public String getHostName() {
+            return "repo";
+          }
+
+          @Override
+          public String getProviderUrl() {
+            return "http://repo";
+          }
+
+          @Override
+          public String getBranch() {
+            return null;
+          }
+
+          @Override
+          public Optional<String> getCredentials() {
+            return Optional.empty();
+          }
+
+          @Override
+          public void setDevfileFilename(String devfileName) {}
+        };
+
+    when(fileContentProvider.fetchContent(eq(devfileLocation))).thenReturn("devfile content");
+    when(devfileParser.parseYamlRaw(eq("devfile content")))
+        .thenReturn(new ObjectNode(JsonNodeFactory.instance));
+    when(devfileParser.convertYamlToMap(org.mockito.ArgumentMatchers.<JsonNode>any()))
+        .thenReturn(Map.of("schemaVersion", "2.2.0"));
+
+    Optional<FactoryMetaDto> result =
+        urlFactoryBuilder.createFactoryFromDevfile(
+            remoteUrl, fileContentProvider, emptyMap(), false);
+
+    assertTrue(result.isPresent());
+    assertEquals(result.get().getSource(), "devfile.yaml");
+    verify(fileContentProvider, never()).fetchContent(eq(devcontainerLocation));
+  }
+
+  @Test
+  public void testDevcontainerDetectedWhenNoDevfile() throws Exception {
+    String devfileLocation = "http://repo/raw/devfile.yaml";
+    String devcontainerLocation = "http://repo/raw/.devcontainer/devcontainer.json";
+
+    RemoteFactoryUrl remoteUrl =
+        new RemoteFactoryUrl() {
+          @Override
+          public String getProviderName() {
+            return "test";
+          }
+
+          @Override
+          public List<DevfileLocation> devfileFileLocations() {
+            return singletonList(
+                new DevfileLocation() {
+                  @Override
+                  public Optional<String> filename() {
+                    return Optional.of("devfile.yaml");
+                  }
+
+                  @Override
+                  public String location() {
+                    return devfileLocation;
+                  }
+                });
+          }
+
+          @Override
+          public String rawFileLocation(String filename) {
+            return "http://repo/raw/" + filename;
+          }
+
+          @Override
+          public String getHostName() {
+            return "repo";
+          }
+
+          @Override
+          public String getProviderUrl() {
+            return "http://repo";
+          }
+
+          @Override
+          public String getBranch() {
+            return null;
+          }
+
+          @Override
+          public Optional<String> getCredentials() {
+            return Optional.empty();
+          }
+
+          @Override
+          public void setDevfileFilename(String devfileName) {}
+        };
+
+    Map<String, Object> templateAdditions =
+        Map.of("commands", List.of(Map.of("id", "start-devcontainer")));
+
+    when(fileContentProvider.fetchContent(eq(devfileLocation)))
+        .thenThrow(new IOException("not found"));
+    when(fileContentProvider.fetchContent(eq(devcontainerLocation)))
+        .thenReturn("{\"name\": \"test\"}");
+    JsonNode templateNode = new ObjectNode(JsonNodeFactory.instance);
+    when(devfileParser.parseYamlRaw(anyString())).thenReturn(templateNode);
+    when(devfileParser.convertYamlToMap(templateNode)).thenReturn(templateAdditions);
+
+    Optional<FactoryMetaDto> result =
+        urlFactoryBuilder.createFactoryFromDevfile(
+            remoteUrl, fileContentProvider, emptyMap(), false);
+
+    assertTrue(result.isPresent());
+    assertEquals(result.get().getSource(), ".devcontainer/devcontainer.json");
+    assertTrue(result.get() instanceof FactoryDevfileV2Dto);
+    Map<String, Object> devfile = ((FactoryDevfileV2Dto) result.get()).getDevfile();
+    assertEquals(devfile.get("schemaVersion"), "2.3.0");
+    assertEquals(devfile.get("commands"), List.of(Map.of("id", "start-devcontainer")));
+  }
+
+  @Test
+  public void testNoDevfileNoDevcontainerReturnsEmpty() throws Exception {
+    String devfileLocation = "http://repo/raw/devfile.yaml";
+
+    RemoteFactoryUrl remoteUrl =
+        new RemoteFactoryUrl() {
+          @Override
+          public String getProviderName() {
+            return "test";
+          }
+
+          @Override
+          public List<DevfileLocation> devfileFileLocations() {
+            return singletonList(
+                new DevfileLocation() {
+                  @Override
+                  public Optional<String> filename() {
+                    return Optional.of("devfile.yaml");
+                  }
+
+                  @Override
+                  public String location() {
+                    return devfileLocation;
+                  }
+                });
+          }
+
+          @Override
+          public String rawFileLocation(String filename) {
+            return "http://repo/raw/" + filename;
+          }
+
+          @Override
+          public String getHostName() {
+            return "repo";
+          }
+
+          @Override
+          public String getProviderUrl() {
+            return "http://repo";
+          }
+
+          @Override
+          public String getBranch() {
+            return null;
+          }
+
+          @Override
+          public Optional<String> getCredentials() {
+            return Optional.empty();
+          }
+
+          @Override
+          public void setDevfileFilename(String devfileName) {}
+        };
+
+    when(fileContentProvider.fetchContent(anyString())).thenThrow(new IOException("not found"));
+
+    Optional<FactoryMetaDto> result =
+        urlFactoryBuilder.createFactoryFromDevfile(
+            remoteUrl, fileContentProvider, emptyMap(), false);
+
+    assertFalse(result.isPresent());
+  }
+
+  @Test
+  public void testDevcontainerFetchIOExceptionReturnsEmpty() throws Exception {
+    String devfileLocation = "http://repo/raw/devfile.yaml";
+    String devcontainerLocation = "http://repo/raw/.devcontainer/devcontainer.json";
+    String devcontainerLocation2 = "http://repo/raw/.devcontainer.json";
+
+    RemoteFactoryUrl remoteUrl =
+        new RemoteFactoryUrl() {
+          @Override
+          public String getProviderName() {
+            return "test";
+          }
+
+          @Override
+          public List<DevfileLocation> devfileFileLocations() {
+            return singletonList(
+                new DevfileLocation() {
+                  @Override
+                  public Optional<String> filename() {
+                    return Optional.of("devfile.yaml");
+                  }
+
+                  @Override
+                  public String location() {
+                    return devfileLocation;
+                  }
+                });
+          }
+
+          @Override
+          public String rawFileLocation(String filename) {
+            return "http://repo/raw/" + filename;
+          }
+
+          @Override
+          public String getHostName() {
+            return "repo";
+          }
+
+          @Override
+          public String getProviderUrl() {
+            return "http://repo";
+          }
+
+          @Override
+          public String getBranch() {
+            return null;
+          }
+
+          @Override
+          public Optional<String> getCredentials() {
+            return Optional.empty();
+          }
+
+          @Override
+          public void setDevfileFilename(String devfileName) {}
+        };
+
+    when(fileContentProvider.fetchContent(eq(devfileLocation)))
+        .thenThrow(new IOException("not found"));
+    when(fileContentProvider.fetchContent(eq(devcontainerLocation)))
+        .thenThrow(new IOException("not found"));
+    when(fileContentProvider.fetchContent(eq(devcontainerLocation2)))
+        .thenThrow(new IOException("not found"));
+
+    Optional<FactoryMetaDto> result =
+        urlFactoryBuilder.createFactoryFromDevfile(
+            remoteUrl, fileContentProvider, emptyMap(), false);
+
+    assertFalse(result.isPresent());
   }
 
   @DataProvider


### PR DESCRIPTION
<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests
-->

### What does this PR do?
⚠️ Currently WIP

Related to https://github.com/eclipse-che/che/issues/23458

Adds devcontainer.json detection to the factory URL resolver. When a factory URL points to a repo with no devfile but has `.devcontainer/devcontainer.json` (or `.devcontainer.json`), che-server returns a generated devfile that merges devcontainer commands with the default devfile.

The generated devfile adds five commands:
- start-devcontainer (manual command, not postStart): builds the devcontainer image via rootless podman, starts the nested container, runs lifecycle hooks, and publishes terminal runtime for the che-code extension
- rebuild-devcontainer: force rebuild (removes existing container/image)
- rebuild-devcontainer-no-cache: rebuild without cache
- show-devcontainer-log: tail the build/run log
- clean-devcontainer-images: remove the nested container and its image

<img width="2552" height="1345" alt="Screenshot From 2026-09-03 18-36-09" src="https://github.com/user-attachments/assets/04c04c0e-2742-4fce-8317-fb2019f71d0e" />


The detection runs in `URLFactoryBuilder.createFactoryFromDevfile()` after all devfile locations are exhausted. The fallback chain is:
```
devfile.yaml / .devfile.yaml → .devcontainer/devcontainer.json / .devcontainer.json → default empty devfile
```

Key script behaviors:
- Runs all devcontainer lifecycle hooks (initializeCommand, onCreateCommand, updateContentCommand, postCreateCommand, postStartCommand, postAttachCommand)

### Screenshot/screencast of this PR
<!-- Please include a screenshot or a screencast explaining what is doing this PR -->
<img width="2552" height="1345" alt="Screenshot From 2026-09-03 18-37-03" src="https://github.com/user-attachments/assets/20ff7bc4-1812-4e2f-9e50-c11776baea77" />
<img width="2552" height="1345" alt="Screenshot From 2026-09-03 18-37-17" src="https://github.com/user-attachments/assets/e1d9c47c-bce2-419e-8a1c-ebe65d883e5b" />


### What issues does this PR fix or reference?
<!-- Please include any related issue from eclipse che repository (or from another issue tracker).
     Include link to other pull requests like documentation PR from [the docs repo](https://github.com/eclipse/che-docs)
-->
It's related to https://github.com/eclipse-che/che/issues/23458 

#### Prerequisites:
- OpenShift 4.20+ cluster with Eclipse Che installed
- Container run capabilities enabled


#### Steps:
Detailed test plan https://gist.github.com/rohanKanojia/5bfdcb4bbea318f5949dafc495960a05

1. Deploy Che Server to an OpenShift Cluster >= 4.20 
2. Ensure Nested containers functionality is enabled:
```bash
oc patch checluster/eclipse-che -n eclipse-che \
  --type='merge' -p \
  '{"spec":{"devEnvironments":{"disableContainerRunCapabilities":false}}}'
```
3. Build and deploy the custom che-server image, or patch the CheCluster CR to use a pre-built image with this change
```bash
oc patch checluster eclipse-che -n eclipse-che --type=merge -p '{
  "spec": { "components": { "cheServer": { "deployment": { "containers": [{
    "name": "che",
    "image": "quay.io/rokumar/che-server:latest",
    "imagePullPolicy": "Always"
  }] } } } }
}'
```
4. Open a repo with a devcontainer.json but no devfile, e.g. : https://github.com/coder/envbuilder-starter-devcontainer
5. Install the Devcontainer extension https://github.com/rohankanojia-testing/checode-devcontainer-extension (see detailed test instruction steps)
6. Use the flow guided by devcontainer extension like shown here ![Demo](https://raw.githubusercontent.com/rohankanojia-testing/checode-devcontainer-extension/main/docs/images/demo.gif)

### PR Checklist

[As the author of this Pull Request I made sure that:](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#pull-request-template-and-its-checklist)

- [x] [The Eclipse Contributor Agreement is valid](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-eclipse-contributor-agreement-is-valid)
- [x] [Code produced is complete](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-produced-is-complete)
- [x] [Code builds without errors](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-builds-without-errors)
- [x] [Tests are covering the bugfix](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#tests-are-covering-the-bugfix)
- [ ] [The repository devfile is up to date and works](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-repository-devfile-is-up-to-date-and-works)
- [x] [Sections `What issues does this PR fix or reference` and `How to test this PR` completed](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#sections-what-issues-does-this-pr-fix-or-reference-and-how-to-test-this-pr-completed)
- [ ] [Relevant user documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [Relevant contributing documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [CI/CD changes implemented, documented and communicated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#cicd-changes-implemented-documented-and-communicated)

### Release Notes

### Reviewers

Reviewers, please comment how you tested the PR when approving it.

