### PR TITLE
fix(deps): bump io.netty from 4.2.15.Final to 4.2.17.Final

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -72,7 +72,7 @@
         <io.jaegertracing.version>1.8.1</io.jaegertracing.version>
         <io.jsonwebtoken.jjwt.version>0.13.0</io.jsonwebtoken.jjwt.version>
         <io.micrometer.version>1.11.5</io.micrometer.version>
-        <io.netty.version>4.2.15.Final</io.netty.version>
+        <io.netty.version>4.2.17.Final</io.netty.version>
         <io.opentracing.api.extensions.version>0.6.0</io.opentracing.api.extensions.version>
         <io.opentracing.concurrent.version>0.4.0</io.opentracing.concurrent.version>
         <io.opentracing.contrib.metrics.version>0.3.0</io.opentracing.contrib.metrics.version>


### PR DESCRIPTION
Backport: bump io.netty from 4.2.15.Final to 4.2.17.Final to address CVE-2026-56745 (#1045)

Related issues: 
- https://redhat.atlassian.net/browse/CRW-12106
- https://redhat.atlassian.net/browse/CRW-12088
- https://redhat.atlassian.net/browse/CRW-12071
- https://redhat.atlassian.net/browse/CRW-12053
- https://redhat.atlassian.net/browse/CRW-12036
- https://redhat.atlassian.net/browse/CRW-12001


